### PR TITLE
Add hover to filter and sort selectors

### DIFF
--- a/ui/src/ReusableComponents/ProductFilter.tsx
+++ b/ui/src/ReusableComponents/ProductFilter.tsx
@@ -165,6 +165,7 @@ function ProductFilter({
                 data-testid="filterBy-dropdown"
                 className="dropdown filterBy-dropdown"
                 inputId="filterBy-dropdown"
+                classNamePrefix="product-filter"
                 options={allGroupedTagFilterOptions}
                 value={checkBoxFilterValues}
                 isMulti

--- a/ui/src/ReusableComponents/ProductFilterOrSortBy.scss
+++ b/ui/src/ReusableComponents/ProductFilterOrSortBy.scss
@@ -23,12 +23,20 @@
   color: $gray-1;
 }
 
-.sortby-dropdown{
+.sortby-dropdown {
   min-width: 100px;
+
+  .product-sort-by__control {
+    cursor: pointer;
+  }
 }
 
-.filterBy-dropdown{
+.filterBy-dropdown {
   min-width: 0;
+
+  .product-filter__control {
+    cursor: pointer;
+  }
 }
 
 .sortby-option {
@@ -37,6 +45,7 @@
   padding: 0 4px;
   display: flex;
   align-items:center;
+  cursor: pointer;
 }
 
 .dropdown-label {
@@ -49,7 +58,7 @@
   min-width: 50px;
 }
 
-.sortby-option-check{
+.sortby-option-check {
   margin-left: auto;
 }
 
@@ -57,6 +66,7 @@
   margin-top: 6px;
   display: flex;
   align-items: flex-start;
+  cursor: pointer;
 }
 
 .filter-option > .checkbox {

--- a/ui/src/ReusableComponents/ProductSortBy.tsx
+++ b/ui/src/ReusableComponents/ProductSortBy.tsx
@@ -53,6 +53,7 @@ function ProductSortBy({
                 styles={filterByStyles}
                 id="sortby-dropdown"
                 className="dropdown sortby-dropdown"
+                classNamePrefix="product-sort-by"
                 inputId="sortby-dropdown"
                 options={sortByOptions}
                 value={originalSortOption}

--- a/ui/src/SpaceDashboard/SpaceDashboard.tsx
+++ b/ui/src/SpaceDashboard/SpaceDashboard.tsx
@@ -57,8 +57,8 @@ function SpaceDashboard({setCurrentModal}: SpaceDashboardProps): JSX.Element {
     }
 
     useEffect(() => {
-                window.history.pushState([], 'User Dashboard', '/user/dashboard');
-                refreshUserSpaces().then();
+        window.history.pushState([], 'User Dashboard', '/user/dashboard');
+        refreshUserSpaces().then();
 
     }, []);
 

--- a/ui/src/tests/AuthenticatedRoute.test.tsx
+++ b/ui/src/tests/AuthenticatedRoute.test.tsx
@@ -21,7 +21,7 @@ import {act, render, RenderResult, wait, waitForDomChange} from '@testing-librar
 import {AuthenticatedRoute} from '../AuthenticatedRoute';
 import {createMemoryHistory, MemoryHistory} from 'history';
 import Cookies from 'universal-cookie';
-import Axios, {AxiosResponse} from "axios";
+import Axios, {AxiosResponse} from 'axios';
 
 describe('AuthenticatedRoute', function() {
     let originalWindow: Window;
@@ -47,13 +47,13 @@ describe('AuthenticatedRoute', function() {
         });
     });
 
-    it('should redirect to Auth provider when not Authenticated', async() => {
+    it('should redirect to Auth provider when not Authenticated', async () => {
         Axios.post = jest.fn(() => Promise.reject({} as AxiosResponse));
         window.location = {href: '', origin: 'http://localhost'} as Location;
         renderComponent({authenticated: false});
         const route = 'http://totallyreal.endpoint/oauth/thing?client_id=urn:aaaaa_aaaaaa_aaaaaa:aaa:aaaa&resource=urn:bbbbbb_bbbb_bbbbbb:bbb:bbbb&response_type=token&redirect_uri=http://localhost/adfs/catch';
 
-        await wait (() => {
+        await wait(() => {
             expect(window.location.href).toEqual(route);
         });
     });

--- a/ui/src/tests/LocalStorageFilters.test.tsx
+++ b/ui/src/tests/LocalStorageFilters.test.tsx
@@ -59,7 +59,7 @@ describe('filter products', () => {
     });
 
     it('should show unedited location tags in the filter as checked from local storage', async () => {
-        filters.locationTagsFilters.push(TestUtils.detroit.name)
+        filters.locationTagsFilters.push(TestUtils.detroit.name);
         localStorage.setItem('filters', JSON.stringify(filters));
         const app = renderWithRedux(<PeopleMover/>);
         const myTagsButton = await app.findByText('My Tags');

--- a/ui/src/tests/ValidationGuard.test.tsx
+++ b/ui/src/tests/ValidationGuard.test.tsx
@@ -19,8 +19,8 @@ import {render, RenderResult, wait} from '@testing-library/react';
 import AuthorizedRoute from '../Validation/AuthorizedRoute';
 import * as React from 'react';
 import Axios, {AxiosResponse} from 'axios';
-import {Router} from "react-router";
-import {createMemoryHistory} from "history";
+import {Router} from 'react-router';
+import {createMemoryHistory} from 'history';
 
 describe('The Validation Guard', () => {
     it('should redirect to login when security is enabled and you are not authorized', async () => {


### PR DESCRIPTION
## Issue
Connects #207

## What was done
- [x] Added hover states for the sort by and filter dropdown and toggles.

## How to test
1. Hover your cursor over the sort by and filter selection toggles and ensure that you see a pointer cursor.
2. Do the same with the filter dropdown checkboxes and the sort by dropdown options.
