### PR TITLE
Redirect user to login when endpoint returns 401 Unauthorized

### DIFF
--- a/ui/src/Products/Product.scss
+++ b/ui/src/Products/Product.scss
@@ -68,7 +68,7 @@
   align-items: flex-start;
 
   .productName {
-    margin: 5px 0 0;
+    margin: 5px 0;
     font-size: 14px;
     line-height: 16px;
     color: $gray-1;

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -37,7 +37,7 @@ import RedirectWrapper from './ReusableComponents/RedirectWrapper';
 import Axios from 'axios';
 import UnsupportedBrowserPage from './UnsupportedBrowserPage/UnsupportedBrowserPage';
 import FocusRing from './FocusRing';
-import MatomoEvents from "./Matomo/MatomoEvents";
+import MatomoEvents from './Matomo/MatomoEvents';
 
 let reduxDevToolsExtension: Function | undefined = (window as any).__REDUX_DEVTOOLS_EXTENSION__;
 let reduxDevToolsEnhancer: Function | undefined;

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -36,7 +36,8 @@ import {AuthenticatedRoute} from './Auth/AuthenticatedRoute';
 import RedirectWrapper from './ReusableComponents/RedirectWrapper';
 import Axios from 'axios';
 import UnsupportedBrowserPage from './UnsupportedBrowserPage/UnsupportedBrowserPage';
-import FocusRing from "./FocusRing";
+import FocusRing from './FocusRing';
+import MatomoEvents from "./Matomo/MatomoEvents";
 
 let reduxDevToolsExtension: Function | undefined = (window as any).__REDUX_DEVTOOLS_EXTENSION__;
 let reduxDevToolsEnhancer: Function | undefined;
@@ -80,6 +81,29 @@ export interface RunConfig {
 }
 
 window.addEventListener('keydown', FocusRing.turnOnWhenTabbing);
+
+const UNAUTHORIZED = 401;
+const FORBIDDEN = 403;
+Axios.interceptors.response.use(
+    response => response,
+    error => {
+        const {status} = error.response;
+        let category = 'Error';
+        switch (status) {
+            case UNAUTHORIZED: {
+                category = 'Unauthorized';
+                window.location.href = '/user/login';
+                break;
+            }
+            case FORBIDDEN: {
+                category = 'Forbidden';
+                break;
+            }
+        }
+        MatomoEvents.pushEvent(category, error.response.data.method, error.response.data.url, status);
+        return Promise.reject(error);
+    }
+);
 
 function isUnsupportedBrowser(): boolean {
     // Safari 3.0+ "[object HTMLElementConstructor]"


### PR DESCRIPTION

## Issue
Resolves #561 

## What was done
- [x] Added interceptor to all axios endpoints that will redirect to login if it returns a 401

## How to test
1. Login and go to a space. Delete/change you cookie. Attempt to do anything that requires an endpoint (create or edit a product/person, get new products/people from different dates, etc). Verify that it redirects you to the login page

### FOR DEVS
Feature URL: See feature branch

### FOR APPROVAL
Approval URL: See Approval branch
