### PR TITLE
Wrap space tiles on smaller screens

### DIFF
--- a/ui/src/Application/Styleguide/Breakpoints.scss
+++ b/ui/src/Application/Styleguide/Breakpoints.scss
@@ -1,0 +1,17 @@
+@mixin tablet {
+  @media (min-width: 768px) {
+    @content;
+  }
+}
+
+@mixin desktop {
+  @media (min-width: 992px) {
+    @content;
+  }
+}
+
+@mixin xl-desktop {
+  @media (min-width: 1700px) {
+    @content;
+  }
+}

--- a/ui/src/Application/Styleguide/Main.scss
+++ b/ui/src/Application/Styleguide/Main.scss
@@ -18,6 +18,7 @@
 @import './Colors';
 @import './Buttons';
 @import './Material-Icons';
+@import './Breakpoints';
 
 $focus-state-border: 2px solid $prime-1;
 

--- a/ui/src/SpaceDashboard/SpaceDashboard.scss
+++ b/ui/src/SpaceDashboard/SpaceDashboard.scss
@@ -15,14 +15,17 @@
  * limitations under the License.
  */
 
-@import "../Application/Styleguide/Colors.scss";
+@import '../Application/Styleguide/Colors.scss';
+
+$spaceTileWidth: 400px;
 
 .userSpaceItemContainer {
-  margin-top: 50px;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
   grid-auto-rows: 128px;
+  grid-template-columns: repeat(auto-fill, minmax($spaceTileWidth, 1fr));
+  justify-content: center;
   grid-gap: 32px;
+  margin-top: 50px;
   padding: 88px;
 }
 

--- a/ui/src/SpaceDashboard/SpaceDashboardTile.scss
+++ b/ui/src/SpaceDashboard/SpaceDashboardTile.scss
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 @import "../Application/Styleguide/Colors.scss";
+@import '../Application/Styleguide/Breakpoints.scss';
 
 .spaceTile {
   background: $logo-gradient;
@@ -25,6 +26,11 @@
   flex-direction: row;
   width: 400px;
   cursor: pointer;
+  margin: 0 auto;
+
+  @include desktop  {
+    margin: 0;
+  }
 }
 
 .spaceMetadata {


### PR DESCRIPTION
## Issue
Resolves #536

## What was done
- [x] Fixed the space tiles so that when resizing the screen, the tiles wrap appropriately.

## How to test
1. Go to the dashboard and shrink and grow the browser width and ensure that it is a good user experience no matter what the browser size.

### FOR DEVS
Feature URL: See feature branch

### FOR APPROVAL
Approval URL: See Approval branch
