### PR TITLE
Ensure dashboard shows only spaces user has access to

### DIFF
--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
@@ -50,8 +50,8 @@ class SpaceController(private val spaceService: SpaceService, private val logger
 
     @PostMapping("/user")
     fun createUserSpace(
-            @RequestBody request: SpaceCreationRequest,
-            @RequestHeader(name = "Authorization") token: String
+        @RequestBody request: SpaceCreationRequest,
+        @RequestHeader(name = "Authorization") token: String
     ): SpaceResponse {
         return spaceService.createSpaceWithUser(token.replace("Bearer ", ""), request.spaceName)
     }

--- a/ui/src/SpaceDashboard/SpaceClient.ts
+++ b/ui/src/SpaceDashboard/SpaceClient.ts
@@ -23,7 +23,7 @@ const baseSpaceUrl = `/api/spaces`;
 
 class SpaceClient {
     static async getSpacesForUser(accessToken: string): Promise<AxiosResponse<Space[]>> {
-        const url = baseSpaceUrl;
+        const url = baseSpaceUrl + '/user';
         const config = {
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
## Issue
Connects #N/A

## What was done
- [x] Fixed issue where dashboard wasn't filtering spaces by user.

## How to test
1. Log into your dashboard and ensure you're only seeing spaces that you have access too.
