### PR TITLE
stashing builds for use in deploys in jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
                             steps {
                                 dir("ui") {
                                     sh "npm run build"
+                                    stash includes: 'build/**', name: 'ui'
                                 }
                             }
                         }
@@ -60,6 +61,7 @@ pipeline {
                             steps {
                                 dir("api") {
                                     sh "./gradlew assemble"
+                                    stash includes: 'build/libs/*.jar', name: 'api'
                                 }
                             }
                         }
@@ -69,8 +71,10 @@ pipeline {
         }
         stage('API Deploy') {
             when {
-                branch 'master'
-                branch 'stage'
+                anyOf {
+                    branch 'master'
+                    branch 'stage'
+                }
             }
             agent {
                 kubernetes {
@@ -90,6 +94,7 @@ pipeline {
                    string(credentialsId: 'adfs_resource', variable: 'ADFS_RESOURCE')
                              ]) {
                     dir("api") {
+                        unstash 'api'
                         sh 'echo Pushing to Cloud Foundry'
                         sh  """./gradlew cf-push-blue-green \
                         -Pcf.ccUser=$CI_USER \
@@ -108,8 +113,10 @@ pipeline {
         }
         stage('UI Deploy') {
             when {
-                branch 'master'
-                branch 'stage'
+                anyOf {
+                    branch 'master'
+                    branch 'stage'
+                }
             }
             agent {
                 kubernetes {
@@ -123,6 +130,7 @@ pipeline {
                         string(credentialsId: 'peoplemover_pcf_cchost', variable: 'PCF_HOST'),
                 ]) {
                     dir("ui") {
+                        unstash 'ui'
                         sh 'echo Login to Cloud Foundry'
                         sh """cf login \
                             -a $PCF_HOST \


### PR DESCRIPTION
## Issue
Connects #298 

## What was done
- [x] Added stashing commands to jenkins steps so the builds can be used in later agents to deploy

## How to test
1. Push to stage and see if the app gets uploaded and the site is functioning normally
