### PR TITLE
Changed Css to get accordion element position on the right at the start

### DIFF
--- a/ui/src/Application/PeopleMover.scss
+++ b/ui/src/Application/PeopleMover.scss
@@ -39,7 +39,7 @@
 .productAndAccordionContainer {
     display: flex;
     flex-direction: row;
-    justify-content: stretch;
+    justify-content: flex-end;
 }
 
 .accordionContainer {


### PR DESCRIPTION
## Issue
Connects #399 

## What was done
- [x] Stick content on left of product view to left side of screen when loading

## How to test
1. Login in and navigate to your space
2. Confirm the leftmost content is always on the left
