### PR TITLE
Pressing enter should not close forms

### DIFF
--- a/ui/src/ModalFormComponents/FormButton.tsx
+++ b/ui/src/ModalFormComponents/FormButton.tsx
@@ -19,7 +19,7 @@ import React, {ReactNode} from 'react';
 import './FormButton.scss';
 
 type ButtonStyle = 'primary' | 'secondary';
-type ButtonType = 'submit' | 'reset' | 'button' | undefined;
+type ButtonType = 'submit' | 'reset' | 'button';
 
 interface Props {
     children: ReactNode;
@@ -34,7 +34,7 @@ interface Props {
 const FormButton = ({
     children,
     onClick,
-    type,
+    type = 'button',
     buttonStyle = 'primary',
     className,
     testId,

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -103,6 +103,12 @@ function ProductForm({
             console.error('No current space uuid');
             return;
         }
+
+        if (currentProduct.name.trim() === '') {
+            console.error('No product name set');
+            return;
+        }
+
         if (editing) {
             ProductClient.editProduct(currentSpace, currentProduct)
                 .then(closeModal)


### PR DESCRIPTION
## Issue
Resolves #498

## What was done
- [x] Fix product, person and assign to forms closing when pressing enter

## How to test
1. Press enter on while name field has focus in product form
2. Press enter on while name field has focus in person form
3. Press enter on while name field has focus in assign to form
4. Verify none of these forms close after pressing enter

Feature URL: https://featurebranchui.apps.pd01i.edc1.cf.ford.com/
Feature Branch Deployment: https://jenkins-fordlabs.apps.pd01e.edc1.cf.ford.com/job/PeopleMover/job/Deploy%20PeopleMover%20FeatureBranch/
