### PR TITLE
Group products by location

### DIFF
--- a/ui/src/Application/PeopleMover.tsx
+++ b/ui/src/Application/PeopleMover.tsx
@@ -26,7 +26,13 @@ import Branding from '../ReusableComponents/Branding';
 import CurrentModal from '../Redux/Containers/ModalContainer';
 import UnassignedDrawerContainer from '../Redux/Containers/UnassignedDrawerContainer';
 import {connect} from 'react-redux';
-import {fetchProductsAction, fetchProductTagsAction, setCurrentSpaceAction, setPeopleAction} from '../Redux/Actions';
+import {
+    fetchLocationsAction,
+    fetchProductsAction,
+    fetchProductTagsAction,
+    setCurrentSpaceAction,
+    setPeopleAction,
+} from '../Redux/Actions';
 import BoardSelectionTabs from '../Boards/BoardSelectionTabs';
 import {GlobalStateProps} from '../Redux/Reducers';
 import {CurrentModalState} from '../Redux/Reducers/currentModalReducer';
@@ -39,6 +45,7 @@ import SpaceClient from '../SpaceDashboard/SpaceClient';
 import {Product} from '../Products/Product';
 import ReassignedDrawer from '../ReassignedDrawer/ReassignedDrawer';
 import {ProductTag} from '../ProductTag/ProductTag';
