### PR TITLE
Fix notes to text wrap & only show icon if text is present

### DIFF
--- a/ui/src/Assignments/PersonAndRoleInfo.scss
+++ b/ui/src/Assignments/PersonAndRoleInfo.scss
@@ -25,7 +25,7 @@
 
   .personName {
     display: flex;
-    align-items: center;
+    align-items: flex-end;
   }
 
   .notesIcon {
@@ -67,5 +67,6 @@
   .hoverBoxNotes {
     margin: 16px 20px;
     line-height: 18px;
+    white-space: pre-wrap;
   }
 }

--- a/ui/src/Assignments/PersonAndRoleInfo.tsx
+++ b/ui/src/Assignments/PersonAndRoleInfo.tsx
@@ -25,6 +25,7 @@ interface Props {
 }
 
 const PersonAndRoleInfo = ({ assignment = {id: 0} as Assignment, isUnassignedProduct}: Props): ReactElement => {
+    const { person } = assignment;
     const [hoverBoxIsOpened, setHoverBoxIsOpened] = useState<boolean>(false);
     const [hoverTimeout, setHoverTimeout] = useState<NodeJS.Timeout>();
     const showHoverBox = hoverBoxIsOpened && !isUnassignedProduct;
@@ -35,7 +36,9 @@ const PersonAndRoleInfo = ({ assignment = {id: 0} as Assignment, isUnassignedPro
         return (
             <div className="hoverBoxContainer"
                 data-testid="hoverBoxContainer">
-                <p className="hoverBoxNotes">{notes}</p>
+                <p className="hoverBoxNotes">
+                    {notes}
+                </p>
             </div>
         );
     };
@@ -56,21 +59,23 @@ const PersonAndRoleInfo = ({ assignment = {id: 0} as Assignment, isUnassignedPro
     return (
         <div data-testid={`assignmentCard${assignment.id}info`}
             className="personNameAndRoleContainer">
-            <div className={`${assignment.person.name === 'Chris Boyer' ? 'chrisBoyer' : ''} personName`}
+            <div className={`${person.name === 'Chris Boyer' ? 'chrisBoyer' : ''} personName`}
                 data-testid="personName"
                 onMouseEnter={(): void => onNoteHover(true)}
                 onMouseLeave={(): void => onNoteHover(false)}>
-                {assignment.person.name}
-                {!!assignment.person.notes &&
+                {person.name}
+                {!!person.notes && !!person.notes.trim() &&
                     <i className="material-icons notesIcon" data-testid="notesIcon">
                         note
-                        {showHoverBox && <HoverBox notes={assignment.person.notes}/>}
+                        {showHoverBox && <HoverBox notes={person.notes}/>}
                     </i>
                 }
             </div>
-            <div className="personRole">
-                {assignment.person.spaceRole && assignment.person.spaceRole.name}
-            </div>
+            {person?.spaceRole?.name && (
+                <div className="personRole">
+                    {person.spaceRole.name}
+                </div>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
## Issue
N/A

## What was done
- [x] Fix notes to text wrap & only show icon if text is present

## How to test
1. Ensure that when you hover over notes that the text wraps and doesn't overflow over the text box.
2. Ensure that if you save a note that is nothing but white space, that the notes icon does not show up, but only shows up when text is actually present.

### FOR DEVS
Feature URL: See feature branch

### FOR APPROVAL
Approval URL: See Approval branch
