### PR TITLE
Standerdized focus state for inputs, buttons, textareas and selects

### DIFF
--- a/ui/src/Application/PeopleMover.scss
+++ b/ui/src/Application/PeopleMover.scss
@@ -99,3 +99,16 @@
     display: flex;
     flex-direction: column;
 }
+
+// Remove default outline when user is tabbing
+button:focus,
+input:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+}
+
+// Use box shadow to make focus ring for all buttons, inputs, selects and textareas except in React Select Library
+:not([class*="-Input"]) > div > *:focus {
+    box-shadow: 0 0 0 2px #4C8EF5;
+}

--- a/ui/src/Application/PeopleMover.scss
+++ b/ui/src/Application/PeopleMover.scss
@@ -109,6 +109,6 @@ textarea:focus {
 }
 
 // Use box shadow to make focus ring for all buttons, inputs, selects and textareas except in React Select Library
-:not([class*="-Input"]) > div > *:focus {
+:not([class*="css-"]) > div > *:focus {
     box-shadow: 0 0 0 2px #4C8EF5;
 }

--- a/ui/src/Application/PeopleMover.scss
+++ b/ui/src/Application/PeopleMover.scss
@@ -110,5 +110,5 @@ textarea:focus {
 
 // Use box shadow to make focus ring for all buttons, inputs, selects and textareas except in React Select Library
 :not([class*="css-"]) > div > *:focus {
-    box-shadow: 0 0 0 2px #4C8EF5;
+    box-shadow: 0 0 0 2px $outline-focus-blue;
 }

--- a/ui/src/Application/Styleguide/Buttons.scss
+++ b/ui/src/Application/Styleguide/Buttons.scss
@@ -17,7 +17,6 @@
 
 button {
   border: none;
-  outline: none;
   cursor: pointer;
   font-size: 16px;
   letter-spacing: 0.5px;

--- a/ui/src/Application/Styleguide/Colors.scss
+++ b/ui/src/Application/Styleguide/Colors.scss
@@ -28,6 +28,8 @@ $prime-1: #5463B0;
 
 $orange-hover: #EB7B57;
 
+$outline-focus-blue: #4C8EF5;
+
 $role-1: #9ADAD3;
 $role-2: #A8CBFA;
 $role-3: #A7EEFE;

--- a/ui/src/ModalFormComponents/Select.scss
+++ b/ui/src/ModalFormComponents/Select.scss
@@ -58,7 +58,6 @@
   margin: 0;
 
   &:focus {
-    outline: none;
     border: $focus-state-border !important;
     border-radius: 4px;
   }

--- a/ui/src/ReusableComponents/ReactSelectStyles.tsx
+++ b/ui/src/ReusableComponents/ReactSelectStyles.tsx
@@ -32,8 +32,8 @@ export const reactSelectStyles = {
         borderRadius: '2px',
         padding: '0',
         // These lines disable the blue border
-        boxShadow: 'none',
-        border: isFocused ? '2px solid #5463B0' : '1px solid hsl(0, 0%, 80%)',
+        boxShadow: isFocused ? '0 0 0 2px #4C8EF5' : 'none',
+        border: '1px solid hsl(0, 0%, 80%)',
         backgroundColor: 'transparent',
         // @ts-ignore
         '&:hover': {

--- a/ui/src/Traits/MyTraits.scss
+++ b/ui/src/Traits/MyTraits.scss
@@ -112,12 +112,6 @@
       font-size: 14px;
       line-height: 24px;
 
-      &:focus {
-        outline: none;
-        border: $focus-state-border;
-        border-radius: 4px;
-      }
-
       .role {
         width: 170px;
       }


### PR DESCRIPTION
Co-authored-by: Alex Wojtala <alexwojtala@gmail.com>
Co-authored-by: chris dorman <cdorman1@ford.com>

## Issue
Resolves #479 

## What was done
- [x] Added focus state to cancel and save buttons in modals
- [x] Standardize focus state for buttons, inputs, textareas and selects

## How to test
1. Open person (or any modal) tab through and ensure focus state is working on element including save and cancel buttons

Feature URL: https://featurebranchui.apps.pd01i.edc1.cf.ford.com/
Feature Branch Deployment: https://jenkins-fordlabs.apps.pd01e.edc1.cf.ford.com/job/PeopleMover/job/Deploy%20PeopleMover%20FeatureBranch/