+import {SpaceLocation} from '../Locations/SpaceLocation';
 
 export interface PeopleMoverProps {
     currentModal: CurrentModalState;
@@ -48,6 +55,7 @@ export interface PeopleMoverProps {
 
     fetchProducts(): Array<Product>;
     fetchProductTags(): Array<ProductTag>;
+    fetchLocations(): Array<SpaceLocation>;
     setCurrentSpace(space: Space): Space;
     setPeople(people: Array<Person>): Array<Person>;
 }
@@ -59,6 +67,7 @@ function PeopleMover({
     products,
     fetchProducts,
     fetchProductTags,
+    fetchLocations,
     setCurrentSpace,
     setPeople,
 }: PeopleMoverProps): JSX.Element {
@@ -86,6 +95,7 @@ function PeopleMover({
                     });
                 await fetchProducts();
                 await fetchProductTags();
+                await fetchLocations();
                 const peopleInSpace = (await PeopleClient.getAllPeopleInSpace()).data;
 
                 setPeople(peopleInSpace);
@@ -132,6 +142,7 @@ const mapStateToProps = (state: GlobalStateProps) => ({
 const mapDispatchToProps = (dispatch: any) => ({
     fetchProducts: () => dispatch(fetchProductsAction()),
     fetchProductTags: () => dispatch(fetchProductTagsAction()),
+    fetchLocations: () => dispatch(fetchLocationsAction()),
     setCurrentSpace: (space: Space) => dispatch(setCurrentSpaceAction(space)),
     setPeople: (people: Array<Person>) => dispatch(setPeopleAction(people)),
 });

--- a/ui/src/Products/ProductCard.tsx
+++ b/ui/src/Products/ProductCard.tsx
@@ -19,7 +19,8 @@ import React, {RefObject, useEffect, useState} from 'react';
 import './Product.scss';
 import {connect} from 'react-redux';
 import {
-    AvailableModals, fetchProductsAction,
+    AvailableModals,
+    fetchProductsAction,
     registerProductRefAction,
     setCurrentModalAction,
     setWhichEditMenuOpenAction,

--- a/ui/src/Products/ProductList.tsx
+++ b/ui/src/Products/ProductList.tsx
@@ -18,7 +18,7 @@
 import React, {useEffect, useState} from 'react';
 import {Product} from './Product';
 import {connect} from 'react-redux';
-import {GlobalStateProps} from '../Redux/Reducers';
+import {GlobalStateProps, SortByType} from '../Redux/Reducers';
 import {AllGroupedTagFilterOptions} from '../ReusableComponents/ProductFilter';
 import moment from 'moment';
 import {ProductTag} from '../ProductTag/ProductTag';
@@ -31,7 +31,7 @@ interface ProductListProps {
     productTags: Array<ProductTag>;
     allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions>;
     viewingDate: Date;
-    productSortBy: string;
+    productSortBy: SortByType;
 }
 
 function ProductList({

--- a/ui/src/Products/ProductList.tsx
+++ b/ui/src/Products/ProductList.tsx
@@ -21,14 +21,12 @@ import {connect} from 'react-redux';
 import {GlobalStateProps, SortByType} from '../Redux/Reducers';
 import {AllGroupedTagFilterOptions} from '../ReusableComponents/ProductFilter';
 import moment from 'moment';
-import {ProductTag} from '../ProductTag/ProductTag';
 import GroupedByList from './ProductListGrouped';
 import SortedByList from './ProductListSorted';
 import { getSelectedTagsFromGroupedTagOptions } from '../Redux/Reducers/allGroupedTagOptionsReducer';
 
 interface ProductListProps {
     products: Array<Product>;
-    productTags: Array<ProductTag>;
     allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions>;
     viewingDate: Date;
     productSortBy: SortByType;
@@ -36,7 +34,6 @@ interface ProductListProps {
 
 function ProductList({
     products,
-    productTags,
     allGroupedTagFilterOptions,
     viewingDate,
     productSortBy,
@@ -85,15 +82,16 @@ function ProductList({
                 .filter(isActiveProduct);
 
             switch (productSortBy) {
-                case 'product-tag': {
-                    return <GroupedByList
-                        products={filteredAndActiveProduct}
-                        productTags={productTags}/>;
-                }
-                default:
+                case 'name' : {
                     return <SortedByList
                         products={filteredAndActiveProduct}
                         productSortBy={productSortBy}/>;
+                }
+                default:
+                    return <GroupedByList
+                        products={filteredAndActiveProduct}
+                        productSortBy={productSortBy}/>;
+
             }
         } else {
             return <></>;

--- a/ui/src/Redux/Actions/index.ts
+++ b/ui/src/Redux/Actions/index.ts
@@ -27,6 +27,8 @@ import {Product} from '../../Products/Product';
 import ProductClient from '../../Products/ProductClient';
 import {ProductTag} from '../../ProductTag/ProductTag';
 import ProductTagClient from '../../ProductTag/ProductTagClient';
+import {SpaceLocation} from "../../Locations/SpaceLocation";
+import LocationClient from "../../Locations/LocationClient";
 
 export enum AvailableActions {
     SET_CURRENT_MODAL,
@@ -43,12 +45,14 @@ export enum AvailableActions {
     SET_VIEWING_DATE,
     SET_PRODUCTS,
     SET_PRODUCT_TAGS,
+    SET_LOCATIONS,
     SET_PRODUCT_SORT_BY,
 }
 
 export enum AvailableModals {
     CREATE_PRODUCT,
     CREATE_PRODUCT_OF_PRODUCT_TAG,
+    CREATE_PRODUCT_OF_LOCATION,
     EDIT_PRODUCT,
     CREATE_PERSON,
     EDIT_PERSON,
@@ -130,6 +134,11 @@ export const setProductTagsAction = (productTags: Array<ProductTag>) => ({
     productTags,
 });
 
+export const setLocationsAction = (locations: Array<SpaceLocation>) => ({
+    type: AvailableActions.SET_LOCATIONS,
+    locations,
+});
+
 export const setProductSortByAction = (productSortBy: string) => ({
     type: AvailableActions.SET_PRODUCT_SORT_BY,
     productSortBy,
@@ -161,5 +170,19 @@ export const fetchProductTagsAction: ActionCreator<ThunkAction<void, Function, n
                     return 0;
                 });
                 dispatch(setProductTagsAction(productTags));
+            });
+    };
+
+export const fetchLocationsAction: ActionCreator<ThunkAction<void, Function, null, Action<string>>> = () =>
+    (dispatch: Dispatch, getState: Function): Promise<void> => {
+        return LocationClient.get(getState().currentSpace.name,)
+            .then(result => {
+                let locations: Array<SpaceLocation> = result.data || [];
+                locations = locations.sort((a, b) => {
+                    if (a.name.toLowerCase() < b.name.toLowerCase()) { return -1; }
+                    if (a.name.toLowerCase() > b.name.toLowerCase()) { return 1; }
+                    return 0;
+                });
+                dispatch(setLocationsAction(locations));
             });
     };

--- a/ui/src/Redux/Containers/ModalContainer.tsx
+++ b/ui/src/Redux/Containers/ModalContainer.tsx
@@ -45,8 +45,18 @@ const getCurrentModal = (currentModal: CurrentModalState, products: Array<Produc
         case AvailableModals.CREATE_PRODUCT_OF_PRODUCT_TAG: {
             const newProduct = {
                 ...emptyProduct(currentSpace.id),
-                startDate:  moment(viewingDate).format('YYYY-MM-DD'),
+                startDate: moment(viewingDate).format('YYYY-MM-DD'),
                 productTags: [item],
+            };
+            return <ProductForm editing={false}
+                product={newProduct}
+                spaceId={currentSpace.id!!}/>;
+        }
+        case AvailableModals.CREATE_PRODUCT_OF_LOCATION: {
+            const newProduct = {
+                ...emptyProduct(currentSpace.id),
+                startDate: moment(viewingDate).format('YYYY-MM-DD'),
+                spaceLocation: {...item},
             };
             return <ProductForm editing={false}
                 product={newProduct}

--- a/ui/src/Redux/Reducers/index.ts
+++ b/ui/src/Redux/Reducers/index.ts
@@ -32,7 +32,9 @@ import {viewingDateReducer} from './viewingDateReducer';
 import productsReducer from './productsReducer';
 import {Product} from '../../Products/Product';
 import productTagsReducer from './productTagsReducer';
-import {ProductTag} from "../../ProductTag/ProductTag";
+import {ProductTag} from '../../ProductTag/ProductTag';
+
+export type SortByType = 'location' | 'product-tag' | 'name'
 
 export default combineReducers({
     currentModal: currentModalReducer,
@@ -53,7 +55,7 @@ export interface GlobalStateProps {
     isUnassignedDrawerOpen: boolean;
     whichEditMenuOpen: EditMenuToOpen;
     productRefs: Array<ProductCardRefAndProductPair>;
-    productSortBy: string;
+    productSortBy: SortByType;
     allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions>;
     currentSpace: Space;
     viewingDate: Date;

--- a/ui/src/Redux/Reducers/index.ts
+++ b/ui/src/Redux/Reducers/index.ts
@@ -27,12 +27,14 @@ import productSortByReducer from './productSortByReducer';
 import {AllGroupedTagFilterOptions} from '../../ReusableComponents/ProductFilter';
 import allGroupedTagFilterOptionsReducer from './allGroupedTagOptionsReducer';
 import currentSpaceReducer from './currentSpaceReducer';
-import {Space} from '../../SpaceDashboard/Space';
 import {viewingDateReducer} from './viewingDateReducer';
 import productsReducer from './productsReducer';
-import {Product} from '../../Products/Product';
 import productTagsReducer from './productTagsReducer';
+import locationsReducer from './locationsReducer';
+import {Space} from '../../SpaceDashboard/Space';
+import {Product} from '../../Products/Product';
 import {ProductTag} from '../../ProductTag/ProductTag';
+import {SpaceLocation} from '../../Locations/SpaceLocation';
 
 export type SortByType = 'location' | 'product-tag' | 'name'
 
@@ -47,6 +49,7 @@ export default combineReducers({
     viewingDate: viewingDateReducer,
     products: productsReducer,
     productTags: productTagsReducer,
+    locations: locationsReducer,
 });
 
 export interface GlobalStateProps {
@@ -61,4 +64,5 @@ export interface GlobalStateProps {
     viewingDate: Date;
     products: Array<Product>;
     productTags: Array<ProductTag>;
+    locations: Array<SpaceLocation>;
 }

--- a/ui/src/Redux/Reducers/locationsReducer.ts
+++ b/ui/src/Redux/Reducers/locationsReducer.ts
@@ -21,7 +21,6 @@ import {SpaceLocation} from '../../Locations/SpaceLocation';
 
 const locationsReducer = (state: Array<SpaceLocation> = [], action: {type: AvailableActions; locations: Array<SpaceLocation>} ): Array<SpaceLocation> => {
     if (action.type === AvailableActions.SET_LOCATIONS) {
-        console.log('Get Location State', action.locations)
         return [...action.locations];
     } else {
         return state;

--- a/ui/src/Redux/Reducers/locationsReducer.ts
+++ b/ui/src/Redux/Reducers/locationsReducer.ts
@@ -1,0 +1,31 @@
+/*
+ *
+ * Copyright (c) 2019 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AvailableActions} from '../Actions';
+import {SpaceLocation} from '../../Locations/SpaceLocation';
+
+const locationsReducer = (state: Array<SpaceLocation> = [], action: {type: AvailableActions; locations: Array<SpaceLocation>} ): Array<SpaceLocation> => {
+    if (action.type === AvailableActions.SET_LOCATIONS) {
+        console.log('Get Location State', action.locations)
+        return [...action.locations];
+    } else {
+        return state;
+    }
+};
+
+export default locationsReducer;

--- a/ui/src/ReusableComponents/ProductSortBy.tsx
+++ b/ui/src/ReusableComponents/ProductSortBy.tsx
@@ -18,23 +18,27 @@
 import Select from 'react-select';
 import {CustomIndicator, filterByStyles, SortByOption} from './ReactSelectStyles';
 import React, {useEffect, useState} from 'react';
-import {GlobalStateProps} from '../Redux/Reducers';
+import {GlobalStateProps, SortByType} from '../Redux/Reducers';
 import {connect} from 'react-redux';
-import {Option} from '../CommonTypes/Option';
 import './ProductFilterOrSortBy.scss';
 import {setProductSortByAction} from '../Redux/Actions';
 
+interface SortByOption {
+    label: string;
+    value: SortByType;
+}
+
 interface ProductSortByProps {
-    productSortBy: string;
-    setProductSortBy(productSortBy: string): void ;
+    productSortBy: SortByType;
+    setProductSortBy(productSortBy: SortByType): void;
 }
 
 function ProductSortBy({
     productSortBy,
     setProductSortBy,
 }: ProductSortByProps): JSX.Element {
-    const [originalSortOption, setOriginalSortOption] = useState<Option>();
-    const sortByOptions: Array<Option> = [
+    const [originalSortOption, setOriginalSortOption] = useState<SortByOption>();
+    const sortByOptions: Array<SortByOption> = [
         {label:'Name', value:'name'},
         {label:'Location', value:'location'},
         {label:'Product Tag', value:'product-tag'},
@@ -43,7 +47,7 @@ function ProductSortBy({
         setOriginalSortOption(stringToOption(productSortBy));
     }, [productSortBy]);
 
-    function stringToOption(value: string): Option {
+    function stringToOption(value: string): SortByOption {
         return sortByOptions.filter(option => option.value === value)[0];
     }
     return (
@@ -57,7 +61,7 @@ function ProductSortBy({
                 inputId="sortby-dropdown"
                 options={sortByOptions}
                 value={originalSortOption}
-                onChange={(value): void => setProductSortBy((value as Option).value)}
+                onChange={(value): void => setProductSortBy((value as SortByOption).value)}
                 components={{Option: SortByOption, DropdownIndicator: CustomIndicator}}/>
         </React.Fragment>
     );
@@ -68,7 +72,7 @@ const mapStateToProps = (state: GlobalStateProps) => ({
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
-    setProductSortBy: (productSortBy: string) => dispatch(setProductSortByAction(productSortBy)),
+    setProductSortBy: (productSortBy: SortByType) => dispatch(setProductSortByAction(productSortBy)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ProductSortBy);

--- a/ui/src/tests/PeopleMover.test.tsx
+++ b/ui/src/tests/PeopleMover.test.tsx
@@ -72,6 +72,7 @@ describe('PeopleMover', () => {
             const actualProductNames = productNameElements.map((element) => element.innerHTML);
             expect(actualProductNames).toEqual(
                 [
+                    TestUtils.productWithoutLocation.name,
                     TestUtils.productForHank.name,
                     TestUtils.productWithAssignments.name,
                     TestUtils.productWithoutAssignments.name,
@@ -79,20 +80,33 @@ describe('PeopleMover', () => {
             );
         });
 
-        it('should sort products by location',  async () => {
+        it('should group products by location',  async () => {
             await wait(() => {
                 selectEvent.select(app.getByLabelText('Sort By:'), ['Location']);
             });
 
-            const productNameElements = await app.findAllByTestId('productName');
-            const actualProductNames = productNameElements.map((element) => element.innerHTML);
-            expect(actualProductNames).toEqual(
-                [
-                    TestUtils.productForHank.name,
-                    TestUtils.productWithoutAssignments.name,
-                    TestUtils.productWithAssignments.name,
-                ]
-            );
+            const productGroups = await app.findAllByTestId('productGroup');
+
+            expect(productGroups.length).toBe(4);
+            const productGroup1 = productGroups[0];
+            expect(productGroup1).toHaveTextContent('Ann Arbor');
+            expect(productGroup1).toHaveTextContent('Hanky Product');
+            expect(productGroup1).toHaveTextContent('New Product');
+
+            const productGroup2 = productGroups[1];
+            expect(productGroup2).toHaveTextContent('Dearborn');
+            expect(productGroup2).toHaveTextContent('Product 3');
+            expect(productGroup2).toHaveTextContent('New Product');
+
+            const productGroup3 = productGroups[2];
+            expect(productGroup3).toHaveTextContent('Southfield');
+            expect(productGroup3).toHaveTextContent('Product 1');
+            expect(productGroup3).toHaveTextContent('New Product');
+
+            const productGroup4 = productGroups[3];
+            expect(productGroup4).toHaveTextContent('No Location');
+            expect(productGroup4).toHaveTextContent('Awesome Product');
+            expect(productGroup4).toHaveTextContent('New Product');
         });
 
         it('should group products by product tag',  async () => {

--- a/ui/src/tests/Product.test.tsx
+++ b/ui/src/tests/Product.test.tsx
@@ -64,7 +64,7 @@ describe('Products', () => {
 
         it('displays the empty product text', async () => {
             const app = renderWithRedux(<PeopleMover/>);
-            await app.findByText('Add a person by clicking');
+            await app.findAllByText('Add a person by clicking');
         });
 
         it('does not display the empty product text for a product with people', async () => {

--- a/ui/src/tests/TestUtils.tsx
+++ b/ui/src/tests/TestUtils.tsx
@@ -364,6 +364,17 @@ class TestUtils {
         productTags: [],
     };
 
+    static productWithoutLocation: Product = {
+        id: 5,
+        name: 'Awesome Product',
+        spaceId: 1,
+        startDate: '2011-01-01',
+        endDate: '2022-02-02',
+        assignments: [],
+        archived: false,
+        productTags: [],
+    };
+
     static archivedProduct: Product = {
         id: 4,
         name: 'I am archived',
@@ -382,6 +393,7 @@ class TestUtils {
         TestUtils.productForHank,
         TestUtils.productWithoutAssignments,
         TestUtils.archivedProduct,
+        TestUtils.productWithoutLocation,
     ];
 
     static notEmptyProducts: Array<Product> = [


### PR DESCRIPTION
## Issue
Connects #205

## What was done
- [x] Added functionality for grouping products by location

## How to test
1. Go to `/flippingsweet` and add multiple products with various locations.
2. Sort products by `Location`.
3. Ensure that the products reorganize into groupings based on location.
4. Ensure that if a product does not have a location, that it shows up under a "No Location" group at the bottom of the page.
