### PR TITLE
Refresh filter dropdown when entering space

### DIFF
--- a/ui/src/Calendar/CalendarInputLabel.tsx
+++ b/ui/src/Calendar/CalendarInputLabel.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef, Ref, useEffect} from 'react';
+import React, {forwardRef, Ref} from 'react';
 
 interface CustomInputProps {
     value?: string;

--- a/ui/src/Products/ProductListSorted.tsx
+++ b/ui/src/Products/ProductListSorted.tsx
@@ -31,18 +31,18 @@ function SortedByList({ products, productSortBy}: Props): JSX.Element {
     const [sortedProducts, setSortedProducts] = useState<Array<Product>>([...products]);
 
     useEffect(() => {
+        function sortBy(products: Array<Product>, productSortBy: string):  Array<Product> {
+            switch (productSortBy) {
+                case 'location': return [...products].sort(sortByLocation);
+                case 'name': return [...products].sort(sortByProductName);
+                default: return [...products];
+            }
+        }
+
         if (products && products.length) {
             setSortedProducts(sortBy(products, productSortBy));
         }
     }, [products, productSortBy]);
-
-    function sortBy(products: Array<Product>, productSortBy: string):  Array<Product> {
-        switch (productSortBy) {
-            case 'location': return [...products].sort(sortByLocation);
-            case 'name': return [...products].sort(sortByProductName);
-            default: return [...products];
-        }
-    }
 
     function sortByProductName(productA: Product, productB: Product): number {
         return productA.name.toLowerCase().localeCompare(productB.name.toLowerCase());

--- a/ui/src/ReusableComponents/OAuthRedirect.tsx
+++ b/ui/src/ReusableComponents/OAuthRedirect.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, {useState} from 'react';
+import React from 'react';
 import {Redirect} from 'react-router';
 import Cookies from 'universal-cookie';
 

--- a/ui/src/ReusableComponents/ProductFilter.tsx
+++ b/ui/src/ReusableComponents/ProductFilter.tsx
@@ -17,20 +17,21 @@
 
 import React, {useEffect, useState} from 'react';
 import Select from 'react-select';
+import {connect} from 'react-redux';
+import {AxiosResponse} from 'axios';
+import {Dispatch} from 'redux';
 import {CustomIndicator, filterByStyles, FilterControl, FilterOptions} from './ReactSelectStyles';
 import ProductTagClient from '../ProductTag/ProductTagClient';
 import LocationClient from '../Locations/LocationClient';
 import RoleClient from '../Roles/RoleClient';
-import {connect} from 'react-redux';
 import {GlobalStateProps} from '../Redux/Reducers';
 import {setAllGroupedTagFilterOptions} from '../Redux/Actions';
-import './ProductFilterOrSortBy.scss';
 import {TraitClient} from '../Traits/TraitClient';
-import {AxiosResponse} from 'axios';
 import {Trait} from '../Traits/Trait';
-import {Dispatch} from 'redux';
 import {FilterOption} from '../CommonTypes/Option';
 import {Space} from '../SpaceDashboard/Space';
+
+import './ProductFilterOrSortBy.scss';
 
 export type LocalStorageFilters = {
     locationTagsFilters: Array<string>;
@@ -54,12 +55,11 @@ function ProductFilter({
     setAllGroupedTagFilterOptions,
     allGroupedTagFilterOptions,
 }: ProductFilterProps): JSX.Element {
-
     const [checkBoxFilterValues, setCheckBoxFilterValues] = useState<Array<FilterOption>>([]);
 
     useEffect(() => {
         initializeGroupedTagOptions().then();
-    }, []);
+    }, [currentSpace]);
 
     useEffect( () => {
         if (allGroupedTagFilterOptions.length > 0) {
@@ -68,7 +68,7 @@ function ProductFilter({
             const selectedRoleFilters: Array<FilterOption> = allGroupedTagFilterOptions[2].options.filter(option => option.selected);
             setCheckBoxFilterValues([...selectedLocationFilters, ...selectedProductFilters, ...selectedRoleFilters]);
         }
-    }, [allGroupedTagFilterOptions]);
+    }, [allGroupedTagFilterOptions, currentSpace]);
 
     async function initializeGroupedTagOptions(): Promise<void> {
         const localStorageFilter: LocalStorageFilters = getLocalStorageFilters();
@@ -104,9 +104,7 @@ function ProductFilter({
 
     function getLocalStorageFilters(): LocalStorageFilters {
         const localStorageFilters: string | null = localStorage.getItem('filters');
-        if (localStorageFilters) {
-            return JSON.parse(localStorageFilters);
-        }
+        if (localStorageFilters) return JSON.parse(localStorageFilters);
         return {
             locationTagsFilters: [],
             productTagsFilters: [],


### PR DESCRIPTION
## Issue
Connects #242 

## What was done
- [x] Ensured that the filters dropdown updates when user navigates to a new space

## How to test
1. Go the dashboard and click on a space.
2. Click the browsers back button then go to a different space.
3. Ensure that the filters dropdown reflects the tags that should be present for the active space.
