### PR TITLE
Add hover state to edit space button

### DIFF
--- a/ui/src/SpaceDashboard/SpaceDashboardTile.scss
+++ b/ui/src/SpaceDashboard/SpaceDashboardTile.scss
@@ -77,6 +77,12 @@
   font-weight: normal;
   font-size: 12px;
   line-height: 18px;
+
+  &:hover {
+    color: $purple;
+    background-color: $gray-6;
+    border-radius: 2px;
+  }
 }
 
 

--- a/ui/src/SpaceDashboard/SpaceForm.tsx
+++ b/ui/src/SpaceDashboard/SpaceForm.tsx
@@ -24,7 +24,7 @@ import SpaceClient from './SpaceClient';
 import './SpaceForm.scss';
 import {createEmptySpace, Space} from './Space';
 
-interface CreateSpaceFormProps {
+interface SpaceFormProps {
     space?: Space;
     closeModal(): void;
     fetchUserSpaces(): void;
@@ -34,7 +34,7 @@ function SpaceForm({
     space,
     closeModal,
     fetchUserSpaces,
-}: CreateSpaceFormProps): JSX.Element {
+}: SpaceFormProps): JSX.Element {
     const maxLength = 40;
     const editing = !!space;
     const [formSpace, setFormSpace] = useState<Space>(initializeSpace());
@@ -57,9 +57,7 @@ function SpaceForm({
                 .then(closeModal)
                 .then(fetchUserSpaces);
         }
-
     }
-
 
     function onSpaceNameFieldChanged(event: React.ChangeEvent<HTMLInputElement>): void {
         setFormSpace({


### PR DESCRIPTION
Co-authored-by: Vianney Willot <vianney.willot@gmail.com>
Co-authored-by: Elise Griffiths <egriff38@ford.com>

## Issue
Connects #222 

## What was done
- [x] add hovering to edit button

## How to test
1. hover on the edit button of the space menu and see the magnificent text color change to purple and the delightfull background change to a smoothing light grey
