### PR TITLE
My role warning 

### DIFF
--- a/ui/src/Traits/EditTraitSection.tsx
+++ b/ui/src/Traits/EditTraitSection.tsx
@@ -186,6 +186,9 @@ function EditTraitSection({
         setSelectedColor(color);
     };
 
+
+    let isTraitNameInvalid = enteredTrait.name === '' || duplicateErrorMessage || enteredTrait.name.toLowerCase() === originalTraitName?.toLowerCase();
+
     return (
         <>
             <div className={`editTagRow ${traitNameClass}`} data-testid={createDataTestId('editTagRow', traitName)}>
@@ -210,7 +213,7 @@ function EditTraitSection({
                         aria-label="Close Edited Tag">
                         <img src={CloseIcon} alt=""/>
                     </button>
-                    <button disabled={enteredTrait.name === '' || duplicateErrorMessage || enteredTrait.name.toLowerCase() === originalTraitName?.toLowerCase()}
+                    <button disabled={isTraitNameInvalid}
                         onClick={handleSubmit}
                         data-testid="saveTagButton"
                         className="saveEditTagButton"

--- a/ui/src/Traits/EditTraitSection.tsx
+++ b/ui/src/Traits/EditTraitSection.tsx
@@ -206,7 +206,7 @@ function EditTraitSection({
             </div>
             {duplicateErrorMessage && (
                 <div className="duplicateErrorMessage">
-                    A {traitName} with this name already exists. Enter a different name.
+                    Oops! You already have this {traitName}. Please try using a different one.
                 </div>
             )}
         </>

--- a/ui/src/Traits/MyTraits.tsx
+++ b/ui/src/Traits/MyTraits.tsx
@@ -279,7 +279,8 @@ function MyTraits({
                 traitClient={traitClient}
                 traitName={traitName}
                 colorSection={colorSection}
-                currentSpace={currentSpace}/>
+                currentSpace={currentSpace}
+                listOfTraits={traits}/>
         );
     };
 
@@ -302,7 +303,7 @@ function MyTraits({
                             traitClient={traitClient}
                             traitName={traitName}
                             currentSpace={currentSpace}
-                        />
+                            listOfTraits={traits}/>
                         }
                     </React.Fragment>
                 );

--- a/ui/src/tests/MyTags.test.tsx
+++ b/ui/src/tests/MyTags.test.tsx
@@ -165,20 +165,22 @@ describe('PeopleMover My Tags', () => {
             });
 
             it('should display error message only for corresponding edit product tag section', async () => {
-                ProductTagClient.edit = jest.fn(() => Promise.reject({
-                    response: { status: 409 },
-                }));
+                // ProductTagClient.edit = jest.fn(() => Promise.reject({
+                //     response: { status: 409 },
+                // }));
 
                 const updatedProductTag = 'av';
 
                 const editProductTagText = await app.findByTestId('tagNameInput');
-                fireEvent.change(editProductTagText, {target: {value: updatedProductTag}});
+                fireEvent.change(editProductTagText, {target: {value: 'FordX'}});
+                // fireEvent.change(editProductTagText, {target: {value: updatedProductTag}});
 
-                const secondEditProductTagIcon = editIcons[1];
-                fireEvent.click(secondEditProductTagIcon);
+                // const secondEditProductTagIcon = editIcons[1];
+                // fireEvent.click(secondEditProductTagIcon);
 
                 const saveButton = await app.findByTestId('saveTagButton');
-                fireEvent.click(saveButton);
+                expect(saveButton).toBeDisabled()
+                // fireEvent.click(saveButton);
 
                 const errorMessage = await app.findAllByText('A product tag with this name already exists. Enter a different name.');
                 expect(errorMessage.length).toEqual(1);

--- a/ui/src/tests/MyTags.test.tsx
+++ b/ui/src/tests/MyTags.test.tsx
@@ -117,7 +117,7 @@ describe('PeopleMover My Tags', () => {
                 const saveButton = await app.findByTestId('saveTagButton');
                 fireEvent.click(saveButton);
 
-                await app.findByText('A location with this name already exists. Enter a different name.');
+                await app.findByText('Oops! You already have this location. Please try using a different one.');
             });
         });
 
@@ -148,41 +148,13 @@ describe('PeopleMover My Tags', () => {
                 expect(queryByText(myTagsModal, 'FordX')).not.toBeInTheDocument();
             });
 
-            it('should display error message when you try to edit product tag to have some existed tag name', async () => {
-                ProductTagClient.edit = jest.fn(() => Promise.reject({
-                    response: { status: 409 },
-                }));
-
-                const updatedProductTag = 'av';
-
-                const editProductTagText = await app.findByTestId('tagNameInput');
-                fireEvent.change(editProductTagText, {target: {value: updatedProductTag}});
-
-                const saveButton = await app.findByTestId('saveTagButton');
-                fireEvent.click(saveButton);
-
-                await app.findByText('A product tag with this name already exists. Enter a different name.');
-            });
-
             it('should display error message only for corresponding edit product tag section', async () => {
-                // ProductTagClient.edit = jest.fn(() => Promise.reject({
-                //     response: { status: 409 },
-                // }));
-
-                const updatedProductTag = 'av';
-
                 const editProductTagText = await app.findByTestId('tagNameInput');
                 fireEvent.change(editProductTagText, {target: {value: 'FordX'}});
-                // fireEvent.change(editProductTagText, {target: {value: updatedProductTag}});
-
-                // const secondEditProductTagIcon = editIcons[1];
-                // fireEvent.click(secondEditProductTagIcon);
-
                 const saveButton = await app.findByTestId('saveTagButton');
-                expect(saveButton).toBeDisabled()
-                // fireEvent.click(saveButton);
+                expect(saveButton).toBeDisabled();
 
-                const errorMessage = await app.findAllByText('A product tag with this name already exists. Enter a different name.');
+                const errorMessage = await app.findAllByText('Oops! You already have this product tag. Please try using a different one.');
                 expect(errorMessage.length).toEqual(1);
             });
         });
@@ -291,7 +263,7 @@ describe('PeopleMover My Tags', () => {
 
                 fireEvent.click(saveButton);
 
-                await app.findByText('A location with this name already exists. Enter a different name.');
+                await app.findByText('Oops! You already have this location. Please try using a different one.');
             });
         });
 
@@ -360,7 +332,7 @@ describe('PeopleMover My Tags', () => {
 
                 fireEvent.click(saveButton);
 
-                await app.findByText('A product tag with this name already exists. Enter a different name.');
+                await app.findByText('Oops! You already have this product tag. Please try using a different one.');
             });
         });
 

