### PR TITLE
Trim spaces off emails before sending them to backend

### DIFF
--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthController.kt
@@ -59,7 +59,7 @@ class AuthController(
 
         val failures = arrayListOf<String>();
         request.emails.forEach {email ->
-            val userId = email.substringBefore('@').toUpperCase()
+            val userId = email.trim().substringBefore('@').toUpperCase()
             try {
                 userSpaceMappingRepository.save(UserSpaceMapping(userId = userId, spaceId = space.id))
             } catch (e: DataIntegrityViolationException) {

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthController.kt
@@ -59,7 +59,7 @@ class AuthController(
 
         val failures = arrayListOf<String>();
         request.emails.forEach {email ->
-            val userId = email.trim().substringBefore('@').toUpperCase()
+            val userId = email.substringBefore('@').toUpperCase().trim()
             try {
                 userSpaceMappingRepository.save(UserSpaceMapping(userId = userId, spaceId = space.id))
             } catch (e: DataIntegrityViolationException) {

--- a/ui/src/AccountDropdown/EditContributorsForm.tsx
+++ b/ui/src/AccountDropdown/EditContributorsForm.tsx
@@ -49,7 +49,7 @@ function EditContributorsForm({currentSpace, closeModal, setCurrentModal}: Props
     };
 
     const parseEmails = (event: ChangeEvent<HTMLTextAreaElement>): void => {
-        const emails: string[] = event.target.value.split(',');
+        const emails: string[] = event.target.value.split(',').map((email: string) => email.trim());
         if (validateEmail(emails[0])) {
             setEnableInviteButton(true);
         } else {


### PR DESCRIPTION
## Issue
Resolves #508 

## What was done
- [x] Trim white space off emails before sending to backend

## How to test
1. Invite people using spaces after the comma and after the email address
2. Ensure the people are still correct given access to the space

Feature URL: https://featurebranchui.apps.pd01i.edc1.cf.ford.com/
Feature Branch Deployment: https://jenkins-fordlabs.apps.pd01e.edc1.cf.ford.com/job/PeopleMover/job/Deploy%20PeopleMover%20FeatureBranch/
