### PR TITLE
Change "board" text to "space"

### DIFF
--- a/ui/src/Modal/ConfirmationModal.tsx
+++ b/ui/src/Modal/ConfirmationModal.tsx
@@ -22,9 +22,7 @@ import './Modal.scss';
 
 export interface ConfirmationModalProps {
     submit(itemToDelete?: unknown): void | Promise<void>;
-
     archiveCallback?(): void;
-
     close(): void;
 
     canArchive?: boolean;
@@ -44,49 +42,61 @@ function ConfirmationModal({
     warningMessage,
     submitButtonLabel,
 }: ConfirmationModalProps): JSX.Element {
+    const isArchivable = canArchive && !isArchived;
+
+    const ArchiveMessage = (): JSX.Element => (
+        <div><br/>You can also choose to archive this product to be able to access it later.</div>
+    );
+
+    const CloseConfirmationMessage = (): JSX.Element => (
+        <div><br/>Are you sure you want to close the window?</div>
+    );
+    
+    const DeleteButton = (): JSX.Element => (
+        <button className="formButton confirmationModalDelete"
+            onClick={submit}
+            data-testid="confirmDeleteButton">
+            {submitButtonLabel ? submitButtonLabel : 'Delete'}
+        </button>
+    );
+    
+    const ArchiveButton = (): JSX.Element => (
+        <button
+            className="formButton confirmationModalDelete"
+            data-testid="confirmationModalArchive"
+            onClick={archiveCallback}>
+            Archive
+        </button>
+    );
+
+    const CancelButton = (): JSX.Element => (
+        <button
+            className="formButton cancelFormButton"
+            data-testid="confirmationModalCancel"
+            onClick={close}>
+            Cancel
+        </button>
+    );
 
     return (
         <div className="modalContainer">
             <div className="modalDialogContainer">
                 <div className="modalPopupContainer">
-
                     <div className="modalTitleAndCloseButtonContainer">
                         <div className="modalTitleSpacer"/>
                         <div className="modalTitle">Are you sure?</div>
                         <div className="fa fa-times fa-lg closeButton" onClick={close}/>
                     </div>
-
                     <div className="confirmationModalContent">
-
                         <div>{warningMessage}</div>
-
-                        {(canArchive && !isArchived) && <div>
-                            <br/>
-                            You can also choose to archive this product to be able to access it later.
-                        </div>}
-                        {(confirmClose) && <div>
-                            <br/>
-                            Are you sure you want to close the window?
-                        </div>}
-
+                        {(isArchivable) && <ArchiveMessage />}
+                        {(confirmClose) && <CloseConfirmationMessage />}
                     </div>
-
-                    <div className={`yesNoButtons confirmationControlButtons confirmationModalControls${canArchive ? ' archiveable' : ''}`}>
-
-                        <button className="formButton cancelFormButton" data-testid="confirmationModalCancel"
-                            onClick={close}>Cancel</button>
-
-                        <div className={`archiveAndDeleteContainer${canArchive && !isArchived ? ' archiveable' : ''}`}>
-                            {canArchive && !isArchived && (<button
-                                className="formButton confirmationModalDelete"
-                                data-testid="confirmationModalArchive"
-                                onClick={archiveCallback}>Archive</button>)}
-
-                            <button className="formButton confirmationModalDelete"
-                                onClick={submit}
-                                data-testid="confirmDeleteButton">{submitButtonLabel ? submitButtonLabel : 'Delete'}
-                            </button>
-
+                    <div className={`yesNoButtons confirmationControlButtons confirmationModalControls ${canArchive ? 'archivable' : ''}`}>
+                        <CancelButton />
+                        <div className={`archiveAndDeleteContainer ${isArchivable ? 'archivable' : ''}`}>
+                            {isArchivable && <ArchiveButton />}
+                            <DeleteButton />
                         </div>
                     </div>
                 </div>

--- a/ui/src/Modal/ConfirmationModal.tsx
+++ b/ui/src/Modal/ConfirmationModal.tsx
@@ -42,7 +42,7 @@ function ConfirmationModal({
     warningMessage,
     submitButtonLabel,
 }: ConfirmationModalProps): JSX.Element {
-    const isArchivable = canArchive && !isArchived;
+    const isArchivable = (): boolean => Boolean(canArchive && !isArchived);
 
     const ArchiveMessage = (): JSX.Element => (
         <div><br/>You can also choose to archive this product to be able to access it later.</div>
@@ -62,7 +62,7 @@ function ConfirmationModal({
     
     const ArchiveButton = (): JSX.Element => (
         <button
-            className="formButton confirmationModalDelete"
+            className="formButton archiveFormButton"
             data-testid="confirmationModalArchive"
             onClick={archiveCallback}>
             Archive
@@ -89,15 +89,15 @@ function ConfirmationModal({
                     </div>
                     <div className="confirmationModalContent">
                         <div>{warningMessage}</div>
-                        {(isArchivable) && <ArchiveMessage />}
+                        {(isArchivable()) && <ArchiveMessage />}
                         {(confirmClose) && <CloseConfirmationMessage />}
                     </div>
                     <div className={`yesNoButtons confirmationControlButtons confirmationModalControls ${canArchive ? 'archivable' : ''}`}>
-                        <CancelButton />
-                        <div className={`archiveAndDeleteContainer ${isArchivable ? 'archivable' : ''}`}>
-                            {isArchivable && <ArchiveButton />}
-                            <DeleteButton />
+                        <div className={`cancelAndArchiveContainer ${isArchivable() ? 'archivable' : ''}`}>
+                            <CancelButton />
+                            {isArchivable() && <ArchiveButton />}
                         </div>
+                        <DeleteButton />
                     </div>
                 </div>
             </div>

--- a/ui/src/Modal/Form.scss
+++ b/ui/src/Modal/Form.scss
@@ -91,6 +91,7 @@ select.formInput{
     height: 32px;
 }
 
+.archiveFormButton,
 .cancelFormButton {
     background-color:white;
     border: 1px solid $prime-1;

--- a/ui/src/Modal/Modal.scss
+++ b/ui/src/Modal/Modal.scss
@@ -89,7 +89,7 @@
     flex-grow:0;
 }
 
-.yesNoButtons.confirmationModalControls{
+.yesNoButtons.confirmationModalControls {
     padding: 0 52px;
 }
 
@@ -97,14 +97,14 @@
     margin-top: 32px;
 }
 
-.archiveAndDeleteContainer {
-    justify-content: flex-end;
+.cancelAndArchiveContainer {
+    justify-content: flex-start;
 }
 
-.archiveAndDeleteContainer.archivable {
+.cancelAndArchiveContainer.archivable {
     display: flex;
     flex-direction: row;
-    min-width: 242px;
+    min-width: 218px;
     justify-content: space-between;
 }
 

--- a/ui/src/Modal/Modal.scss
+++ b/ui/src/Modal/Modal.scss
@@ -58,7 +58,6 @@
 }
 
 .modalTitle {
-
     font-size: 20px;
     color: $purple-title;
     font-weight: bold;
@@ -73,8 +72,7 @@
     border-radius: 50%;
 }
 
-.confirmationModalContent{
-
+.confirmationModalContent {
     font-size: 14px;
     color: $gray-1;
     padding: 0 52px;
@@ -82,7 +80,7 @@
     line-height: 16px;
 }
 
-.confirmationModalControls.archiveable {
+.confirmationModalControls.archivable {
     justify-content: space-between;
 }
 
@@ -103,7 +101,7 @@
     justify-content: flex-end;
 }
 
-.archiveAndDeleteContainer.archiveable {
+.archiveAndDeleteContainer.archivable {
     display: flex;
     flex-direction: row;
     min-width: 242px;

--- a/ui/src/Modal/Modal.tsx
+++ b/ui/src/Modal/Modal.tsx
@@ -68,25 +68,15 @@ function Modal({
         );
         return (
             <div className="modalContainer" data-testid="modalContainer"
-                onClick={() => {
-                    close();
-                }}
-                onKeyDown={(event) => {
-                    if (event.key === 'Escape') {
-                        close();
-                    }
+                onClick={close}
+                onKeyDown={(event): void => {
+                    if (event.key === 'Escape') close();
                 }}>
-
                 <div className="modalDialogContainer">
                     <div className="modalPopupContainer"
                         data-testid="modalPopupContainer"
-                        onClick={event => {
-                            event.stopPropagation();
-                        }}
-                    >
-
-                        <input type={'text'} autoFocus={true} aria-hidden={true} className="hiddenInputField"/>
-
+                        onClick={(event): void => { event.stopPropagation(); }}>
+                        <input type="text" autoFocus={true} aria-hidden={true} className="hiddenInputField"/>
                         <div className="modalTitleAndCloseButtonContainer">
                             <div className="modalTitleSpacer"/>
                             <div className="modalTitle">{title}</div>

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -136,7 +136,7 @@ function ProductForm({
             },
             archiveCallback: archiveProduct,
             isArchived: currentProduct.archived,
-            warningMessage: 'Deleting this product will permanently remove it from this board.',
+            warningMessage: 'Deleting this product will permanently remove it from this space.',
         };
         const deleteConfirmationModal: JSX.Element = ConfirmationModal(propsForDeleteConfirmationModal);
         setConfirmDeleteModal(deleteConfirmationModal);


### PR DESCRIPTION
## Issue
Connects #263

## What was done
- [x] Updated "board" text to "space" on the delete product modal
- [x] Moved the `archive` button to the left on said delete modal, and update styles of said button to match the cancel button
- [x] Updated the `ui/src/Modal/ConfirmationModal.tsx` and `ui/src/Modal/Modal.tsx` files to be a little easier to read

## How to test
1. Go to the app and attempt to delete a product
2. Ensure that the delete product confirmation modal shows the desired text and design
