### PR TITLE
Add logic to change only color of role

### DIFF
--- a/ui/src/Traits/EditTraitSection.tsx
+++ b/ui/src/Traits/EditTraitSection.tsx
@@ -75,6 +75,7 @@ function EditTraitSection({
     const [duplicateErrorMessage, setDuplicateErrorMessage] = useState<boolean>(false);
     const traitNameClass = traitName.replace(' ', '_');
     const originalTraitName = trait?.name;
+    const originalTraitColor = (trait as SpaceRole)?.color;
 
     useEffect(() => {
         let mounted = false;
@@ -148,7 +149,7 @@ function EditTraitSection({
         const input: string = event.target ? event.target.value : '';
 
         const doesInputTraitAlreadyExist = listOfTraits?.find(trait => {
-            return trait.name.toLowerCase().trim() === input.toLowerCase().trim();
+            return trait.name.toLowerCase().trim() === input.toLowerCase().trim() && input.toLowerCase().trim() !== originalTraitName?.toLowerCase().trim();
         });
         if (doesInputTraitAlreadyExist) {
             setDuplicateErrorMessage(true);
@@ -190,7 +191,7 @@ function EditTraitSection({
     };
 
 
-    let isTraitNameInvalid = enteredTrait.name === '' || duplicateErrorMessage || enteredTrait.name.toLowerCase() === originalTraitName?.toLowerCase();
+    let isTraitNameInvalid = enteredTrait.name === '' || duplicateErrorMessage || (enteredTrait.name.toLowerCase() === originalTraitName?.toLowerCase() && originalTraitColor?.color === selectedColor?.color);
 
     return (
         <>


### PR DESCRIPTION
Co-authored-by: Alex Wojtala <alexwojtala@gmail.com>
Co-authored-by: chris dorman <cdorman1@ford.com>

## Issue
Resolves #499 

## What was done
- [x] Allow changing only the color in the role form

## How to test
1. Open the role form
2. Change only the color of one of the roles
3. Submit the change and make sure the role correctly updates

Feature URL: https://featurebranchui.apps.pd01i.edc1.cf.ford.com/
Feature Branch Deployment: https://jenkins-fordlabs.apps.pd01e.edc1.cf.ford.com/job/PeopleMover/job/Deploy%20PeopleMover%20FeatureBranch/
