### PR TITLE
Remove focus states from buttons, anchors when user is using mouse

### DIFF
--- a/ui/cypress/e2e/focus_ring.test.js
+++ b/ui/cypress/e2e/focus_ring.test.js
@@ -1,0 +1,13 @@
+import person from '../fixtures/person';
+const date = Cypress.moment().format('yyyy-MM-DD');
+
+describe('People', () => {
+    beforeEach(() => {
+        cy.visitBoard();
+    });
+
+    it('Keyboard usage adds focus ring to buttons and anchors', () => {
+        cy.get('body').trigger('keydown', {key: 'Tab'});
+        cy.get('body.user-is-tabbing');
+    });
+});

--- a/ui/src/Application/PeopleMover.scss
+++ b/ui/src/Application/PeopleMover.scss
@@ -105,6 +105,7 @@
 button:focus,
 input:focus,
 select:focus,
+a:focus,
 textarea:focus {
     outline: none;
 }
@@ -112,4 +113,11 @@ textarea:focus {
 // Use box shadow to make focus ring for all buttons, inputs, selects and textareas except in React Select Library
 :not([class*="css-"]) > div > *:focus {
     box-shadow: 0 0 0 2px $outline-focus-blue;
+}
+
+body:not(.user-is-tabbing)  {
+    button:focus,
+    a:focus {
+        box-shadow: none;
+    }
 }

--- a/ui/src/Application/PeopleMover.scss
+++ b/ui/src/Application/PeopleMover.scss
@@ -115,9 +115,10 @@ textarea:focus {
   box-shadow: 0 0 0 2px $outline-focus-blue;
 }
 
-body:not(.user-is-tabbing)  {
-    button:focus,
-    a:focus {
-        box-shadow: none;
-    }
+body:not(.user-is-tabbing) {
+  button:focus,
+  a:focus,
+  div:focus {
+    box-shadow: none;
+  }
 }

--- a/ui/src/Application/PeopleMover.scss
+++ b/ui/src/Application/PeopleMover.scss
@@ -18,87 +18,87 @@
 @import '../Application/Styleguide/Colors.scss';
 
 .spaceButtons button {
-    margin: 0 12px;
+  margin: 0 12px;
 }
 
 .logo-image {
-    height: 25px;
-    width: 25px;
+  height: 25px;
+  width: 25px;
 }
 
 .productAndAccordionContainer {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
 }
 
 .accordionContainer {
-    flex-grow: 0;
-    min-width: 204px;
-    max-height: 82vh;
-    margin-top: 2px;
+  flex-grow: 0;
+  min-width: 204px;
+  max-height: 82vh;
+  margin-top: 2px;
 
-    font-size: 14px;
-    color: $gray-1;
+  font-size: 14px;
+  color: $gray-1;
 }
 
 .unassignedContainer {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 .drawerContainerTitleAndIcon {
-    display: flex;
-    align-items: center;
-    padding-left: 20px;
+  display: flex;
+  align-items: center;
+  padding-left: 20px;
 }
 
 .drawerCaret {
-    margin-right: 14px;
+  margin-right: 14px;
 }
 
 .archivedHeader {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    height: 46px;
-    flex-grow: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 46px;
+  flex-grow: 1;
 }
 
 .accordionHeaderContainer {
-    box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.3);
-    border: 2px solid $gray-5;
-    border-bottom: 0;
-    border-radius: 2px;
-    font-weight: bold;
-    box-sizing: border-box;
+  box-shadow: 1px 2px 3px rgba(0, 0, 0, 0.3);
+  border: 2px solid $gray-5;
+  border-bottom: 0;
+  border-radius: 2px;
+  font-weight: bold;
+  box-sizing: border-box;
 }
 
 .accordionText {
-    padding-left: 5px;
+  padding-left: 5px;
 }
 
 .addtionalFilterMultiValue {
-    background-color: $gray-5;
-    border-radius: 6px;
-    display: flex;
-    margin: 3px;
-    padding: 6px 4px;
-    min-width: 0;
-    box-sizing: border-box;
-    align-items: center;
-    height: 22px;
-    font-style: italic;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    max-width: 10vw;
-    white-space: nowrap;
+  background-color: $gray-5;
+  border-radius: 6px;
+  display: flex;
+  margin: 3px;
+  padding: 6px 4px;
+  min-width: 0;
+  box-sizing: border-box;
+  align-items: center;
+  height: 22px;
+  font-style: italic;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 10vw;
+  white-space: nowrap;
 }
 
 .App {
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 // Remove default outline when user is tabbing
@@ -107,12 +107,12 @@ input:focus,
 select:focus,
 a:focus,
 textarea:focus {
-    outline: none;
+  outline: none;
 }
 
 // Use box shadow to make focus ring for all buttons, inputs, selects and textareas except in React Select Library
 :not([class*="css-"]) > div > *:focus {
-    box-shadow: 0 0 0 2px $outline-focus-blue;
+  box-shadow: 0 0 0 2px $outline-focus-blue;
 }
 
 body:not(.user-is-tabbing)  {

--- a/ui/src/FocusRing.tsx
+++ b/ui/src/FocusRing.tsx
@@ -1,0 +1,18 @@
+const turnOnWhenTabbing = (e: { key: string }): void => {
+    if (e.key === 'Tab') {
+        document.body.classList.add('user-is-tabbing');
+        window.removeEventListener('keydown', turnOnWhenTabbing);
+        window.addEventListener('click', turnOffWhenClicking);
+    }
+};
+
+const turnOffWhenClicking = (): void => {
+    document.body.classList.remove('user-is-tabbing');
+    window.removeEventListener('click', turnOffWhenClicking);
+    window.addEventListener('keydown', turnOnWhenTabbing);
+};
+
+export default {
+    turnOnWhenTabbing,
+    turnOffWhenClicking,
+};

--- a/ui/src/Modal/Modal.tsx
+++ b/ui/src/Modal/Modal.tsx
@@ -18,6 +18,7 @@
 import React, {useEffect, useState} from 'react';
 import {JSX} from '@babel/types';
 import ConfirmationModal, {ConfirmationModalProps} from './ConfirmationModal';
+import FocusRing from '../FocusRing';
 
 interface ModalProps {
     modalForm: JSX.Element | null;
@@ -81,8 +82,14 @@ function Modal({
                 <div className="modalDialogContainer">
                     <div className="modalPopupContainer"
                         data-testid="modalPopupContainer"
-                        onClick={(e): void => { e.stopPropagation(); }}
-                        onKeyDown={(e): void => { e.stopPropagation(); }}>
+                        onClick={(e): void => {
+                            e.stopPropagation();
+                            FocusRing.turnOffWhenClicking();
+                        }}
+                        onKeyDown={(e): void => {
+                            e.stopPropagation();
+                            FocusRing.turnOnWhenTabbing(e);
+                        }}>
                         <input type="text" aria-hidden={true} className="hiddenInputField"/>
                         <div className="modalTitleAndCloseButtonContainer">
                             <div className="modalTitleSpacer"/>

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -65,7 +65,9 @@ const store = createStore(
 );
 
 declare global {
-    interface Window { runConfig: RunConfig }
+    interface Window {
+        runConfig: RunConfig;
+    }
 }
 
 export interface RunConfig {
@@ -75,6 +77,22 @@ export interface RunConfig {
     adfs_client_id: string;
     adfs_resource: string;
 }
+
+function turnOnFocusRingWhenTabbing(e: KeyboardEvent): void {
+    if (e.key === 'Tab') {
+        document.body.classList.add('user-is-tabbing');
+        window.removeEventListener('keydown', turnOnFocusRingWhenTabbing);
+        window.addEventListener('click', turnOffFocusRingWhenClicking);
+    }
+}
+
+function turnOffFocusRingWhenClicking(e: MouseEvent): void {
+    document.body.classList.remove('user-is-tabbing');
+    window.removeEventListener('click', turnOffFocusRingWhenClicking);
+    window.addEventListener('keydown', turnOnFocusRingWhenTabbing);
+}
+
+window.addEventListener('keydown', turnOnFocusRingWhenTabbing);
 
 function isUnsupportedBrowser(): boolean {
     // Safari 3.0+ "[object HTMLElementConstructor]"
@@ -96,8 +114,8 @@ if (isUnsupportedBrowser()) {
     ReactDOM.render(<UnsupportedBrowserPage/>, document.getElementById('root'));
 } else {
     Axios.get(`/api/config`,
-        {headers: { 'Content-Type': 'application/json'}}
-    ).then( (response) => {
+        {headers: {'Content-Type': 'application/json'}}
+    ).then((response) => {
 
         window.runConfig = Object.freeze(response.data);
 
@@ -131,7 +149,7 @@ if (isUnsupportedBrowser()) {
                         </Route>
 
                         <Route>
-                            <Redirect to={`/error/404`} />
+                            <Redirect to={`/error/404`}/>
                         </Route>
                     </Switch>
                 </Router>

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -36,6 +36,7 @@ import {AuthenticatedRoute} from './Auth/AuthenticatedRoute';
 import RedirectWrapper from './ReusableComponents/RedirectWrapper';
 import Axios from 'axios';
 import UnsupportedBrowserPage from './UnsupportedBrowserPage/UnsupportedBrowserPage';
+import FocusRing from "./FocusRing";
 
 let reduxDevToolsExtension: Function | undefined = (window as any).__REDUX_DEVTOOLS_EXTENSION__;
 let reduxDevToolsEnhancer: Function | undefined;
@@ -78,21 +79,7 @@ export interface RunConfig {
     adfs_resource: string;
 }
 
-function turnOnFocusRingWhenTabbing(e: KeyboardEvent): void {
-    if (e.key === 'Tab') {
-        document.body.classList.add('user-is-tabbing');
-        window.removeEventListener('keydown', turnOnFocusRingWhenTabbing);
-        window.addEventListener('click', turnOffFocusRingWhenClicking);
-    }
-}
-
-function turnOffFocusRingWhenClicking(e: MouseEvent): void {
-    document.body.classList.remove('user-is-tabbing');
-    window.removeEventListener('click', turnOffFocusRingWhenClicking);
-    window.addEventListener('keydown', turnOnFocusRingWhenTabbing);
-}
-
-window.addEventListener('keydown', turnOnFocusRingWhenTabbing);
+window.addEventListener('keydown', FocusRing.turnOnWhenTabbing);
 
 function isUnsupportedBrowser(): boolean {
     // Safari 3.0+ "[object HTMLElementConstructor]"


### PR DESCRIPTION
## Issue
Resolves #537 

## What was done
- [x] Added an event listener that changes the classname on the body depending on if the user is using the keyboard or mouse to navigate the site

## How to test
When using the mouse, none of the following should have a blue focus state (but the blue focus state should exist with keyboard usage):
1. Click PeopleMover logo with mouse - there is a blue focus state that appears.
2. Click account dropdown with mouse - there is a blue focus state that appears.
3. Click My Roles with mouse - there is a blue focus state that appears.
4. Click My Tags with mouse - there is a blue focus state that appears.
5. Go to My Roles, click Edit, Trash icon, add new role with a mouse - there is a blue focus state that appears at these three clicks.
6. Go to My Tags, click Edit, trash icon, add product tag, add location tag, there is a blue focus state that appears at these four clicks.
7. Assign someone to a different product, click Revert button in the reassign column, there is a blue focus state that appears when clicking Revert with mouse.
8. Click Add Person with mouse, there is a blue focus state that appears.
9. Click Add Product with mouse, there is a blue focus state that appears.
10. Exit out of any modal in PeopleMover, there is a blue focus state that appears when clicking x icon with mouse
11. Click space ellipses in dashboard with mouse, there is a blue focus state that appears.
12. Click calendar dropdown, focus state appears as half shaded circle or square at random times and when hovering. There should be a blue circle that appears around the date that you click

### FOR DEVS
Feature URL: See feature branch

### FOR APPROVAL
Approval URL: See Approval branch
