### PR TITLE
[#246] Show new product button when sorting with groups and no products

### DIFF
--- a/ui/src/Products/ProductListGrouped.tsx
+++ b/ui/src/Products/ProductListGrouped.tsx
@@ -141,10 +141,13 @@ function GroupedByList({
                     </span>
                 );
             })}
-            <ProductGroup
-                tagName={`No ${groupedListData.traitTitle}`}
-                useGrayBackground
-                productFilterFunction={groupedListData.filterByNoTraitFunction}/>
+            {products.length === 0 ?
+                <NewProductButton /> :
+                <ProductGroup
+                    tagName={`No ${groupedListData.traitTitle}`}
+                    useGrayBackground
+                    productFilterFunction={groupedListData.filterByNoTraitFunction}/>
+            }
         </div>
     );
 }


### PR DESCRIPTION
## Issue
Connects #246 

## What was done
- [x] New product button can now be found when there are no products and they are being sorted by location or product tag

## How to test
1. Create a new space or open a new space without products
2. Without adding any products, change the sort by to location or product tag
3. Ensure the + product button is visible and a new product can be added

Co-authored-by: Alex Wojtala <alexwojtala@gmail.com>
Co-authored-by: Kari Schmitt <schmitt.160@osu.edu>
