### PR TITLE
Center add new space button on mobile

### DIFF
--- a/ui/src/SpaceDashboard/SpaceDashboard.scss
+++ b/ui/src/SpaceDashboard/SpaceDashboard.scss
@@ -16,6 +16,7 @@
  */
 
 @import '../Application/Styleguide/Colors.scss';
+@import '../Application/Styleguide/Breakpoints.scss';
 
 $spaceTileWidth: 400px;
 
@@ -44,6 +45,11 @@ $spaceTileWidth: 400px;
   justify-content: center;
   width: 400px;
   height: 128px;
+  margin: 0 auto;
+
+  @include desktop  {
+    margin: 0;
+  }
 
   .createNewSpaceIcon {
     font-size: 34px;


### PR DESCRIPTION
Co-authored-by: Alex Wojtala <alexwojtala@gmail.com>
Co-authored-by: Ashley Clifton <aclift19@ford.com>

## Issue
Resolves #536 

## What was done
- [x] Center add new space button on mobile

## How to test
1. Go to the dashboard and shrink the browser so that it looks like a "mobile" view. Ensure all the tiles AND the add new space button are centered on the page.

### FOR DEVS
Feature URL: See feature branch

### FOR APPROVAL
Approval URL: See Approval branch
