### PR TITLE
Invite Contributors Confirmation Modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ node_modules/
 # env
 ui/.env.local
 application-local.properties
+.java-version
 
 ### VSCode ###
 bin/

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthController.kt
@@ -18,6 +18,7 @@
 package com.ford.internalprojects.peoplemover.auth
 
 import com.ford.internalprojects.peoplemover.space.SpaceRepository
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -52,13 +53,21 @@ class AuthController(val userSpaceMappingRepository: UserSpaceMappingRepository,
     }
 
     @PutMapping(path = ["/api/user/invite/space"])
-    fun inviteUsersToSpace(@Valid @RequestBody request: AuthInviteUsersToSpaceRequest): ResponseEntity<Void> {
+    fun inviteUsersToSpace(@Valid @RequestBody request: AuthInviteUsersToSpaceRequest): ResponseEntity<ArrayList<String>> {
         val space = spaceRepository.findByNameIgnoreCase(request.spaceName)!!
-        request.emails.forEach {
-            val userId = it.substringBefore('@').toUpperCase()
-            userSpaceMappingRepository.save(UserSpaceMapping(userId = userId, spaceId = space.id))
-        }
-        return ResponseEntity.noContent().build()
-    }
 
+        val failures = arrayListOf<String>();
+        request.emails.forEach {email ->
+            val userId = email.substringBefore('@').toUpperCase()
+            try {
+                userSpaceMappingRepository.save(UserSpaceMapping(userId = userId, spaceId = space.id))
+            } catch (e: DataIntegrityViolationException) {
+                System.out.println(userId + " already has access to this space.");
+            } catch (e: Exception) {
+                failures.add(email)
+                System.out.println(e)
+            }
+        }
+        return ResponseEntity.ok(failures)
+    }
 }

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/UserSpaceMappingRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/UserSpaceMappingRepository.kt
@@ -1,6 +1,5 @@
 package com.ford.internalprojects.peoplemover.auth
 
-import com.ford.internalprojects.peoplemover.space.Space
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.*

