### PR TITLE
Grey out add tag button when edit tag is open

### DIFF
--- a/ui/src/Traits/MyTraits.scss
+++ b/ui/src/Traits/MyTraits.scss
@@ -154,7 +154,13 @@
 
   .addNewTraitRow {
     cursor: pointer;
+    background: none;
+
+    &:disabled {
+      cursor: not-allowed;
+    }
   }
+
   .selectRoleCircles {
     margin: 10px 0;
     display: flex;

--- a/ui/src/Traits/MyTraits.tsx
+++ b/ui/src/Traits/MyTraits.tsx
@@ -204,6 +204,10 @@ function MyTraits({
         }
     }
 
+    function isEditBoxOpen(): boolean {
+        return editSectionsOpen.includes(true);
+    }
+
     function ViewTraitRow({ trait, index }: { trait: Trait; index: number }): JSX.Element {
         let colorToUse: string | undefined;
         if (colorSection) {
@@ -223,7 +227,7 @@ function MyTraits({
                 <span className="traitName" data-testid={`given${testIdTraitName}Name`}>
                     {trait.name}
                 </span>
-                {userIsNotEditingATag && (
+                {userIsNotEditingATag && !addSectionOpen && (
                     <div className="traitIcons">
                         <i className="fas fa-pen fa-s traitEditIcon"
                             data-testid={`${testIdTraitName}EditIcon`}
@@ -273,7 +277,7 @@ function MyTraits({
                 currentSpace={currentSpace}/>
             }
 
-            {!addSectionOpen && <div className="traitRow addNewTraitRow"
+            {!addSectionOpen && <button className="traitRow addNewTraitRow" disabled={isEditBoxOpen()}
                 onClick={(): void => setAddSectionOpen(true)}
                 onKeyDown={(e): void => handleKeyDownForSetAddSectionOpen(e, true)}>
                 <span data-testid="addNewTraitCircle">
@@ -283,7 +287,7 @@ function MyTraits({
                     data-testid={`addNew${toTitleCase(traitName).replace(' ', '')}`}>
                     Add New {toTitleCase(traitName)}
                 </span>
-            </div>
+            </button>
             }
             {confirmDeleteModal}
         </div>

--- a/ui/src/tests/MyTags.test.tsx
+++ b/ui/src/tests/MyTags.test.tsx
@@ -291,6 +291,36 @@ describe('PeopleMover My Tags', () => {
             });
         });
 
+        describe('interaction between editing and creating location tag', () => {
+
+            it('should not show pen and trash can when add new tag is clicked', async () => {
+                expect(app.queryAllByTestId('locationEditIcon').length).toEqual(4);
+                expect(app.queryAllByTestId('locationDeleteIcon').length).toEqual(4);
+
+                const addNewLocationButton = await app.findByText('Add New Location');
+                fireEvent.click(addNewLocationButton);
+
+                expect(app.queryAllByTestId('locationEditIcon').length).toEqual(0);
+                expect(app.queryAllByTestId('locationDeleteIcon').length).toEqual(0);
+            });
+
+            it('should not show pen and trash icons when editing location tag', async () => {
+                expect(app.queryAllByTestId('locationEditIcon').length).toEqual(4);
+                expect(app.queryAllByTestId('locationDeleteIcon').length).toEqual(4);
+                fireEvent.click(app.queryAllByTestId('locationEditIcon')[0]);
+
+                expect(app.queryAllByTestId('locationEditIcon').length).toEqual(0);
+                expect(app.queryAllByTestId('locationDeleteIcon').length).toEqual(0);
+            });
+
+            it('should have create location button disabled when editing location tag', async () => {
+                fireEvent.click(app.queryAllByTestId('locationEditIcon')[0]);
+
+                const addNewLocationButton = await app.findByText('Add New Location');
+                expect(addNewLocationButton).toBeDisabled();
+            });
+        });
+
         describe('adding a product tag', () => {
             beforeEach(async () => {
                 const addNewProductTagButton = await app.findByText('Add New Product Tag');

--- a/ui/src/tests/MyTags.test.tsx
+++ b/ui/src/tests/MyTags.test.tsx
@@ -359,5 +359,35 @@ describe('PeopleMover My Tags', () => {
                 await app.findByText('A product tag with this name already exists. Enter a different name.');
             });
         });
+
+        describe('interaction between editing and creating product tag', () => {
+
+            it('should not show pen and trash can when add new tag is clicked', async () => {
+                expect(app.queryAllByTestId('producttagEditIcon').length).toEqual(4);
+                expect(app.queryAllByTestId('producttagDeleteIcon').length).toEqual(4);
+
+                const addNewLocationButton = await app.findByText('Add New Product Tag');
+                fireEvent.click(addNewLocationButton);
+
+                expect(app.queryAllByTestId('producttagEditIcon').length).toEqual(0);
+                expect(app.queryAllByTestId('producttagDeleteIcon').length).toEqual(0);
+            });
+
+            it('should not show pen and trash icons when editing product tag', async () => {
+                expect(app.queryAllByTestId('producttagEditIcon').length).toEqual(4);
+                expect(app.queryAllByTestId('producttagDeleteIcon').length).toEqual(4);
+                fireEvent.click(app.queryAllByTestId('producttagEditIcon')[0]);
+
+                expect(app.queryAllByTestId('producttagEditIcon').length).toEqual(0);
+                expect(app.queryAllByTestId('producttagDeleteIcon').length).toEqual(0);
+            });
+
+            it('should have create producttag button disabled when editing product tag', async () => {
+                fireEvent.click(app.queryAllByTestId('producttagEditIcon')[0]);
+
+                const addNewLocationButton = await app.findByText('Add New Product Tag');
+                expect(addNewLocationButton).toBeDisabled();
+            });
+        });
     });
 });

--- a/ui/src/tests/MyTags.test.tsx
+++ b/ui/src/tests/MyTags.test.tsx
@@ -21,18 +21,21 @@ import PeopleMover from '../Application/PeopleMover';
 import {act, findByTestId, findByText, fireEvent, queryByText, RenderResult} from '@testing-library/react';
 import LocationClient from '../Locations/LocationClient';
 import ProductTagClient from '../ProductTag/ProductTagClient';
+import MyTagsModal from "../Tags/MyTagsModal";
+import {PreloadedState} from "redux";
+import {GlobalStateProps} from "../Redux/Reducers";
 
 describe('PeopleMover My Tags', () => {
     let app: RenderResult;
+    const initialState: PreloadedState<GlobalStateProps> = {currentSpace: TestUtils.space, allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions} as GlobalStateProps;
+
 
     beforeEach(async () => {
         jest.clearAllMocks();
         TestUtils.mockClientCalls();
 
         await act(async () => {
-            app = renderWithRedux(<PeopleMover/>);
-            const myTagsButton = await app.findByText('My Tags');
-            fireEvent.click(myTagsButton);
+            app = renderWithRedux(<MyTagsModal/>, undefined, initialState);
         });
     });
 
@@ -51,9 +54,9 @@ describe('PeopleMover My Tags', () => {
     });
 
     it('Should contain all product tags available in the space', async () => {
-        const modalContainer = await app.findByTestId('modalContainer');
+        const myTagsModal = await app.findByTestId('myTagsModal');
         for (const productTag of TestUtils.productTags) {
-            await findByText(modalContainer, productTag.name);
+            await findByText(myTagsModal, productTag.name);
         }
     });
 
@@ -76,8 +79,8 @@ describe('PeopleMover My Tags', () => {
                 fireEvent.click(locationTagIcon);
                 await app.findByTestId('saveTagButton');
 
-                const modalContainer = await app.findByTestId('modalContainer');
-                const editLocationTagText: HTMLInputElement = await findByTestId(modalContainer, 'tagNameInput') as HTMLInputElement;
+                const myTagsModal = await app.findByTestId('myTagsModal');
+                const editLocationTagText: HTMLInputElement = await findByTestId(myTagsModal, 'tagNameInput') as HTMLInputElement;
                 expect(editLocationTagText.value).toEqual('Ann Arbor');
             });
 
@@ -95,8 +98,8 @@ describe('PeopleMover My Tags', () => {
 
                 await app.findByText(updatedLocation);
 
-                const modalContainer = await app.findByTestId('modalContainer');
-                expect(queryByText(modalContainer, 'Ann Arbor')).not.toBeInTheDocument();
+                const myTagsModal = await app.findByTestId('myTagsModal');
+                expect(queryByText(myTagsModal, 'Ann Arbor')).not.toBeInTheDocument();
             });
 
             it('should display error message when location with existed name is edited', async () => {
@@ -142,8 +145,8 @@ describe('PeopleMover My Tags', () => {
 
                 await app.findByText(updatedProductTag);
 
-                const modalContainer = await app.findByTestId('modalContainer');
-                expect(queryByText(modalContainer, 'FordX')).not.toBeInTheDocument();
+                const myTagsModal = await app.findByTestId('myTagsModal');
+                expect(queryByText(myTagsModal, 'FordX')).not.toBeInTheDocument();
             });
 
             it('should display error message when you try to edit product tag to have some existed tag name', async () => {
@@ -202,16 +205,16 @@ describe('PeopleMover My Tags', () => {
                 const cancelButton = await app.findByText('Cancel');
                 fireEvent.click(cancelButton);
 
-                const modalContainer = await app.findByTestId('modalContainer');
-                await findByText(modalContainer, 'Ann Arbor');
+                const myTagsModal = await app.findByTestId('myTagsModal');
+                await findByText(myTagsModal, 'Ann Arbor');
             });
 
             it('should remove location tag when clicking delete button in confirmation modal', async () => {
                 const deleteButton = await app.findByText('Delete');
                 fireEvent.click(deleteButton);
 
-                const modalContainer = await app.findByTestId('modalContainer');
-                expect(queryByText(modalContainer, 'Ann Arbor')).not.toBeInTheDocument();
+                const myTagsModal = await app.findByTestId('myTagsModal');
+                expect(queryByText(myTagsModal, 'Ann Arbor')).not.toBeInTheDocument();
             });
         });
 
@@ -231,16 +234,16 @@ describe('PeopleMover My Tags', () => {
                 const deleteButton = await app.findByText('Delete');
                 fireEvent.click(deleteButton);
 
-                const modalContainer = await app.findByTestId('modalContainer');
-                expect(queryByText(modalContainer, 'AV')).not.toBeInTheDocument();
+                const myTagsModal = await app.findByTestId('myTagsModal');
+                expect(queryByText(myTagsModal, 'AV')).not.toBeInTheDocument();
             });
 
             it('should not remove product tag when clicking cancel button in confirmation modal', async () => {
                 const cancelButton = await app.findByText('Cancel');
                 fireEvent.click(cancelButton);
 
-                const modalContainer = await app.findByTestId('modalContainer');
-                await findByText(modalContainer, 'AV');
+                const myTagsModal = await app.findByTestId('myTagsModal');
+                await findByText(myTagsModal, 'AV');
             });
 
         });

--- a/ui/src/tests/RoleModal.test.tsx
+++ b/ui/src/tests/RoleModal.test.tsx
@@ -23,19 +23,18 @@ import RoleClient from '../Roles/RoleClient';
 import {RoleAddRequest} from '../Roles/RoleAddRequest';
 import {PreloadedState} from 'redux';
 import {GlobalStateProps} from '../Redux/Reducers';
+import MyRolesModal from "../Roles/MyRolesModal";
 
 describe('PeopleMover Role Modal', () => {
     let app: RenderResult;
-    const initialState: PreloadedState<GlobalStateProps> = {currentSpace: TestUtils.space} as GlobalStateProps;
+    const initialState: PreloadedState<GlobalStateProps> = {currentSpace: TestUtils.space, allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions} as GlobalStateProps;
 
     beforeEach(async () => {
         jest.clearAllMocks();
         TestUtils.mockClientCalls();
 
         await act(async () => {
-            app = renderWithRedux(<PeopleMover/>, undefined, initialState);
-            const myRolesButton = await app.findByText('My Roles');
-            fireEvent.click(myRolesButton);
+            app = renderWithRedux(<MyRolesModal/>, undefined, initialState);
         });
     });
 
@@ -44,10 +43,10 @@ describe('PeopleMover Role Modal', () => {
     });
 
     it('should show existing roles', async () => {
-        const modalContainer = await app.findByTestId('modalContainer');
-        await findByText(modalContainer, 'Software Engineer');
-        await findByText(modalContainer, 'Product Designer');
-        await findByText(modalContainer, 'Product Manager');
+        const myRolesModalContainer = await app.findByTestId('myRolesModalContainer');
+        await findByText(myRolesModalContainer, 'Software Engineer');
+        await findByText(myRolesModalContainer, 'Product Designer');
+        await findByText(myRolesModalContainer, 'Product Manager');
     });
 
     it('should show existing roles with color-circle', async () => {
@@ -182,8 +181,8 @@ describe('PeopleMover Role Modal', () => {
                 expect(app.queryByTestId('cancelTagButton')).not.toBeInTheDocument();
             });
 
-            const modalContainer = await app.findByTestId('modalContainer');
-            await findByText(modalContainer, expectedNewRoleName);
+            const myRolesModalContainer = await app.findByTestId('myRolesModalContainer');
+            await findByText(myRolesModalContainer, expectedNewRoleName);
         });
 
         it('should save role with the given name and color when you hit the Enter key', async () => {
@@ -207,8 +206,8 @@ describe('PeopleMover Role Modal', () => {
                 expect(app.queryByText('Cancel')).not.toBeInTheDocument();
             });
 
-            const modalContainer = await app.findByTestId('modalContainer');
-            await findByText(modalContainer, expectedNewRoleName);
+            const myRolesModalContainer = await app.findByTestId('myRolesModalContainer');
+            await findByText(myRolesModalContainer, expectedNewRoleName);
         });
 
         it('should not allow saving empty role', async () => {
@@ -274,8 +273,8 @@ describe('PeopleMover Role Modal', () => {
             const myFirstPencil = roleEditIcons[0];
             fireEvent.click(myFirstPencil);
 
-            const modalContainer = await app.findByTestId('modalContainer');
-            const roleNameInputField: HTMLInputElement = await findByTestId(modalContainer, 'tagNameInput') as HTMLInputElement;
+            const myRolesModalContainer = await app.findByTestId('myRolesModalContainer');
+            const roleNameInputField: HTMLInputElement = await findByTestId(myRolesModalContainer, 'tagNameInput') as HTMLInputElement;
             expect(roleNameInputField.value).toEqual('Product Designer');
         });
 
@@ -313,8 +312,8 @@ describe('PeopleMover Role Modal', () => {
             expect(circles[1]).toHaveStyle('background-color: 2');
             expect(circles[2]).toHaveStyle('background-color: 3');
 
-            const modalContainer = await app.findByTestId('modalContainer');
-            expect(queryByText(modalContainer, 'Software Engineer')).not.toBeInTheDocument();
+            const myRolesModalContainer = await app.findByTestId('myRolesModalContainer');
+            expect(queryByText(myRolesModalContainer, 'Software Engineer')).not.toBeInTheDocument();
         });
 
         it('should not allow saving empty role', async () => {
@@ -363,8 +362,38 @@ describe('PeopleMover Role Modal', () => {
                 expect(app.queryByText(deleteWarning)).not.toBeInTheDocument();
             });
 
-            const modalContainer = await app.findByTestId('modalContainer');
-            expect(queryByText(modalContainer, 'Product Manager')).not.toBeInTheDocument();
+            const myRolesModalContainer = await app.findByTestId('myRolesModalContainer');
+            expect(queryByText(myRolesModalContainer, 'Product Manager')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('interaction between editing and creating role', () => {
+
+        it('should not show pen and trash can when add new tag is clicked', async () => {
+            expect(app.queryAllByTestId('roleEditIcon').length).toEqual(3);
+            expect(app.queryAllByTestId('roleDeleteIcon').length).toEqual(3);
+
+            const addNewLocationButton = await app.findByText('Add New Role');
+            fireEvent.click(addNewLocationButton);
+
+            expect(app.queryAllByTestId('roleEditIcon').length).toEqual(0);
+            expect(app.queryAllByTestId('roleDeleteIcon').length).toEqual(0);
+        });
+
+        it('should not show pen and trash icons when editing role', async () => {
+            expect(app.queryAllByTestId('roleEditIcon').length).toEqual(3);
+            expect(app.queryAllByTestId('roleDeleteIcon').length).toEqual(3);
+            fireEvent.click(app.queryAllByTestId('roleEditIcon')[0]);
+
+            expect(app.queryAllByTestId('roleEditIcon').length).toEqual(0);
+            expect(app.queryAllByTestId('roleDeleteIcon').length).toEqual(0);
+        });
+
+        it('should have create role button disabled when editing role', async () => {
+            fireEvent.click(app.queryAllByTestId('roleEditIcon')[0]);
+
+            const addNewLocationButton = await app.findByText('Add New Role');
+            expect(addNewLocationButton).toBeDisabled();
         });
     });
 });


### PR DESCRIPTION
## Issue
Resolves #459

## What was done
- [x] grey add tag button when edit tag is open
- [x] hide pen and trash when create tag is open
## How to test
1. create a tag in my roles and my tags and see the trash and pen disappear
2. edit a tag  in my roles and my tags and see the create tag become grey out (we used the same color than for the add space button in create space modal)


Feature URL: https://featurebranchui.apps.pd01i.edc1.cf.ford.com/
