### PR TITLE
Update Cypress product test's datepicker functionality

### DIFF
--- a/ui/cypress/e2e/product.test.js
+++ b/ui/cypress/e2e/product.test.js
@@ -63,7 +63,6 @@ const populateProductForm = ({ name, location, tags = [], startDate, nextPhaseDa
     cy.get('@calendarStartDate').should('have.value', startDate);
     cy.get('.modalTitle').click();
 
-
     cy.get('@calendarEndDate')
         .should('have.value', '')
         .click();

--- a/ui/cypress/e2e/product.test.js
+++ b/ui/cypress/e2e/product.test.js
@@ -49,20 +49,39 @@ const populateProductForm = ({ name, location, tags = [], startDate, nextPhaseDa
         cy.get('@productForm').find('[id=productTags]').focus().type(tag + '{enter}', {force: true});
     });
 
-    const todaysDate = Cypress.moment().format('MM/DD/yyyy');
-    cy.get('#start')
-        .should('have.value', todaysDate)
-        .focus()
-        .type(startDate)
-        .should('have.value', startDate);
-    cy.get('#end')
-        .should('have.value', '')
-        .focus()
-        .type(nextPhaseDate)
-        .should('have.value', nextPhaseDate);
-    cy.get('[data-testid=modalPopupContainer]').click();
+    cy.get('#start').as('calendarStartDate');
+    cy.get('#end').as('calendarEndDate');
 
-    cy.get('[data-testid=formNotesToField]').focus().type(notes).should('have.value', notes);
+    const todaysDate = Cypress.moment().format('MM/DD/yyyy');
+    cy.get('@calendarStartDate')
+        .should('have.value', todaysDate)
+        .click();
+
+    const today = Cypress.moment();
+    cy.get(dateSelector(today)).click({force: true});
+
+    cy.get('@calendarStartDate').should('have.value', startDate);
+    cy.get('.modalTitle').click();
+
+
+    cy.get('@calendarEndDate')
+        .should('have.value', '')
+        .click();
+
+    const tomorrow = Cypress.moment().add(1, 'days');
+    cy.get(dateSelector(tomorrow)).click({force: true});
+
+    cy.get('@calendarEndDate').should('have.value', nextPhaseDate);
+
+    cy.get('[data-testid=formNotesToField]')
+        .focus()
+        .type(notes)
+        .should('have.value', notes);
+};
+
+const dateSelector = (moment) => {
+    const dateLabel = moment.format( 'dddd, MMMM Do, yyyy');
+    return `[aria-label="Choose ${dateLabel}"]`;
 };
 
 const submitProductForm = () => {


### PR DESCRIPTION
## Issue
Connects N/A

## What was done
- [x] Update cypress "Create a product" test to click on the calendar pop up instead of typing in a date.

I was seeing an inconsistency where it would type the date for the start date, then type the date for the end date and would pass, saying the end date was in fact the next date, but visually it would show as the same date as the start date. This fixes that issue.

## How to test
1. Run the product cypress test and ensure the date selection behaves as expected.
