### PR TITLE
Hitting enter on space form submits the form

### DIFF
--- a/ui/src/SpaceDashboard/SpaceForm.tsx
+++ b/ui/src/SpaceDashboard/SpaceForm.tsx
@@ -83,6 +83,7 @@ function SpaceForm({
             <div className="createSpaceButtonContainer">
                 <FormButton
                     buttonStyle="secondary"
+                    type="button"
                     onClick={closeModal}>
                     Cancel
                 </FormButton>


### PR DESCRIPTION
Co-authored-by: Vianney Willot <vianney.willot@gmail.com>
Co-authored-by: Michael Rygiel <michael.rygiel1@gmail.com>

## Issue
Resolves #482 

## What was done
- [x] Added a type to the close button so hitting enter key does not close form
## How to test
1. Create/edit a space, and hit enter. It should create/update the space.

Feature URL: https://featurebranchui.apps.pd01i.edc1.cf.ford.com/
Feature Branch Deployment: https://jenkins-fordlabs.apps.pd01e.edc1.cf.ford.com/job/PeopleMover/job/Deploy%20PeopleMover%20FeatureBranch/
