### PR TITLE
Prevent submitting empty name in space form

### DIFF
--- a/ui/src/Application/Styleguide/Colors.scss
+++ b/ui/src/Application/Styleguide/Colors.scss
@@ -34,6 +34,7 @@ $role-3: #A7EEFE;
 $scrollbar-color: #ABABAB;
 $font-color: #323b3e;
 $purple: #4F5FAB;
+$light-purple: #C8D0F3;
 $logo-gradient: linear-gradient(90deg, #984AA1 0%, #4F5FAB 76.03%);
 $purple-title: #984AA1;
 $error-message: #C82656;

--- a/ui/src/SpaceDashboard/CreateSpaceForm.scss
+++ b/ui/src/SpaceDashboard/CreateSpaceForm.scss
@@ -52,5 +52,19 @@
 
   .createSpaceSubmitButton {
     margin-left: 12px;
+    border-radius: 6px;
+  }
+
+  .createSpaceSubmitButton:disabled {
+    background-color: $light-purple;
+    cursor: not-allowed;
+  }
+
+  .createSpaceCancelButton {
+    color: $purple;
+    background-color: $white;
+    border: solid 1px $purple;
+    box-sizing: border-box;
+    border-radius: 6px;
   }
 }

--- a/ui/src/SpaceDashboard/CreateSpaceForm.tsx
+++ b/ui/src/SpaceDashboard/CreateSpaceForm.tsx
@@ -56,7 +56,7 @@ function CreateSpaceForm({
 
         <div className={'createSpaceButtonContainer'}>
             <button className={'createSpaceCancelButton'} onClick={closeModal}>Cancel</button>
-            <button className={'createSpaceSubmitButton'} onClick={addSpace}>Add Space</button>
+            <button className={'createSpaceSubmitButton'} disabled={spaceName.length <= 0} onClick={addSpace}>Add Space</button>
         </div>
 
     </div>;


### PR DESCRIPTION
Co-authored-by: Alex Wojtala <alexwojtala@gmail.com>
Co-authored-by: Nick Reuter <thenewimagineer@gmail.com>

## Issue
Connects #268 

## What was done
- [x] Prevent clicking submit when name is empty in space creation modal on dashboard
- [x] Fix styling on cancel button

## How to test
1. Navigate to user dashboard
2. Try to create a space
3. Verify submit is grayed out and not clickable
4. Verify Cancel button looks correct
5. Add characters to name
6. Verify submit button changes
7. Click submit
8. Verify space created