### PR TITLE
Add uuid field to space

### DIFF
--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/Space.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/Space.kt
@@ -34,6 +34,9 @@ data class Space (
     val id: Int? = null,
 
     @Column(unique = true, nullable = false)
+    val uuid: String = UUID.randomUUID().toString(),
+
+    @Column(unique = true, nullable = false)
     val name: String,
 
     @OneToMany(mappedBy = "spaceId", orphanRemoval = true, cascade = [CascadeType.REMOVE, CascadeType.REFRESH], fetch = FetchType.EAGER)
@@ -45,5 +48,5 @@ data class Space (
     var lastModifiedDate: Timestamp? = null
 ) {
     constructor(name: String):
-            this(null, name, HashSet(), ArrayList(), null)
+        this(null, UUID.randomUUID().toString(), name, HashSet(), ArrayList(), null)
 }

--- a/api/src/main/resources/db/h2/V001__baseline.sql
+++ b/api/src/main/resources/db/h2/V001__baseline.sql
@@ -1,6 +1,7 @@
 create table space
 (
     id    int          not null identity primary key,
+    uuid varchar(36) not null,
     name varchar(255) not null unique,
     last_modified_date datetime
 );

--- a/api/src/main/resources/db/mysql/V004__add_uuid_to_space.sql
+++ b/api/src/main/resources/db/mysql/V004__add_uuid_to_space.sql
@@ -1,0 +1,1 @@
+ALTER TABLE space ADD uuid varchar(36) not null;


### PR DESCRIPTION
Co-authored-by: Nick Reuter <thenewimagineer@gmail.com>
Co-authored-by: Alex Wojtala <alexwojtala@gmail.com>

## Issue
Connects #289 

## What was done
- [x] Added migration script for a UUID field in the space table as prep for non-unique space names

## How to test
Should not be different
