### PR TITLE
230  typing date bug

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2230,6 +2230,14 @@
         "@types/react-transition-group": "*"
       }
     },
+    "@types/react-text-mask": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@types/react-text-mask/-/react-text-mask-5.4.6.tgz",
+      "integrity": "sha512-0KkER9oXZY/v1x8aoMTHwANlWnKT5tnmV7Zz+g81gBvcHRtcIHotcpY4KgWRwx0T5JMcsYmEh7wGOz0lwdONew==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-transition-group": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
@@ -14169,6 +14177,14 @@
         "prop-types": "^15.6.2",
         "react-is": "^16.8.6",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-text-mask": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/react-text-mask/-/react-text-mask-5.4.3.tgz",
+      "integrity": "sha1-mR77QpnjDC5sLEbRP2FxaUY+DS0=",
+      "requires": {
+        "prop-types": "^15.5.6"
       }
     },
     "react-transition-group": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@types/react-text-mask": "^5.4.6",
     "@types/redux-mock-store": "^1.0.2",
     "axios": "^0.18.1",
     "env-cmd": "^8.0.2",
@@ -19,6 +20,7 @@
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.4.0",
     "react-select": "^3.0.8",
+    "react-text-mask": "^5.4.3",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "universal-cookie": "^4.0.3"

--- a/ui/src/Products/ProductForm.scss
+++ b/ui/src/Products/ProductForm.scss
@@ -31,11 +31,18 @@
   padding-top: 6px;
 }
 
+.react-datepicker__close-icon {
+  padding: 0 5px 0 0 !important;
+}
+
 .react-datepicker__close-icon::after {
   font-size: 18px !important;
   width: 18px !important;
   padding: 0 !important;
-  background-color: $gray-1 !important;
+  background-color: $white !important;
+  color: $gray-1 !important;
+  content: 'x' !important;
+  font-weight: bold;
 }
 
 .calendar-icon {

--- a/ui/src/Products/ProductForm.scss
+++ b/ui/src/Products/ProductForm.scss
@@ -37,3 +37,11 @@
   padding: 0 !important;
   background-color: $gray-1 !important;
 }
+
+.calendar-icon {
+  position: relative;
+  top: -24px;
+  left: 194px;
+  height: 0;
+  width: 0;
+}

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -299,25 +299,6 @@ function ProductForm({
         setNotesFieldLength(e.target.value.length);
     }
 
-    // const StartDateDatePicker = ({ value, onClick }) => (
-    //     <div>
-    //         <input onClick={onClick} >{value}</input>
-    //         <i className="far fa-calendar-alt" />
-    //         <MaskedInput
-    //             mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
-    //         />
-    //     </div>
-    // );
-
-    // const StartDateDatePicker = () => (
-    //     <div>
-    //         <MaskedInput
-    //             mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
-    //         />
-    //         <i className="far fa-calendar-alt" />
-    //     </div>
-    // );
-
     return (
         <div className="formContainer">
             <form className="form" data-testid="productForm">
@@ -393,15 +374,12 @@ function ProductForm({
                             }
                         }}
                         customInput={
-                            <React.Fragment>
-                                <MaskedInput
-                                    className="formInput formTextInput"
-                                    mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
-                                />
-                                <i className="far fa-calendar-alt" />
-                            </React.Fragment>
+                            <MaskedInput
+                                mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
+                            />
                         }
                     />
+                    <i className="far fa-calendar-alt calendar-icon" />
                 </div>
                 <div className="formItem" data-testid="productFormNextPhaseDateField">
                     <label className="formItemLabel" htmlFor="end">End Date</label>
@@ -422,6 +400,7 @@ function ProductForm({
                         isClearable
                         placeholderText="MM/DD/YYYY"
                     />
+                    {!endDate && <i className="far fa-calendar-alt calendar-icon" />}
                 </div>
                 <div className="formItem">
                     <label className="formItemLabel" htmlFor="notes">Notes</label>

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -25,6 +25,7 @@ import LocationClient from '../Locations/LocationClient';
 import {closeModalAction, setAllGroupedTagFilterOptions} from '../Redux/Actions';
 import {connect} from 'react-redux';
 import DatePicker from 'react-datepicker';
+import MaskedInput from 'react-text-mask';
 import 'react-datepicker/dist/react-datepicker.css';
 import {JSX} from '@babel/types';
 import {emptyProduct, Product} from './Product';
@@ -298,6 +299,25 @@ function ProductForm({
         setNotesFieldLength(e.target.value.length);
     }
 
+    // const StartDateDatePicker = ({ value, onClick }) => (
+    //     <div>
+    //         <input onClick={onClick} >{value}</input>
+    //         <i className="far fa-calendar-alt" />
+    //         <MaskedInput
+    //             mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
+    //         />
+    //     </div>
+    // );
+
+    // const StartDateDatePicker = () => (
+    //     <div>
+    //         <MaskedInput
+    //             mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
+    //         />
+    //         <i className="far fa-calendar-alt" />
+    //     </div>
+    // );
+
     return (
         <div className="formContainer">
             <form className="form" data-testid="productForm">
@@ -364,10 +384,23 @@ function ProductForm({
                         id="start"
                         selected={startDate}
                         onChange={date => {
-                            setStartDate(date ? date : moment(viewingDate).toDate());
-                            updateProductField('startDate', date ? moment(date).format('YYYY-MM-DD') : moment(viewingDate).format('YYYY-MM-DD'));
+                            if (date) {
+                                setStartDate(date);
+                                updateProductField('startDate', moment(date).format('YYYY-MM-DD'));
+                            } else {
+                                setStartDate(moment(currentProduct.startDate).toDate());
+                                updateProductField('startDate', moment(currentProduct.startDate).format('YYYY-MM-DD'));
+                            }
                         }}
-                        isClearable
+                        customInput={
+                            <React.Fragment>
+                                <MaskedInput
+                                    className="formInput formTextInput"
+                                    mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
+                                />
+                                <i className="far fa-calendar-alt" />
+                            </React.Fragment>
+                        }
                     />
                 </div>
                 <div className="formItem" data-testid="productFormNextPhaseDateField">
@@ -381,8 +414,13 @@ function ProductForm({
                             setEndDate(date ? date : null);
                             updateProductField('endDate', date ? moment(date).format('YYYY-MM-DD') : '');
                         }}
+                        customInput={
+                            <MaskedInput
+                                mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
+                            />
+                        }
                         isClearable
-                        placeholderText="MM-DD-YYYY"
+                        placeholderText="MM/DD/YYYY"
                     />
                 </div>
                 <div className="formItem">


### PR DESCRIPTION
## Issue
Connects #230 

## What was done
- Change Close icon
- Show calendar icon for Start date at all times
- show calendar icon for end date when there is no end date
- show close icon for end date when there is a date
- users can now type in a date for start and end date. The date that is typed in must be valid in order for it to be used. 

## How to test
1. Create a new product or edit a previous product. Make sure the correct icons are displayed during different states in the form. Type in dates and check that the format is correct
