### PR TITLE
Empty product name warning message

### DIFF
--- a/ui/cypress/e2e/product.test.js
+++ b/ui/cypress/e2e/product.test.js
@@ -103,35 +103,37 @@ describe('Product', () => {
 
     });
 
-    it('Display duplicate product name warning if product name is a duplicate', () => {
-        cy.route('POST', Cypress.env('API_LOCATION_PATH')).as('postNewLocation');
-        cy.route('POST', Cypress.env('API_PRODUCT_TAG_PATH')).as('postNewTag');
-        cy.route('PUT', Cypress.env('API_PRODUCTS_PATH') + '/**').as('updateProduct');
+    context('Product Name input warnings', () => {
+        it('Display duplicate product name warning if product name is a duplicate', () => {
+            cy.route('POST', Cypress.env('API_LOCATION_PATH')).as('postNewLocation');
+            cy.route('POST', Cypress.env('API_PRODUCT_TAG_PATH')).as('postNewTag');
+            cy.route('PUT', Cypress.env('API_PRODUCTS_PATH') + '/**').as('updateProduct');
 
-        cy.get('[data-testid=editProductIcon__baguette_bakery]').click();
-        cy.get('[data-testid=editMenuOption__edit_product]').click();
+            cy.get('[data-testid=editProductIcon__baguette_bakery]').click();
+            cy.get('[data-testid=editMenuOption__edit_product]').click();
 
-        const productName = 'Baguette Bakery';
-        cy.get('[data-testid=productFormNameField]').clear().focus().type(productName).should('have.value', productName);
+            const productName = 'My Product';
+            cy.get('[data-testid=productFormNameField]').clear().focus().type(productName).should('have.value', productName);
 
-        cy.get('[data-testid=productFormSubmitButton]').should('have.text', 'Save').click();
+            cy.get('[data-testid=productFormSubmitButton]').should('have.text', 'Save').click();
 
-        cy.get('[data-testid=duplicateProductNameWarning]');
-    });
+            cy.get('[data-testid=duplicateProductNameWarning]');
+        });
 
-    it('Display empty product name warning if product name is empty', () => {
-        cy.route('POST', Cypress.env('API_LOCATION_PATH')).as('postNewLocation');
-        cy.route('POST', Cypress.env('API_PRODUCT_TAG_PATH')).as('postNewTag');
-        cy.route('PUT', Cypress.env('API_PRODUCTS_PATH') + '/**').as('updateProduct');
+        it('Display empty product name warning if product name is empty', () => {
+            cy.route('POST', Cypress.env('API_LOCATION_PATH')).as('postNewLocation');
+            cy.route('POST', Cypress.env('API_PRODUCT_TAG_PATH')).as('postNewTag');
+            cy.route('PUT', Cypress.env('API_PRODUCTS_PATH') + '/**').as('updateProduct');
 
-        cy.get('[data-testid=editProductIcon__baguette_bakery]').click();
-        cy.get('[data-testid=editMenuOption__edit_product]').click();
+            cy.get('[data-testid=editProductIcon__baguette_bakery]').click();
+            cy.get('[data-testid=editMenuOption__edit_product]').click();
 
-        cy.get('[data-testid=productFormNameField]').clear().focus().type('').should('have.value', '');
+            cy.get('[data-testid=productFormNameField]').clear();
 
-        cy.get('[data-testid=productFormSubmitButton]').should('have.text', 'Save').click();
+            cy.get('[data-testid=productFormSubmitButton]').should('have.text', 'Save').click();
 
-        cy.get('[data-testid=emptyProductNameWarning]');
+            cy.get('[data-testid=emptyProductNameWarning]');
+        });
     });
 });
 

--- a/ui/cypress/e2e/product.test.js
+++ b/ui/cypress/e2e/product.test.js
@@ -102,6 +102,37 @@ describe('Product', () => {
         cy.get('[data-testid=editProductIcon__baguette_bakery]').should('not.exist');
 
     });
