### PR TITLE
Update styles for Invite contributors confirmation modal

### DIFF
--- a/ui/src/SpaceDashboard/InviteContributorsConfirmationModal.scss
+++ b/ui/src/SpaceDashboard/InviteContributorsConfirmationModal.scss
@@ -30,6 +30,7 @@
     font-size: 14px;
     line-height: 16px;
     width: 100%;
+    padding-bottom: 12px;
   }
 
   .inviteContributorsConfirmationShareLinkContainer {
@@ -38,11 +39,11 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin: 12px 0 28px;
+    margin-bottom: 28px;
 
     .inviteContributorsConfirmationLink {
       white-space: nowrap;
-      overflow: scroll;
+      overflow-x: auto;
       background: #F2F2F2;
       border-radius: 6px;
       padding: 10px;


### PR DESCRIPTION
Co-authored-by: Nick Reuter <thenewimagineer@gmail.com>
Co-authored-by: Ashley Clifton <randomashes@gmail.com>

## Issue
Connects #278 

## What was done
- [x] Updated the scroll for the invite confirmation modal url to only scroll horizontally
- [x] Fixed the padding below the form text

## How to test
1. On a windows device, Invite a user so that the invite confirmation modal pops up
2. Ensure that the modal styles look how they should.
