### PR TITLE
Prevent page refresh on space link copied

### DIFF
--- a/ui/src/AccountDropdown/InviteContributorsConfirmationForm.test.tsx
+++ b/ui/src/AccountDropdown/InviteContributorsConfirmationForm.test.tsx
@@ -1,0 +1,72 @@
+/*
+ *
+ *  Copyright (c) 2020 Ford Motor Company
+ *  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+import InviteContributorsConfirmationForm from './InviteContributorsConfirmationForm';
+import {renderWithRedux} from '../tests/TestUtils';
+import React from 'react';
+import {fireEvent, wait} from '@testing-library/react';
+
+Object.assign(navigator, {
+    clipboard: {
+        writeText: (): void => {return;},
+    },
+});
+
+describe('Invite Contributors Confirmation Form', function() {
+    const expectedUrl = 'https://some-url';
+    let originalWindow: Window;
+
+    beforeEach(() => {
+        originalWindow = window;
+        delete window.location;
+        (window as Window) = Object.create(window);
+        window.location = {href: expectedUrl} as Location;
+    });
+
+    afterEach(() => {
+        (window as Window) = originalWindow;
+    });
+
+    it('should show correct space URL', function() {
+        const component = renderWithRedux(<InviteContributorsConfirmationForm/>);
+        expect(component.queryByText(expectedUrl)).not.toBeNull();
+    });
+
+    it('should copy the url to clipboard', async () => {
+        jest.spyOn(navigator.clipboard, 'writeText');
+        const component = renderWithRedux(<InviteContributorsConfirmationForm/>);
+
+        await wait(() => {
+            fireEvent.click(component.getByText('Copy link'));
+        });
+
+        expect(navigator.clipboard.writeText).toBeCalledWith(expectedUrl);
+    });
+
+    it('should should change text on copy', async () => {
+        const component = renderWithRedux(<InviteContributorsConfirmationForm/>);
+
+        await wait(() => {
+            fireEvent.click(component.getByText('Copy link'));
+        });
+
+        expect(component.queryByText('Copy link')).toBeNull();
+        expect(component.queryByText('Copied!')).not.toBeNull();
+    });
+});

--- a/ui/src/AccountDropdown/InviteContributorsConfirmationForm.tsx
+++ b/ui/src/AccountDropdown/InviteContributorsConfirmationForm.tsx
@@ -35,6 +35,8 @@ const InviteContributorConfirmationForm = ({ closeModal }: Props): JSX.Element =
         event.preventDefault();
         await navigator.clipboard.writeText(linkToSpace);
         setCopiedLink(true);
+
+        setTimeout(() => {setCopiedLink(false);}, 3000);
     };
 
     return (

--- a/ui/src/AccountDropdown/InviteContributorsConfirmationForm.tsx
+++ b/ui/src/AccountDropdown/InviteContributorsConfirmationForm.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 import {Dispatch} from 'redux';
 import {closeModalAction} from '../Redux/Actions';
 import FormButton from '../ModalFormComponents/FormButton';
@@ -28,10 +28,13 @@ interface Props {
 }
 
 const InviteContributorConfirmationForm = ({ closeModal }: Props): JSX.Element => {
-    const linkToSpace: string = window ? window.location.href : '';
+    const linkToSpace: string = window.location.href;
+    const [copiedLink, setCopiedLink] = useState<boolean>(false);
 
-    const copyLink = async (): Promise<void> => {
+    const copyLink = async (event: React.MouseEvent): Promise<void> => {
+        event.preventDefault();
         await navigator.clipboard.writeText(linkToSpace);
+        setCopiedLink(true);
     };
 
     return (
@@ -44,7 +47,7 @@ const InviteContributorConfirmationForm = ({ closeModal }: Props): JSX.Element =
                     {linkToSpace}
                 </div>
                 <button className="inviteContributorsConfirmationCopyButton" onClick={copyLink}>
-                    Copy link
+                    {copiedLink ? 'Copied!' : 'Copy link'}
                 </button>
             </div>
             <FormButton

--- a/ui/src/AccountDropdown/InviteContributorsConfirmationModal.scss
+++ b/ui/src/AccountDropdown/InviteContributorsConfirmationModal.scss
@@ -59,6 +59,7 @@
       cursor: pointer;
       background: none;
       padding: 0;
+      width: 4rem;
     }
   }
 }


### PR DESCRIPTION
Co-authored-by: Nick Reuter <thenewimagineer@gmail.com>
Co-authored-by: Elise Griffiths <egriff38@ford.com>

## Issue
Connects #437 

## What was done
- [x] Prevent page refresh when clicking copy link button
- [x] Make text change when button clicked for better user interaction

## How to test
1. Invite someone to a space
2. Click the "Copy link" button
