### PR TITLE
Remove double scroll when modal is open

### DIFF
--- a/ui/src/Application/PeopleMover.scss
+++ b/ui/src/Application/PeopleMover.scss
@@ -17,10 +17,6 @@
 
 @import '../Application/Styleguide/Colors.scss';
 
-.noOverflow {
-    overflow: hidden;
-}
-
 .spaceButtons button {
     margin: 0 12px;
 }

--- a/ui/src/Application/PeopleMover.tsx
+++ b/ui/src/Application/PeopleMover.tsx
@@ -136,6 +136,7 @@ function PeopleMover({
     );
 }
 
+/* eslint-disable */
 const mapStateToProps = (state: GlobalStateProps) => ({
     currentModal: state.currentModal,
     currentSpace: state.currentSpace,
@@ -152,3 +153,4 @@ const mapDispatchToProps = (dispatch: any) => ({
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(PeopleMover);
+/* eslint-enable */

--- a/ui/src/Application/PeopleMover.tsx
+++ b/ui/src/Application/PeopleMover.tsx
@@ -116,7 +116,7 @@ function PeopleMover({
         !hasProducts()
             ? <></>
             : <div className="App">
-                <div className={currentModal.modal !== null ? 'noOverflow' : ''}>
+                <div>
                     <Header/>
                     <SpaceSelectionTabs/>
                     <div className="productAndAccordionContainer">

--- a/ui/src/Form/NotesTextArea.test.tsx
+++ b/ui/src/Form/NotesTextArea.test.tsx
@@ -18,19 +18,19 @@
  */
 
 
-import {fireEvent, render} from "@testing-library/react";
-import * as React from "react";
-import NotesTextArea from "./NotesTextArea";
+import {fireEvent, render} from '@testing-library/react';
+import * as React from 'react';
+import NotesTextArea from './NotesTextArea';
 
-describe('notes input', ()=>{
+describe('notes input', () => {
 
-    it('should count the number of characters',() =>{
+    it('should count the number of characters', () => {
         const callback = jest.fn();
         const notes = render(<NotesTextArea notes={'this string is 17'} callBack={callback}/>);
         notes.getByText('17 (255 characters max)');
     });
 
-    it('should update character count when notes is typed in', function () {
+    it('should update character count when notes is typed in', function() {
         const callback = jest.fn();
         const notes = render(<NotesTextArea callBack={callback}/>);
         notes.getByText('0 (255 characters max)');
@@ -39,7 +39,7 @@ describe('notes input', ()=>{
         notes.getByText('4 (255 characters max)');
     });
 
-    it('should send update to parent when text changes', function () {
+    it('should send update to parent when text changes', function() {
         const callback = jest.fn();
         const notes = render(<NotesTextArea callBack={callback}/>);
         const input = notes.getByLabelText('Notes');
@@ -47,7 +47,7 @@ describe('notes input', ()=>{
         expect(callback).toHaveBeenCalledWith('Good');
     });
 
-    it('should change the max value allowed in the input', function () {
+    it('should change the max value allowed in the input', function() {
         const callback = jest.fn();
         const notes = render(<NotesTextArea callBack={callback} maxLength={5}/>);
         notes.getByText('0 (5 characters max)');

--- a/ui/src/Modal/Modal.tsx
+++ b/ui/src/Modal/Modal.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {JSX} from '@babel/types';
 import ConfirmationModal, {ConfirmationModalProps} from './ConfirmationModal';
 
@@ -33,6 +33,12 @@ function Modal({
 }: ModalProps): JSX.Element | null {
     const [shouldShowConfirmCloseModal, setShouldShowConfirmCloseModal] = useState<boolean>(false);
     const [confirmCloseModal, setConfirmCloseModal] = useState<JSX.Element | null>(null);
+
+    useEffect(() => {
+        let bodyOverflowState = 'unset';
+        if (modalForm !== null) bodyOverflowState = 'hidden';
+        document.body.style.overflow = bodyOverflowState;
+    }, [modalForm]);
 
     let customModalForm = null;
 
@@ -61,7 +67,7 @@ function Modal({
         }
     }
 
-    if (modalForm != null) {
+    if (modalForm !== null) {
         customModalForm = React.cloneElement(
             modalForm,
             {setShouldShowConfirmCloseModal: setShouldShowConfirmCloseModal}

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -46,8 +46,8 @@ import {Dispatch} from 'redux';
 import {ProductPlaceholderPair} from '../Assignments/CreateAssignmentRequest';
 import {Space} from '../SpaceDashboard/Space';
 import moment from 'moment';
-import NotesTextArea from "../Form/NotesTextArea";
-import {useOnLoad} from "../ReusableComponents/UseOnLoad";
+import NotesTextArea from '../Form/NotesTextArea';
+import {useOnLoad} from '../ReusableComponents/UseOnLoad';
 
 interface PersonFormProps {
     editing: boolean;

--- a/ui/src/Products/ProductCard.tsx
+++ b/ui/src/Products/ProductCard.tsx
@@ -36,7 +36,7 @@ import {CurrentModalState} from '../Redux/Reducers/currentModalReducer';
 import {AxiosResponse} from 'axios';
 import AssignmentCardList from '../Assignments/AssignmentCardList';
 import moment from 'moment';
-import {useOnLoad} from "../ReusableComponents/UseOnLoad";
+import {useOnLoad} from '../ReusableComponents/UseOnLoad';
 
 interface ProductCardProps {
     container: string;

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -39,7 +39,7 @@ import ProductFormEndDateField from './ProductFormEndDateField';
 import 'react-datepicker/dist/react-datepicker.css';
 import '../Modal/Form.scss';
 import './ProductForm.scss';
-import NotesTextArea from "../Form/NotesTextArea";
+import NotesTextArea from '../Form/NotesTextArea';
 
 export const customStyles: StylesConfig = {
     ...reactSelectStyles,

--- a/ui/src/Products/ProductFormProductTagsField.tsx
+++ b/ui/src/Products/ProductFormProductTagsField.tsx
@@ -13,7 +13,7 @@ import ProductTagClient from '../ProductTag/ProductTagClient';
 import {AxiosResponse} from 'axios';
 import {GlobalStateProps} from '../Redux/Reducers';
 import {connect} from 'react-redux';
-import {useOnLoad} from "../ReusableComponents/UseOnLoad";
+import {useOnLoad} from '../ReusableComponents/UseOnLoad';
 
 interface Props {
     spaceId: number;

--- a/ui/src/ReusableComponents/AccountDropdown.tsx
+++ b/ui/src/ReusableComponents/AccountDropdown.tsx
@@ -29,7 +29,7 @@ function AccountDropdown({
     const [redirect, setRedirect] = useState<JSX.Element>();
 
     function showsDropdown(): boolean {
-        if(dropdownFlag) {
+        if (dropdownFlag) {
             hidesDropdown();
         } else {
             setDropdownFlag(!dropdownFlag);

--- a/ui/src/ReusableComponents/EditMenu.tsx
+++ b/ui/src/ReusableComponents/EditMenu.tsx
@@ -17,7 +17,7 @@
 
 import React from 'react';
 import './EditMenu.scss';
-import {useOnLoad} from "./UseOnLoad";
+import {useOnLoad} from './UseOnLoad';
 
 
 export interface EditMenuOption {

--- a/ui/src/ReusableComponents/ReactSelectStyles.tsx
+++ b/ui/src/ReusableComponents/ReactSelectStyles.tsx
@@ -21,7 +21,7 @@ import './FilterInput.scss';
 import {ThemeApplier} from './ThemeApplier';
 import CheckIcon from '../Application/Assets/checkIcon.svg';
 import {Option} from '../CommonTypes/Option';
-import {useOnLoad} from "./UseOnLoad";
+import {useOnLoad} from './UseOnLoad';
 
 export const reactSelectStyles = {
     control: (provided: CSSProperties): CSSProperties => ({

--- a/ui/src/SpaceDashboard/SpaceDashboard.tsx
+++ b/ui/src/SpaceDashboard/SpaceDashboard.tsx
@@ -31,7 +31,7 @@ import Header from '../Header/Header';
 import SpaceDashboardTile from './SpaceDashboardTile';
 
 import './SpaceDashboard.scss';
-import {useOnLoad} from "../ReusableComponents/UseOnLoad";
+import {useOnLoad} from '../ReusableComponents/UseOnLoad';
 
 interface SpaceDashboardProps {
     setCurrentModal(modalState: CurrentModalState): void;

--- a/ui/src/Validation/AuthorizedRoute.tsx
+++ b/ui/src/Validation/AuthorizedRoute.tsx
@@ -19,7 +19,7 @@ import {Redirect, Route, RouteProps} from 'react-router';
 import React, {useState} from 'react';
 import Cookies from 'universal-cookie';
 import {AccessTokenClient} from '../Login/AccessTokenClient';
-import {useOnLoad} from "../ReusableComponents/UseOnLoad";
+import {useOnLoad} from '../ReusableComponents/UseOnLoad';
 
 export default function AuthorizedRoute<T extends RouteProps>(props: T): JSX.Element {
     const {children, ...rest} = props;

--- a/ui/src/tests/Product.test.tsx
+++ b/ui/src/tests/Product.test.tsx
@@ -458,7 +458,7 @@ describe('Products', () => {
         });
 
         it('should call the product client with the product when a deletion is requested', async () => {
-            await act(async() => {
+            await act(async () => {
                 const app = renderWithRedux(<PeopleMover/>);
                 const editProduct3Button = await app.findByTestId('editProductIcon_3');
                 fireEvent.click(editProduct3Button);

--- a/ui/src/tests/ProductList.test.tsx
+++ b/ui/src/tests/ProductList.test.tsx
@@ -37,7 +37,7 @@ describe('Product List tests', () => {
     });
 
     it('should only have one edit menu open at a time', async () => {
-        await act (async () => {
+        await act(async () => {
             app = await renderWithRedux(<PeopleMover/>);
             const editPerson1Button = await app.findByTestId('editPersonIconContainer-1');
             const editPerson3Button = await app.findByTestId('editPersonIconContainer-3');

--- a/ui/src/tests/SpaceButtons.test.tsx
+++ b/ui/src/tests/SpaceButtons.test.tsx
@@ -59,7 +59,7 @@ describe('SpaceButtons', () => {
 
         let result: RenderResult;
 
-        await act (async ( ) => {
+        await act(async ( ) => {
             await wait(() => {
                 result = renderWithRedux(<SpaceButtons/>, undefined, initialState);
             });


### PR DESCRIPTION
## Issue
Connects #203 

## What was done
- [x] Remove double scroll when modal is open

## How to test
1. Go to a page with a lot of products on it and ensure the page is scrollable (shrink browser if need be).
2. Open a modal and ensure that the modal can scroll, but the page behind it does not.
