### PR TITLE
Update all Apache License notes to include 2020 instead of 2019

### DIFF
--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/LocalConfig.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/LocalConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/PeopleMoverApplication.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/PeopleMoverApplication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/Assignment.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/Assignment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/CreateAssignmentsRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/CreateAssignmentsRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/Reassignment.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/Reassignment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/AssignmentAlreadyExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/AssignmentAlreadyExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/AssignmentNotExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/AssignmentNotExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/InvalidDateFormatException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/InvalidDateFormatException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AccessTokenRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AccessTokenRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthCheckScopesRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthCheckScopesRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthInviteUsersToSpaceRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthInviteUsersToSpaceRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/RefreshTokenRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/RefreshTokenRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/ValidateTokenRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/ValidateTokenRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/exceptions/InvalidTokenException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/exceptions/InvalidTokenException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryFactory.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryFactoryBean.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryFactoryBean.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryImpl.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/Color.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/Color.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/exceptions/ColorAlreadyExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/exceptions/ColorAlreadyExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/exceptions/ColorDoesNotExistException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/exceptions/ColorDoesNotExistException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/LocationAddRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/LocationAddRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/LocationController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/LocationController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/LocationEditRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/LocationEditRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/LocationService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/LocationService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/SpaceLocation.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/SpaceLocation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/SpaceLocationRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/SpaceLocationRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/exceptions/LocationAlreadyExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/exceptions/LocationAlreadyExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/exceptions/LocationNotExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/location/exceptions/LocationNotExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/Person.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/Person.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/exceptions/PersonNotExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/exceptions/PersonNotExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/Product.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/Product.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductAddRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductAddRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductEditRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductEditRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/InvalidProductSpaceMappingException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/InvalidProductSpaceMappingException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/ProductAlreadyExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/ProductAlreadyExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/ProductFieldTooLongException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/ProductFieldTooLongException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/ProductNotExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/ProductNotExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTag.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTag.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagAddRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagAddRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagEditRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagEditRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/exceptions/ProductTagAlreadyExistsForSpaceException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/exceptions/ProductTagAlreadyExistsForSpaceException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/exceptions/ProductTagNotExistsForSpaceException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/producttag/exceptions/ProductTagNotExistsForSpaceException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/RoleAddRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/RoleAddRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/RoleController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/RoleController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/RoleEditRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/RoleEditRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/RoleService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/RoleService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/SpaceRole.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/SpaceRole.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/SpaceRolesRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/SpaceRolesRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/exceptions/RoleAlreadyExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/exceptions/RoleAlreadyExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/exceptions/RoleNotExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/role/exceptions/RoleNotExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/Space.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/Space.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceComponent.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceComponent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceCreationRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceCreationRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceResponse.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/TimestampResponse.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/TimestampResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceNameTooLongException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceNameTooLongException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceNotExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceNotExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/utilities/BasicLogger.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/utilities/BasicLogger.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/resources/application-cloud.properties
+++ b/api/src/main/resources/application-cloud.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Ford Motor Company
+# Copyright (c) 2020 Ford Motor Company
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/resources/application-mysql.properties
+++ b/api/src/main/resources/application-mysql.properties
@@ -1,3 +1,20 @@
+#
+# Copyright (c) 2020 Ford Motor Company
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 spring.flyway.locations=classpath:db/mysql
 spring.datasource.url=jdbc:mysql://localhost:3306/PEOPLEMOVER_DB
 spring.datasource.username=root

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Ford Motor Company
+# Copyright (c) 2020 Ford Motor Company
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerInTimeApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerInTimeApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerReassignmentsApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerReassignmentsApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/auth/AuthControllerE2ETest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/auth/AuthControllerE2ETest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/color/ColorApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/color/ColorApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerInTimeApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerInTimeApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagControllerTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagControllerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceControllerApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceControllerApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/utilities/BasicLoggerTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/utilities/BasicLoggerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Ford Motor Company
+ * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019 Ford Motor Company
+# Copyright (c) 2020 Ford Motor Company
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Issue
Connects #383 

## What was done
- [x] Update all back-end (remaining) Apache License notes to include 2020 instead of 2019

## How to test
1. Ensure all files that have an Apache license include the year 2020 instead of 2019