--- a/ui/src/Redux/Actions/index.ts
+++ b/ui/src/Redux/Actions/index.ts
@@ -62,6 +62,7 @@ export enum AvailableModals {
     MY_ROLES_MODAL,
     CREATE_SPACE,
     EDIT_CONTRIBUTORS,
+    CONTRIBUTORS_CONFIRMATION,
 }
 
 export const setCurrentModalAction = (modalState: CurrentModalState) => ({

--- a/ui/src/Redux/Containers/ModalContainer.tsx
+++ b/ui/src/Redux/Containers/ModalContainer.tsx
@@ -89,6 +89,8 @@ const getCurrentModal = (currentModal: CurrentModalState, products: Array<Produc
             return <CreateSpaceForm onSubmit={item}/>;
         case AvailableModals.EDIT_CONTRIBUTORS:
             return <EditContributorsForm/>;
+        case AvailableModals.CONTRIBUTORS_CONFIRMATION:
+            return <div>Contributors Confirmation</div>;
         default:
             return null;
     }
@@ -118,6 +120,8 @@ const getCurrentTitle = (currentModal: CurrentModalState): string => {
             return 'Create New Space';
         case AvailableModals.EDIT_CONTRIBUTORS:
             return 'Invite Members';
+        case AvailableModals.CONTRIBUTORS_CONFIRMATION:
+            return 'Your team member now has access!';
         default:
             return '';
     }

--- a/ui/src/Redux/Containers/ModalContainer.tsx
+++ b/ui/src/Redux/Containers/ModalContainer.tsx
@@ -27,6 +27,7 @@ import {GlobalStateProps} from '../Reducers';
 import {CurrentModalState} from '../Reducers/currentModalReducer';
 import MyTagsModal from '../../Tags/MyTagsModal';
 import MyRolesModal from '../../Roles/MyRolesModal';
+import InviteContributorConfirmationForm from '../../SpaceDashboard/InviteContributorsConfirmationForm';
 import CreateSpaceForm from '../../SpaceDashboard/CreateSpaceForm';
 import {Dispatch} from 'redux';
 import EditContributorsForm from '../../SpaceDashboard/EditContributorsForm';
@@ -90,7 +91,7 @@ const getCurrentModal = (currentModal: CurrentModalState, products: Array<Produc
         case AvailableModals.EDIT_CONTRIBUTORS:
             return <EditContributorsForm/>;
         case AvailableModals.CONTRIBUTORS_CONFIRMATION:
-            return <div>Contributors Confirmation</div>;
+            return <InviteContributorConfirmationForm />;
         default:
             return null;
     }

--- a/ui/src/ReusableComponents/AccountDropdown.tsx
+++ b/ui/src/ReusableComponents/AccountDropdown.tsx
@@ -29,7 +29,7 @@ function AccountDropdown({
     const [redirect, setRedirect] = useState<JSX.Element>();
 
     function showsDropdown(): boolean {
-        if(dropdownFlag) {
+        if (dropdownFlag) {
             hidesDropdown();
         } else {
             setDropdownFlag(!dropdownFlag);
@@ -44,7 +44,7 @@ function AccountDropdown({
         return dropdownFlag;
     }
 
-    function clearAccessTokenCookie() {
+    function clearAccessTokenCookie(): void {
         const cookie = new Cookies();
         cookie.remove('accessToken', {path: '/'});
 

--- a/ui/src/SpaceDashboard/EditContributorsForm.tsx
+++ b/ui/src/SpaceDashboard/EditContributorsForm.tsx
@@ -57,19 +57,20 @@ function EditContributorsForm({
         setInvitedUserEmails(emails);
     };
 
-    return <div className="editContributorsContainer">
-        <div className="inviteContributorsLabel">Invite others to collaborate</div>
-        <textarea placeholder="Enter Emails" onChange={parseEmails} data-testid="emailTextArea"/>
-        <div className="editContributorsButtonContainer">
-            <button className="editContributorsCancelButton" onClick={closeModal}>Cancel</button>
-            <button className="editContributorsSaveButton" onClick={inviteUsers}>Invite</button>
+    return (
+        <div className="editContributorsContainer">
+            <div className="inviteContributorsLabel">Invite others to collaborate</div>
+            <textarea placeholder="Enter Emails" onChange={parseEmails} data-testid="emailTextArea"/>
+            <div className="editContributorsButtonContainer">
+                <button className="editContributorsCancelButton" onClick={closeModal}>Cancel</button>
+                <button className="editContributorsSaveButton" onClick={inviteUsers}>Invite</button>
+            </div>
         </div>
-    </div>;
+    );
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     closeModal: () => dispatch(closeModalAction()),
-
     setCurrentModal: (modalState: CurrentModalState) => dispatch(setCurrentModalAction(modalState)),
 });
 

--- a/ui/src/SpaceDashboard/EditContributorsForm.tsx
+++ b/ui/src/SpaceDashboard/EditContributorsForm.tsx
@@ -45,7 +45,6 @@ function EditContributorsForm({
 
     const inviteUsers = async (): Promise<void> => {
         await SpaceClient.inviteUsersToSpace(spaceName, invitedUserEmails)
-            .then(console.log)
             .catch(console.error)
             .finally(() => {
                 setCurrentModal({modal: AvailableModals.CONTRIBUTORS_CONFIRMATION});

--- a/ui/src/SpaceDashboard/EditContributorsForm.tsx
+++ b/ui/src/SpaceDashboard/EditContributorsForm.tsx
@@ -18,22 +18,22 @@
 import React, {ChangeEvent, useEffect, useState} from 'react';
 import SpaceClient from './SpaceClient';
 import {Dispatch} from 'redux';
-import {closeModalAction} from '../Redux/Actions';
+import {useLocation} from 'react-router-dom';
 import {connect} from 'react-redux';
+import {AvailableModals, closeModalAction, setCurrentModalAction} from '../Redux/Actions';
+import {CurrentModalState} from '../Redux/Reducers/currentModalReducer';
+
 import './EditContributorsForm.scss';
 
-
-import {useLocation} from 'react-router-dom';
-
-
-interface EditContributorsFormProps {
+interface Props {
     closeModal(): void;
+    setCurrentModal(modalState: CurrentModalState): void;
 }
 
 function EditContributorsForm({
     closeModal,
-}: EditContributorsFormProps): JSX.Element {
-
+    setCurrentModal,
+}: Props): JSX.Element {
     const pathname = useLocation().pathname;
 
     const [spaceName, setSpaceName] = useState<string>('');
@@ -43,29 +43,34 @@ function EditContributorsForm({
         setSpaceName(pathname.substring(1, pathname.length));
     }, [pathname]);
 
-    async function inviteUsers(): Promise<void> {
-        await SpaceClient.inviteUsersToSpace(spaceName, invitedUserEmails);
+    const inviteUsers = async (): Promise<void> => {
+        await SpaceClient.inviteUsersToSpace(spaceName, invitedUserEmails)
+            .then(console.log)
+            .catch(console.error)
+            .finally(() => {
+                setCurrentModal({modal: AvailableModals.CONTRIBUTORS_CONFIRMATION});
+            });
+    };
 
-        closeModal();
-    }
-
-    function parseEmails(event: ChangeEvent<HTMLTextAreaElement>): void {
+    const parseEmails = (event: ChangeEvent<HTMLTextAreaElement>): void => {
         const emails: string[] = event.target.value.split(',');
         setInvitedUserEmails(emails);
-    }
+    };
 
-    return <div className={'editContributorsContainer'}>
-        <div className={'inviteContributorsLabel'}>Invite others to collaborate</div>
-        <textarea placeholder={'Enter Emails'} onChange={parseEmails} data-testid={'emailTextArea'}/>
-        <div className={'editContributorsButtonContainer'}>
-            <button className={'editContributorsCancelButton'} onClick={closeModal}>Cancel</button>
-            <button className={'editContributorsSaveButton'} onClick={inviteUsers}>Invite</button>
+    return <div className="editContributorsContainer">
+        <div className="inviteContributorsLabel">Invite others to collaborate</div>
+        <textarea placeholder="Enter Emails" onChange={parseEmails} data-testid="emailTextArea"/>
+        <div className="editContributorsButtonContainer">
+            <button className="editContributorsCancelButton" onClick={closeModal}>Cancel</button>
+            <button className="editContributorsSaveButton" onClick={inviteUsers}>Invite</button>
         </div>
     </div>;
 }
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
     closeModal: () => dispatch(closeModalAction()),
+
+    setCurrentModal: (modalState: CurrentModalState) => dispatch(setCurrentModalAction(modalState)),
 });
 
 export default connect(null, mapDispatchToProps)(EditContributorsForm);

--- a/ui/src/SpaceDashboard/InviteContributorsConfirmationForm.tsx
+++ b/ui/src/SpaceDashboard/InviteContributorsConfirmationForm.tsx
@@ -26,7 +26,11 @@ interface Props {
 }
 
 const InviteContributorConfirmationForm = ({ closeModal }: Props): JSX.Element => {
-    const linkToSpace = window ? window.location.href : '';
+    const linkToSpace: string = window ? window.location.href : '';
+
+    const copyLink = async (): Promise<void> => {
+        await navigator.clipboard.writeText(linkToSpace);
+    };
 
     return (
         <div className="inviteContributorsConfirmationContainer">
@@ -37,7 +41,7 @@ const InviteContributorConfirmationForm = ({ closeModal }: Props): JSX.Element =
                 <div className="inviteContributorsConfirmationLink">
                     {linkToSpace}
                 </div>
-                <div className="inviteContributorsConfirmationCopyButton">
+                <div className="inviteContributorsConfirmationCopyButton" onClick={copyLink}>
                     Copy link
                 </div>
             </div>

--- a/ui/src/SpaceDashboard/InviteContributorsConfirmationForm.tsx
+++ b/ui/src/SpaceDashboard/InviteContributorsConfirmationForm.tsx
@@ -17,13 +17,16 @@
 
 import React from 'react';
 import './InviteContributorsConfirmationModal.scss';
+import {Dispatch} from 'redux';
+import {closeModalAction} from '../Redux/Actions';
+import {connect} from 'react-redux';
 
-const InviteContributorConfirmationForm = (): JSX.Element => {
+interface Props {
+    closeModal(): void;
+}
+
+const InviteContributorConfirmationForm = ({ closeModal }: Props): JSX.Element => {
     const linkToSpace = window ? window.location.href : '';
-    
-    const onClick = (): void => {
-        console.log('Click');
-    };
 
     return (
         <div className="inviteContributorsConfirmationContainer">
@@ -38,18 +41,16 @@ const InviteContributorConfirmationForm = (): JSX.Element => {
                     Copy link
                 </div>
             </div>
-            <div className="inviteContributorsConfirmationButtonContainer">
-                <button className="inviteContributorsConfirmationCancelButton"
-                    onClick={onClick}>
-                    Cancel
-                </button>
-                <button className="inviteContributorsConfirmationSaveButton"
-                    onClick={onClick}>
-                    Done
-                </button>
-            </div>
+            <button className="inviteContributorsConfirmationDoneButton"
+                onClick={closeModal}>
+                Done
+            </button>
         </div>
     );
 };
 
-export default InviteContributorConfirmationForm;
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+    closeModal: () => dispatch(closeModalAction()),
+});
+
+export default connect(null, mapDispatchToProps)(InviteContributorConfirmationForm);

--- a/ui/src/SpaceDashboard/InviteContributorsConfirmationForm.tsx
+++ b/ui/src/SpaceDashboard/InviteContributorsConfirmationForm.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import './InviteContributorsConfirmationModal.scss';
+
+const InviteContributorConfirmationForm = (): JSX.Element => {
+    const linkToSpace = window ? window.location.href : '';
+    
+    const onClick = (): void => {
+        console.log('Click');
+    };
+
+    return (
+        <div className="inviteContributorsConfirmationContainer">
+            <div className="inviteContributorsConfirmationLabel">
+                Share this link with your collaborators.
+            </div>
+            <div className="inviteContributorsConfirmationShareLinkContainer">
+                <div className="inviteContributorsConfirmationLink">
+                    {linkToSpace}
+                </div>
+                <div className="inviteContributorsConfirmationCopyButton">
+                    Copy link
+                </div>
+            </div>
+            <div className="inviteContributorsConfirmationButtonContainer">
+                <button className="inviteContributorsConfirmationCancelButton"
+                    onClick={onClick}>
+                    Cancel
+                </button>
+                <button className="inviteContributorsConfirmationSaveButton"
+                    onClick={onClick}>
+                    Done
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default InviteContributorConfirmationForm;

--- a/ui/src/SpaceDashboard/InviteContributorsConfirmationModal.scss
+++ b/ui/src/SpaceDashboard/InviteContributorsConfirmationModal.scss
@@ -32,22 +32,17 @@
     width: 100%;
   }
 
-  .inviteContributorsConfirmationShareLinkContainer,
-  .inviteContributorsConfirmationButtonContainer {
+  .inviteContributorsConfirmationShareLinkContainer {
     width: 100%;
     height: 32px;
     display: flex;
     justify-content: space-between;
-  }
-
-  .inviteContributorsConfirmationShareLinkContainer {
     align-items: center;
     margin: 12px 0 28px;
 
     .inviteContributorsConfirmationLink {
       white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      overflow: scroll;
       background: #F2F2F2;
       border-radius: 6px;
       padding: 10px;
@@ -64,23 +59,10 @@
     }
   }
 
-  .inviteContributorsConfirmationButtonContainer {
-    width: 216px;
-    margin: 0 auto;
-
-    button {
-      flex: 1;
-      box-sizing: border-box;
-      border-radius: 6px;
-
-      &.inviteContributorsConfirmationCancelButton {
-        margin-right: 16px;
-
-        background: white;
-        color: $prime-1;
-
-        border: 1px solid #4F5FAB;
-      }
-    }
+  .inviteContributorsConfirmationDoneButton {
+    box-sizing: border-box;
+    border-radius: 6px;
+    width: 100px;
+    height: 32px;
   }
 }

--- a/ui/src/SpaceDashboard/InviteContributorsConfirmationModal.scss
+++ b/ui/src/SpaceDashboard/InviteContributorsConfirmationModal.scss
@@ -56,6 +56,7 @@
       line-height: 14px;
       color: $purple-title;
       margin-left: 16px;
+      cursor: pointer;
     }
   }
 

--- a/ui/src/SpaceDashboard/InviteContributorsConfirmationModal.scss
+++ b/ui/src/SpaceDashboard/InviteContributorsConfirmationModal.scss
@@ -1,0 +1,86 @@
+/*!
+ * Copyright (c) 2019 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import "../Application/Styleguide/Colors.scss";
+
+@import "../Application/Styleguide/Colors.scss";
+
+.inviteContributorsConfirmationContainer {
+  margin: 0 auto;
+  color: $gray-1;
+
+  .inviteContributorsConfirmationLabel {
+    text-align: left;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 14px;
+    line-height: 16px;
+    width: 100%;
+  }
+
+  .inviteContributorsConfirmationShareLinkContainer,
+  .inviteContributorsConfirmationButtonContainer {
+    width: 100%;
+    height: 32px;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .inviteContributorsConfirmationShareLinkContainer {
+    align-items: center;
+    margin: 12px 0 28px;
+
+    .inviteContributorsConfirmationLink {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      background: #F2F2F2;
+      border-radius: 6px;
+      padding: 10px;
+      max-width: 343px;
+    }
+
+    .inviteContributorsConfirmationCopyButton {
+      font-style: normal;
+      font-weight: bold;
+      font-size: 12px;
+      line-height: 14px;
+      color: $purple-title;
+      margin-left: 16px;
+    }
+  }
+
+  .inviteContributorsConfirmationButtonContainer {
+    width: 216px;
+    margin: 0 auto;
+
+    button {
+      flex: 1;
+      box-sizing: border-box;
+      border-radius: 6px;
+
+      &.inviteContributorsConfirmationCancelButton {
+        margin-right: 16px;
+
+        background: white;
+        color: $prime-1;
+
+        border: 1px solid #4F5FAB;
+      }
+    }
+  }
+}

--- a/ui/src/tests/Modal.test.tsx
+++ b/ui/src/tests/Modal.test.tsx
@@ -16,37 +16,48 @@
  */
 
 import React from 'react';
+import {render, fireEvent, RenderResult} from '@testing-library/react';
 import Modal from '../Modal/Modal';
-import {render, fireEvent} from '@testing-library/react';
 
 describe('Modal', () => {
+    let mockedCloseFunction: jest.Mock, comp: RenderResult;
+
+    beforeEach(() => {
+        mockedCloseFunction = jest.fn();
+
+        const ModalForm = (props: { setShouldShowConfirmCloseModal: Function }): JSX.Element => {
+            props.setShouldShowConfirmCloseModal();
+            return <p>Hello</p>;
+        };
+
+        comp = render(
+            <Modal
+                title="Test Modal"
+                modalForm={<ModalForm setShouldShowConfirmCloseModal={(): void => {
+                    console.log('hey');
+                }}/>}
+                closeModal={mockedCloseFunction}
+            />
+        );
+    });
 
     it('should close the modal when the escape key is pressed', () => {
-        const mockedCloseFunction = jest.fn();
-        const {getByTestId} = render(<Modal title={'Test Modal'} modalForm={<p>Hello</p>} closeModal={mockedCloseFunction}/>);
-        fireEvent.keyDown(getByTestId('modalContainer'), { key: 'Escape', code: 27 });
+        fireEvent.keyDown(comp.getByTestId('modalContainer'), {key: 'Escape', code: 27});
         expect(mockedCloseFunction).toHaveBeenCalled();
     });
 
     it('should close the modal when the background is clicked', () => {
-        const mockedCloseFunction = jest.fn();
-        const {getByTestId} = render(<Modal title={'Test Modal'} modalForm={<p>Hello</p>} closeModal={mockedCloseFunction}/>);
-        fireEvent.click(getByTestId('modalContainer'));
+        fireEvent.click(comp.getByTestId('modalContainer'));
         expect(mockedCloseFunction).toHaveBeenCalled();
     });
 
     it('should close the modal when the X is clicked', () => {
-        const mockedCloseFunction = jest.fn();
-        const {getByTestId} = render(<Modal title={'Test Modal'} modalForm={<p>Hello</p>} closeModal={mockedCloseFunction}/>);
-        fireEvent.click(getByTestId('modalCloseButton'));
+        fireEvent.click(comp.getByTestId('modalCloseButton'));
         expect(mockedCloseFunction).toHaveBeenCalled();
     });
 
     it('should not close the modal when the modal popup is clicked', () => {
-        const mockedCloseFunction = jest.fn();
-        const {getByTestId} = render(<Modal title={'Test Modal'} modalForm={<p>Hello</p>} closeModal={mockedCloseFunction}/>);
-        fireEvent.click(getByTestId('modalPopupContainer'));
+        fireEvent.click(comp.getByTestId('modalPopupContainer'));
         expect(mockedCloseFunction).not.toHaveBeenCalled();
     });
-
 });


### PR DESCRIPTION
## Issue
Connects #278

## What was done
- [x] Added a modal screen view that shows up after users are invited to a space
- [x] Updated `/api/user/invite/space` endpoint to not return an error when a user already has access to a space

<img width="515" alt="Screen Shot 2020-08-19 at 10 37 16 AM" src="https://user-images.githubusercontent.com/17144844/90648827-033a7580-e208-11ea-8566-85de67bdb19d.png">


## How to test
1. Go to a space and invite users to the space.
2. Ensure that users are successfully given access AND that the new modal pops up.
3. Ensure that the copy paste functionality on the new modal works properly.
