### PR TITLE
Replace delete message depending on trait type

### DIFF
--- a/ui/src/Roles/MyRolesModal.tsx
+++ b/ui/src/Roles/MyRolesModal.tsx
@@ -44,6 +44,7 @@ function MyRolesModal({setShouldShowConfirmCloseModal}: MyRolesModalProps): JSX.
                 traitClient={RoleClient}
                 setTraitSectionOpen={setRoleSectionOpen}
                 colorSection
+                traitType="person"
                 traitName="role"
             />
 

--- a/ui/src/Tags/MyTagsModal.tsx
+++ b/ui/src/Tags/MyTagsModal.tsx
@@ -47,6 +47,7 @@ function MyTagsModal({setShouldShowConfirmCloseModal}: MyTagsModalProps): JSX.El
                 traitClient={LocationClient}
                 colorSection={false}
                 setTraitSectionOpen={setLocationSectionOpen}
+                traitType="product"
                 traitName="location"
             />
 
@@ -57,6 +58,7 @@ function MyTagsModal({setShouldShowConfirmCloseModal}: MyTagsModalProps): JSX.El
                 traitClient={ProductTagClient}
                 colorSection={false}
                 setTraitSectionOpen={setProductTagSectionOpen}
+                traitType="product"
                 traitName="product tag"
             />
 

--- a/ui/src/Traits/MyTraits.tsx
+++ b/ui/src/Traits/MyTraits.tsx
@@ -37,6 +37,7 @@ interface MyTraitsProps {
     title?: string;
     traitClient: TraitClient;
     setTraitSectionOpen: Function;
+    traitType: string;
     colorSection: boolean;
     traitName: string;
     allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions>;
@@ -56,6 +57,7 @@ function MyTraits({
     setTraitSectionOpen,
     colorSection,
     traitName,
+    traitType,
     allGroupedTagFilterOptions,
     setAllGroupedTagFilterOptions,
 }: MyTraitsProps): JSX.Element {
@@ -179,7 +181,7 @@ function MyTraits({
         const propsForDeleteConfirmationModal: ConfirmationModalProps = {
             submit: () => deleteTrait(traitToDelete),
             close: () => setConfirmDeleteModal(null),
-            warningMessage: `Deleting this ${traitName} will remove it from any person or product that has been given this ${traitName}.`,
+            warningMessage: `Deleting this ${traitName} will remove it from any ${traitType} that has been given this ${traitName}.`,
         };
         const deleteConfirmationModal: JSX.Element = ConfirmationModal(propsForDeleteConfirmationModal);
         setConfirmDeleteModal(deleteConfirmationModal);

--- a/ui/src/tests/FilterProducts.test.tsx
+++ b/ui/src/tests/FilterProducts.test.tsx
@@ -82,7 +82,7 @@ describe('filter products', () => {
 
         it('should remove filter location when location is deleted from my tags modal', async () => {
             let locationTagDeleteIcon: HTMLElement;
-            const deleteLocationWarning = 'Deleting this location will remove it from any person or product that has been given this location.';
+            const deleteLocationWarning = 'Deleting this location will remove it from any product that has been given this location.';
 
             const deleteIcons = await app.findAllByTestId('locationDeleteIcon');
             locationTagDeleteIcon = deleteIcons[0];
@@ -186,7 +186,7 @@ describe('filter products', () => {
 
         it('should remove filter option when product tag is deleted from my tags modal', async () => {
             let productTagDeleteIcon: HTMLElement;
-            const deleteProductTagWarning = 'Deleting this product tag will remove it from any person or product that has been given this product tag.';
+            const deleteProductTagWarning = 'Deleting this product tag will remove it from any product that has been given this product tag.';
             const deleteIcons = await app.findAllByTestId('producttagDeleteIcon');
             productTagDeleteIcon = deleteIcons[0];
 

--- a/ui/src/tests/MyTags.test.tsx
+++ b/ui/src/tests/MyTags.test.tsx
@@ -188,7 +188,7 @@ describe('PeopleMover My Tags', () => {
 
         describe('delete a location tag', () => {
             let locationTagDeleteIcon: HTMLElement;
-            const deleteLocationWarning = 'Deleting this location will remove it from any person or product that has been given this location.';
+            const deleteLocationWarning = 'Deleting this location will remove it from any product that has been given this location.';
 
             beforeEach(async () => {
                 const deleteIcons = await app.findAllByTestId('locationDeleteIcon');
@@ -218,7 +218,7 @@ describe('PeopleMover My Tags', () => {
 
         describe('delete a product tag', () => {
             let productTagDeleteIcon: HTMLElement;
-            const deleteProductTagWarning = 'Deleting this product tag will remove it from any person or product that has been given this product tag.';
+            const deleteProductTagWarning = 'Deleting this product tag will remove it from any product that has been given this product tag.';
 
             beforeEach(async () => {
                 const deleteIcons = await app.findAllByTestId('producttagDeleteIcon');

--- a/ui/src/tests/RoleModal.test.tsx
+++ b/ui/src/tests/RoleModal.test.tsx
@@ -334,7 +334,7 @@ describe('PeopleMover Role Modal', () => {
     });
 
     describe('deleting a role', () => {
-        const deleteWarning = 'Deleting this role will remove it from any person or product that has been given this role.';
+        const deleteWarning = 'Deleting this role will remove it from any person that has been given this role.';
 
         it('should show trashcan icon', async () => {
             const roleDeleteIcons = await app.findAllByTestId('roleDeleteIcon');


### PR DESCRIPTION
Co-authored-by: Nick Reuter <thenewimagineer@gmail.com>
Co-authored-by: Alex Wojtala <alexwojtala@gmail.com>

## Issue
Connects #264 

## What was done
- [x] Changed copy on delete confirmation modals to be based on the type of trait being deleted.

## How to test
1. Open "My Tags"
2. Delete a tag
3. Verify the text
4. Open Roles
5. Delete a Role
