### PR TITLE
Fix overflow issue with long product tags

### DIFF
--- a/ui/src/Products/Product.scss
+++ b/ui/src/Products/Product.scss
@@ -78,7 +78,7 @@
 
 .productTagContainer {
   margin-bottom: 6px;
-  margin-top: 4px;
+  margin-top: 0;
   font-size: 10px;
   line-height: 11px;
   color: $gray-1;

--- a/ui/src/Products/Product.scss
+++ b/ui/src/Products/Product.scss
@@ -58,15 +58,14 @@
 }
 
 .productNameEditContainer {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
   padding: 6px 5px 6px 9px;
   position: relative;
 }
 
 .productDetails {
-  align-self: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
   .productName {
     margin: 0;
@@ -75,14 +74,15 @@
     color: $gray-1;
     word-break: break-word;
   }
+}
 
-  .productTagContainer {
-    margin-bottom: 6px;
-    margin-top: 4px;
-    font-size: 10px;
-    line-height: 11px;
-    color: $gray-1;
-  }
+.productTagContainer {
+  margin-bottom: 6px;
+  margin-top: 4px;
+  font-size: 10px;
+  line-height: 11px;
+  color: $gray-1;
+  overflow-wrap: break-word;
 }
 
 .productControlsContainer {

--- a/ui/src/Products/ProductCard.tsx
+++ b/ui/src/Products/ProductCard.tsx
@@ -165,24 +165,24 @@ function ProductCard({
                                 <h2 className="productName" data-testid="productName">
                                     {product.name}
                                 </h2>
-                                <TagList />
-                            </div>
-                            <div className="productControlsContainer">
-                                <div className="addPersonIconContainer">
-                                    <div data-testid={createDataTestId('addPersonToProductIcon', product.name)}
-                                        className="addPersonIcon material-icons greyIcon clickableIcon"
-                                        onClick={setCurrentModalToCreateAssignment}
-                                        onKeyDown={(e): void => handleKeyDownForSetCurrentModalToCreateAssignment(e)}>
-                                        person_add
+                                <div className="productControlsContainer">
+                                    <div className="addPersonIconContainer">
+                                        <div data-testid={createDataTestId('addPersonToProductIcon', product.name)}
+                                            className="addPersonIcon material-icons greyIcon clickableIcon"
+                                            onClick={setCurrentModalToCreateAssignment}
+                                            onKeyDown={(e): void => handleKeyDownForSetCurrentModalToCreateAssignment(e)}>
+                                            person_add
+                                        </div>
+                                    </div>
+                                    <div className="editIcon material-icons greyIcon clickableIcon"
+                                        data-testid={createDataTestId('editProductIcon', product.name)}
+                                        onClick={toggleEditMenu}
+                                        onKeyDown={(e): void => handleKeyDownForToggleEditMenu(e)}>
+                                        more_vert
                                     </div>
                                 </div>
-                                <div className="editIcon material-icons greyIcon clickableIcon"
-                                    data-testid={createDataTestId('editProductIcon', product.name)}
-                                    onClick={toggleEditMenu}
-                                    onKeyDown={(e): void => handleKeyDownForToggleEditMenu(e)}>
-                                    more_vert
-                                </div>
                             </div>
+                            <TagList />
                             {
                                 isEditMenuOpen &&
                                 <EditMenu menuOptionList={getMenuOptionList()}

--- a/ui/src/ReusableComponents/ReactSelectStyles.tsx
+++ b/ui/src/ReusableComponents/ReactSelectStyles.tsx
@@ -52,12 +52,14 @@ export const reactSelectStyles = {
         color: props.data.__isNew__ ? '#5463B0' : '#403D3D',
         fontFamily: 'Helvetica, sans-serif',
         fontSize: '12px',
+        lineHeight: '13.8px',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        padding: '0px 17px 0 0px',
-        height: '30px',
+        padding: '6px 17px 6px 0px',
+        minHeight: '30px',
         margin: '3px 0px',
+        overflowWrap: 'break-word',
         // @ts-ignore
         '&:hover': {
             cursor: 'pointer',

--- a/ui/src/ReusableComponents/ReactSelectStyles.tsx
+++ b/ui/src/ReusableComponents/ReactSelectStyles.tsx
@@ -77,7 +77,9 @@ export const reactSelectStyles = {
         alignItems: 'center',
         fontFamily: 'Helvetica, sans-serif',
         fontSize: '12px',
-        maxWidth: 'unset',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+        maxWidth: '140px',
     }),
     clearIndicator: (provided: CSSProperties): CSSProperties => ({
         ...provided,


### PR DESCRIPTION
## Issue
Resolves #526

## What was done
- [x] Updated the product card so that long tag text wraps
- [x] Updated the product tag and location tag dropdowns so that long tag text wraps and is fully readable
- [x] Updated the location input so that if the selected location tag is longer than is showable, that an ellipsis shows.

## How to test
1. Add a super long product tag and super long location tag. 
2. Ensure that you can add it to a product and the text wraps in both the dropdown and once it is saved to a product.
3. Ensure that a long location tag shows an ellipsis once selected.

### FOR DEVS
Feature URL: See feature branch

### FOR APPROVAL
Approval URL: See Approval branch
