### PR TITLE
Remove Cypress and API tests from git commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
     "url": "git+https://github.com/FordLabs/PeopleMover.git"
   },
   "scripts": {
-    "test:ui": "cd ui && npm run lint && npm run test:ci",
-    "test:api": "cd api && ./gradlew test"
+    "test:ui": "cd ui && npm run lint && npm run test:unit:ci"
   },
   "husky": {
     "hooks": {
-      "pre-commit": ".git/hooks/pre-commit-guet && npm run test:api && npm run test:ui",
+      "pre-commit": ".git/hooks/pre-commit-guet && npm run test:ui",
       "commit-msg": ".git/hooks/commit-msg-guet",
       "post-commit": ".git/hooks/post-commit-guet"
     }


### PR DESCRIPTION
## Issue
Resolves #549 

## What was done
- [x] Remove Cypress and API tests from git commit hooks

## How to test
1. When you commit code, it should only run linting and unit tests.
2. Github actions should run api tests, cypress tests, unit tests, and linting.

### FOR DEVS
Feature URL: See feature branch

### FOR APPROVAL
Approval URL: See Approval branch