+
+    it('Display duplicate product name warning if product name is a duplicate', () => {
+        cy.route('POST', Cypress.env('API_LOCATION_PATH')).as('postNewLocation');
+        cy.route('POST', Cypress.env('API_PRODUCT_TAG_PATH')).as('postNewTag');
+        cy.route('PUT', Cypress.env('API_PRODUCTS_PATH') + '/**').as('updateProduct');
+
+        cy.get('[data-testid=editProductIcon__baguette_bakery]').click();
+        cy.get('[data-testid=editMenuOption__edit_product]').click();
+
+        const productName = 'Baguette Bakery';
+        cy.get('[data-testid=productFormNameField]').clear().focus().type(productName).should('have.value', productName);
+
+        cy.get('[data-testid=productFormSubmitButton]').should('have.text', 'Save').click();
+
+        cy.get('[data-testid=duplicateProductNameWarning]');
+    });
+
+    it('Display empty product name warning if product name is empty', () => {
+        cy.route('POST', Cypress.env('API_LOCATION_PATH')).as('postNewLocation');
+        cy.route('POST', Cypress.env('API_PRODUCT_TAG_PATH')).as('postNewTag');
+        cy.route('PUT', Cypress.env('API_PRODUCTS_PATH') + '/**').as('updateProduct');
+
+        cy.get('[data-testid=editProductIcon__baguette_bakery]').click();
+        cy.get('[data-testid=editMenuOption__edit_product]').click();
+
+        cy.get('[data-testid=productFormNameField]').clear().focus().type('').should('have.value', '');
+
+        cy.get('[data-testid=productFormSubmitButton]').should('have.text', 'Save').click();
+
+        cy.get('[data-testid=emptyProductNameWarning]');
+    });
 });
 
 const populateProductForm = ({name, location, tags = [], startDate, nextPhaseDate, notes}, defaultStartDate) => {

--- a/ui/cypress/e2e/product.test.js
+++ b/ui/cypress/e2e/product.test.js
@@ -103,36 +103,36 @@ describe('Product', () => {
 
     });
 
-    context('Product Name input warnings', () => {
-        it('Display duplicate product name warning if product name is a duplicate', () => {
-            cy.route('POST', Cypress.env('API_LOCATION_PATH')).as('postNewLocation');
-            cy.route('POST', Cypress.env('API_PRODUCT_TAG_PATH')).as('postNewTag');
-            cy.route('PUT', Cypress.env('API_PRODUCTS_PATH') + '/**').as('updateProduct');
-
-            cy.get('[data-testid=editProductIcon__baguette_bakery]').click();
-            cy.get('[data-testid=editMenuOption__edit_product]').click();
-
-            const productName = 'My Product';
-            cy.get('[data-testid=productFormNameField]').clear().focus().type(productName).should('have.value', productName);
-
-            cy.get('[data-testid=productFormSubmitButton]').should('have.text', 'Save').click();
-
-            cy.get('[data-testid=duplicateProductNameWarning]');
-        });
-
-        it('Display empty product name warning if product name is empty', () => {
-            cy.route('POST', Cypress.env('API_LOCATION_PATH')).as('postNewLocation');
-            cy.route('POST', Cypress.env('API_PRODUCT_TAG_PATH')).as('postNewTag');
-            cy.route('PUT', Cypress.env('API_PRODUCTS_PATH') + '/**').as('updateProduct');
-
+    context('Product name field warnings', () => {
+        beforeEach(() => {
             cy.get('[data-testid=editProductIcon__baguette_bakery]').click();
             cy.get('[data-testid=editMenuOption__edit_product]').click();
 
             cy.get('[data-testid=productFormNameField]').clear();
+        });
 
-            cy.get('[data-testid=productFormSubmitButton]').should('have.text', 'Save').click();
+        it('Display duplicate product name warning if product name is a duplicate', () => {
+            const productName = 'My Product';
+            cy.get('[data-testid=productFormNameField]')
+                .focus()
+                .type(productName)
+                .should('have.value', productName);
 
-            cy.get('[data-testid=emptyProductNameWarning]');
+            cy.get('[data-testid=productFormSubmitButton]')
+                .should('have.text', 'Save').click();
+
+            const expectedDuplicateProductNameWarningMessage = 'A product with this name already exists. Please enter a different name.';
+            cy.get('[data-testid=productNameWarningMessage]')
+                .should('have.text', expectedDuplicateProductNameWarningMessage);
+        });
+
+        it('Display empty product name warning if product name is empty', () => {
+            cy.get('[data-testid=productFormSubmitButton]')
+                .should('have.text', 'Save').click();
+
+            const expectedEmptyProductNameWarningMessage = 'Please enter a product name.';
+            cy.get('[data-testid=productNameWarningMessage]')
+                .should('have.text', expectedEmptyProductNameWarningMessage);
         });
     });
 });

--- a/ui/cypress/fixtures/person.ts
+++ b/ui/cypress/fixtures/person.ts
@@ -11,7 +11,7 @@ const person: Person = {
     isNew: true,
     role: 'Product Owner',
     assignTo: 'My Product',
-    notes: 'Here is a thought you might want to remember.',
+    notes: 'Person Note.',
 };
 
 export default person;

--- a/ui/cypress/fixtures/product.ts
+++ b/ui/cypress/fixtures/product.ts
@@ -16,7 +16,7 @@ const product: Product = {
     tags: ['Tag 1', 'Tag 2'],
     startDate: Cypress.moment(),
     nextPhaseDate: Cypress.moment().add(1, 'days'),
-    notes: 'These are some VERY interesting product notes. You\'re welcome.',
+    notes: 'Product note.',
 };
 
 export default product;

--- a/ui/src/Products/ProductForm.scss
+++ b/ui/src/Products/ProductForm.scss
@@ -17,6 +17,13 @@
 
 @import '../Application/Styleguide/Colors.scss';
 
+.productNameWarning {
+  color: $error-message;
+  font-size: 12px;
+  padding-top: 6px;
+  font-style: italic;
+}
+
 .notes {
   box-sizing: border-box;
   padding: 8px;

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -107,6 +107,7 @@ function ProductForm({
     const [confirmDeleteModal, setConfirmDeleteModal] = useState<JSX.Element | null>(null);
 
     const [duplicateProductNameWarning, setDuplicateProductNameWarning] = useState<boolean>(false);
+    const [emptyProductNameWarning, setEmptyProductNameWarning] = useState<boolean>(false);
 
     function initializeProduct(): Product {
         if (product == null) {
@@ -118,6 +119,9 @@ function ProductForm({
     function handleSubmit(event: FormEvent): void {
         event.preventDefault();
 
+        setEmptyProductNameWarning(false);
+        setDuplicateProductNameWarning(false);
+
         currentProduct.productTags = selectedProductTags;
         if (!currentSpace.uuid) {
             console.error('No current space uuid');
@@ -125,6 +129,7 @@ function ProductForm({
         }
 
         if (currentProduct.name.trim() === '') {
+            setEmptyProductNameWarning(true);
             console.error('No product name set');
             return;
         }
@@ -239,7 +244,15 @@ function ProductForm({
                         onChange={(e: ChangeEvent<HTMLInputElement>): void => updateProductField('name', e.target.value)}
                         placeholder="e.g. Product 1"/>
                     {duplicateProductNameWarning &&
-                    <span className="personNameWarning">A product with this name already exists. Please enter a different name.</span>}
+                        <span data-testid="duplicateProductNameWarning" className="personNameWarning">
+                            A product with this name already exists. Please enter a different name.
+                        </span>
+                    }
+                    {emptyProductNameWarning &&
+                        <span data-testid="emptyProductNameWarning" className="personNameWarning">
+                            Please enter a product name.
+                        </span>
+                    }
                 </div>
                 <ProductFormLocationField
                     spaceId={currentSpace.id}

--- a/ui/src/ReusableComponents/EditMenu.tsx
+++ b/ui/src/ReusableComponents/EditMenu.tsx
@@ -63,13 +63,12 @@ function EditMenu(props: EditMenuProps): JSX.Element {
 
     return (
         <div ref={editMenuRef} className="editMenuContainer" data-testid="editMenu">
-            <input className={'hiddenInputField'} type={'text'} ref={hiddenInputRef} onBlur={close}/>
+            <input className="hiddenInputField" type="text" ref={hiddenInputRef} onBlur={close}/>
             {props.menuOptionList.map((menuOption, index) =>
                 <div key={index}
                     className="editMenuContainerOption"
                     onMouseDown={(event): void => onOptionSelected(event, menuOption.callback)}>
-                    <i className={`fas ${menuOption.icon}`}
-                        data-testid={createDataTestId('editMenuOption', menuOption.text)}/>
+                    <i className={`fas ${menuOption.icon}`} data-testid={createDataTestId('editMenuOption', menuOption.text)} />
                     <span>{menuOption.text}</span>
                 </div>
             )}


### PR DESCRIPTION
## Issue
Resolves #494

## What was done
- [x] Updated the product form to show an error message if the user tries to save a product without a product name.

## How to test
1. Try to save a product without a product name and ensure a warning shows up with the text, `Please enter a product name.`.
2. Try to save a product with the same product name as another product and ensure a warning still shows up with the text, `A product with this name already exists. Please enter a different name.`.

Feature URL: https://featurebranchui.apps.pd01i.edc1.cf.ford.com/
Feature Branch Deployment: https://jenkins-fordlabs.apps.pd01e.edc1.cf.ford.com/job/PeopleMover/job/Deploy%20PeopleMover%20FeatureBranch/
