### PR TITLE
Cleanup duplicate test:ui command in ui/package.json

### DIFF
--- a/api/Jenkinsfile
+++ b/api/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
                 stage('UI Test') {
                     steps {
                         dir("ui") {
-                            sh "CI=true npm run test:ci"
+                            sh "npm run test:ci"
                         }
                     }
                 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/FordLabs/PeopleMover.git"
   },
   "scripts": {
-    "test:ui": "cd ui && npm run lint && CI=true npm test"
+    "test:ui": "cd ui && npm run lint && npm run test:ci"
   },
   "husky": {
     "hooks": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,9 +12,8 @@
   "scripts": {
     "start": "env-cmd .env.local react-scripts start",
     "start:noauth": "env-cmd .env.localnoauth react-scripts start",
-    "test:ci": "CI=true react-scripts test --runInBand",
     "test:unit": "react-scripts test",
-    "test:unit:ci": "react-scripts test --runInBand",
+    "test:unit:ci": "CI=true react-scripts test --runInBand",
     "test:unit:coverage": "CI=true react-scripts test --coverage --testResultsProcessor jest-sonar-reporter",
     "cy:open": "cypress open",
     "cy:run": "cypress run",


### PR DESCRIPTION
## Issue
Connects N/A

## What was done
- [x] Cleanup duplicate test:ui command in ui/package.json
- [x] Moved `CI=true` to the `test:ui:ci` command and out of the root package.json test:ui command

## How to test
1. Husky should still run linting and unit tests on commit
2. Builds should still work as expected
