### PR TITLE
[#227] Make user account dropdown close when clicked off of

### DIFF
--- a/ui/src/ReusableComponents/AccountDropdown.tsx
+++ b/ui/src/ReusableComponents/AccountDropdown.tsx
@@ -29,7 +29,18 @@ function AccountDropdown({
     const [redirect, setRedirect] = useState<JSX.Element>();
 
     function showsDropdown(): boolean {
-        setDropdownFlag(!dropdownFlag);
+        if(dropdownFlag) {
+            hidesDropdown();
+        } else {
+            setDropdownFlag(!dropdownFlag);
+            document.addEventListener('click', hidesDropdown, false);
+        }
+        return dropdownFlag;
+    }
+
+    function hidesDropdown(): boolean {
+        setDropdownFlag(false);
+        document.removeEventListener('click', hidesDropdown);
         return dropdownFlag;
     }
 


### PR DESCRIPTION
Co-authored-by: Nick Reuter <thenewimagineer@gmail.com>
Co-authored-by: Vianney Willot <vianney.willot@gmail.com>

## Issue
Connects #227 

## What was done
- [x] Make User Account Dropdown close when clicked off of

## How to test
1. Sign in and open the User Account Dropdown
2. Click anywhere but the options in the dropdown