--- a/ui/src/tests/RoleModal.test.tsx
+++ b/ui/src/tests/RoleModal.test.tsx
@@ -70,7 +70,7 @@ describe('PeopleMover Role Modal', () => {
             const saveButton = await app.findByTestId('saveTagButton');
             expect(saveButton).toBeDisabled();
 
-            await app.findByText('A role with this name already exists. Enter a different name.');
+            await app.findByText('Oops! You already have this role. Please try using a different one.');
         });
 
         it('should add new role section when you click Add New Role', async () => {
@@ -155,7 +155,7 @@ describe('PeopleMover Role Modal', () => {
             const saveButton = await app.findByTestId('saveTagButton');
             expect(saveButton).toBeDisabled();
 
-            await app.findByText('A role with this name already exists. Enter a different name.');
+            await app.findByText('Oops! You already have this role. Please try using a different one.');
         });
 
         it('should show edit section when clicking the pencil', async () => {

--- a/ui/src/tests/RoleModal.test.tsx
+++ b/ui/src/tests/RoleModal.test.tsx
@@ -61,18 +61,14 @@ describe('PeopleMover Role Modal', () => {
         });
 
         it('should show error message when duplicated role is added', async () => {
-            (RoleClient.add as Function) = jest.fn(() => Promise.reject({
-                response: { status: 409 },
-            }));
-
             const addNewRoleButton = await app.findByText('Add New Role');
             fireEvent.click(addNewRoleButton);
 
             const roleNameField = await app.findByTestId('tagNameInput');
-            fireEvent.change(roleNameField, {target: {value: 'I am a duplicate'}});
+            fireEvent.change(roleNameField, {target: {value: 'Software Engineer'}});
 
             const saveButton = await app.findByTestId('saveTagButton');
-            fireEvent.click(saveButton);
+            expect(saveButton).toBeDisabled();
 
             await app.findByText('A role with this name already exists. Enter a different name.');
         });
@@ -147,20 +143,17 @@ describe('PeopleMover Role Modal', () => {
         });
 
         it('should display error message when name is changed to existing role name', async () => {
-            (RoleClient.edit as Function) = jest.fn(() => Promise.reject({
-                response: { status: 409 },
-            }));
-
             const roleEditIcons = await app.findAllByTestId('roleEditIcon');
 
             const myFirstPencil = roleEditIcons[0];
             fireEvent.click(myFirstPencil);
 
             const roleNameField = await app.findByTestId('tagNameInput');
-            fireEvent.change(roleNameField, {target: {value: 'Product Designer'}});
+            fireEvent.change(roleNameField, {target: {value: 'Product Manager'}});
+            // fireEvent.change(roleNameField, {target: {value: 'Product Designer'}});
 
             const saveButton = await app.findByTestId('saveTagButton');
-            fireEvent.click(saveButton);
+            expect(saveButton).toBeDisabled();
 
             await app.findByText('A role with this name already exists. Enter a different name.');
         });
@@ -193,7 +186,7 @@ describe('PeopleMover Role Modal', () => {
             fireEvent.click(myFirstPencil);
 
             const saveButton = await app.findByTestId('saveTagButton');
-            expect(saveButton).not.toBeDisabled();
+            expect(saveButton).toBeDisabled();
 
             const roleNameField = await app.findByTestId('tagNameInput');
             fireEvent.change(roleNameField, {target: {value: ''}});

--- a/ui/src/tests/RoleModal.test.tsx
+++ b/ui/src/tests/RoleModal.test.tsx
@@ -150,7 +150,6 @@ describe('PeopleMover Role Modal', () => {
 
             const roleNameField = await app.findByTestId('tagNameInput');
             fireEvent.change(roleNameField, {target: {value: 'Product Manager'}});
-            // fireEvent.change(roleNameField, {target: {value: 'Product Designer'}});
 
             const saveButton = await app.findByTestId('saveTagButton');
             expect(saveButton).toBeDisabled();


### PR DESCRIPTION
## Issue
Resolves #432

## What was done
- [x] Change the text of warning for traits when a trait already exists
- [x] Submit button for a trait is disabled when a trait already exists and warning appear while user are typing 
## How to test
1. Verify verbage of warning.
2. Try to create a new role with the same name as an existing role and see the warning show up and the button gets disabled

Feature URL: https://featurebranchui.apps.pd01i.edc1.cf.ford.com/
Feature Branch Deployment: https://jenkins-fordlabs.apps.pd01e.edc1.cf.ford.com/job/PeopleMover/job/Deploy%20PeopleMover%20FeatureBranch/
