### PR TITLE
Update verbage from 'Invite Members' to 'Share Access'

### DIFF
--- a/ui/src/Redux/Containers/ModalContainer.tsx
+++ b/ui/src/Redux/Containers/ModalContainer.tsx
@@ -120,7 +120,7 @@ const getCurrentTitle = (currentModal: CurrentModalState): string => {
         case AvailableModals.EDIT_SPACE:
             return 'Edit Space';
         case AvailableModals.EDIT_CONTRIBUTORS:
-            return 'Invite Members';
+            return 'Share Access';
         case AvailableModals.CONTRIBUTORS_CONFIRMATION:
             return 'Your team member now has access!';
         default:

--- a/ui/src/ReusableComponents/AccountDropdown.tsx
+++ b/ui/src/ReusableComponents/AccountDropdown.tsx
@@ -83,7 +83,7 @@ function AccountDropdown({
                 {window.runConfig.invite_users_to_space_enabled && !hideSpaceButtons &&
                     <div data-testid="invite-members" className="account-dropdown-options"
                         onClick={() => setCurrentModal({modal: AvailableModals.EDIT_CONTRIBUTORS})}>
-                        Invite Members
+                        Share Access
                     </div>
                 }
                 {!hideSpaceButtons &&

--- a/ui/src/ReusableComponents/AccountDropdown.tsx
+++ b/ui/src/ReusableComponents/AccountDropdown.tsx
@@ -81,7 +81,7 @@ function AccountDropdown({
 
             {dropdownFlag && <div className={'dropdown-container'}>
                 {window.runConfig.invite_users_to_space_enabled && !hideSpaceButtons &&
-                    <div data-testid="invite-members" className="account-dropdown-options"
+                    <div data-testid="share-access" className="account-dropdown-options"
                         onClick={() => setCurrentModal({modal: AvailableModals.EDIT_CONTRIBUTORS})}>
                         Share Access
                     </div>

--- a/ui/src/tests/AccountDropdown.test.tsx
+++ b/ui/src/tests/AccountDropdown.test.tsx
@@ -54,16 +54,16 @@ describe('Account Dropdown',  () => {
         });
     });
 
-    it('Should open Invite Members modal on click of text in dropdown',  async () => {
+    it('Should open Share Access modal on click of text in dropdown',  async () => {
         await act( async () => {
-            fireEvent.click(await app.findByText('Share Access'));
+            fireEvent.click(await app.findByTestId('share-access'));
         });
         expect(app.getByText('Share Access'));
     });
 
     it('should close Edit Contributors modal on click of Cancel button', async () => {
         await act( async () => {
-            fireEvent.click(await app.findByText('Share Access'));
+            fireEvent.click(await app.findByTestId('share-access'));
             const cancelButton = await app.findByText('Cancel');
             fireEvent.click(cancelButton);
         });
@@ -72,7 +72,7 @@ describe('Account Dropdown',  () => {
 
     it('should submit invited contributors, current space name, and access token on click of Invite button', async () => {
         await act( async () => {
-            fireEvent.click(await app.findByText('Share Access'));
+            fireEvent.click(await app.findByTestId('share-access'));
 
             const usersToInvite = app.getByTestId('emailTextArea');
             fireEvent.change(usersToInvite, {target: {value: 'some1@email.com,some2@email.com,some3@email.com'}});

--- a/ui/src/tests/AccountDropdown.test.tsx
+++ b/ui/src/tests/AccountDropdown.test.tsx
@@ -56,14 +56,14 @@ describe('Account Dropdown',  () => {
 
     it('Should open Invite Members modal on click of text in dropdown',  async () => {
         await act( async () => {
-            fireEvent.click(await app.findByText('Invite Members'));
+            fireEvent.click(await app.findByText('Share Access'));
         });
-        expect(app.getByText('Invite Members'));
+        expect(app.getByText('Share Access'));
     });
 
     it('should close Edit Contributors modal on click of Cancel button', async () => {
         await act( async () => {
-            fireEvent.click(await app.findByText('Invite Members'));
+            fireEvent.click(await app.findByText('Share Access'));
             const cancelButton = await app.findByText('Cancel');
             fireEvent.click(cancelButton);
         });
@@ -72,7 +72,7 @@ describe('Account Dropdown',  () => {
 
     it('should submit invited contributors, current space name, and access token on click of Invite button', async () => {
         await act( async () => {
-            fireEvent.click(await app.findByText('Invite Members'));
+            fireEvent.click(await app.findByText('Share Access'));
 
             const usersToInvite = app.getByTestId('emailTextArea');
             fireEvent.change(usersToInvite, {target: {value: 'some1@email.com,some2@email.com,some3@email.com'}});

--- a/ui/src/tests/SpaceButtons.test.tsx
+++ b/ui/src/tests/SpaceButtons.test.tsx
@@ -45,7 +45,7 @@ describe('SpaceButtons', () => {
         });
 
         try {
-            expect(result.getByTestId('invite-members'));
+            expect(result.getByTestId('share-access'));
             expect(true).toBeFalsy();
         } catch (e) {
             expect(true).toBeTruthy();
@@ -65,7 +65,7 @@ describe('SpaceButtons', () => {
             });
             result.getByTestId('editContributorsModal').click();
         });
-        expect(result.getByTestId('invite-members')).not.toBeNull();
+        expect(result.getByTestId('share-access')).not.toBeNull();
     });
 
 

--- a/ui/src/tests/SpaceDashboard.test.tsx
+++ b/ui/src/tests/SpaceDashboard.test.tsx
@@ -33,7 +33,7 @@ describe('SpaceDashboard tests', () => {
         window.runConfig = {invite_users_to_space_enabled: false} as RunConfig;
         const {component} = await createTestComponent();
         await fireEvent.click(component.getByTestId('editContributorsModal'));
-        expect(component.queryByTestId('invite-members')).toBeNull();
+        expect(component.queryByTestId('share-access')).toBeNull();
         expect(component.queryByTestId('sign-out')).not.toBeNull();
     });
 


### PR DESCRIPTION
## Issue
Connects #371 

## What was done
- [x] Changed text from Invite Member to Share Access

## How to test
1. In the account dropdown menu, there should be Share Access listed instead of Invite Members
