### PR TITLE
Making locations clearable on product form

### DIFF
--- a/ui/src/Products/ProductFormLocationField.tsx
+++ b/ui/src/Products/ProductFormLocationField.tsx
@@ -92,7 +92,7 @@ function ProductFormLocationField({
     function updateSpaceLocations(option: Option): void {
         const updatedProduct: Product = {
             ...currentProduct,
-            spaceLocation: optionToSpaceLocation(option),
+            spaceLocation: option ? optionToSpaceLocation(option) : undefined,
         };
         setCurrentProduct(updatedProduct);
     }
@@ -114,7 +114,7 @@ function ProductFormLocationField({
                 formatCreateLabel={(): JSX.Element => CreateNewText(`Create "${typedInLocation}"`)}
                 placeholder="Select or create location"
                 hideSelectedOptions={true}
-                isClearable={false}
+                isClearable={true}
                 value={locationOptionValue()}
             />
         </div>


### PR DESCRIPTION
Co-authored-by: Michael Rygiel <michael.rygiel1@gmail.com>
Co-authored-by: Ashley Clifton <randomashes@gmail.com>

## Issue
Connects #354 

## What was done
- [x] Locations on a product are now clearable

## How to test
1. Create a new product or edit an existing product. In the product modal, add a location, then click the 'x' to remove the location. Make sure the product saves properly
