### PR TITLE
Fix matomo error actions (shouldn't be undefined)

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -83,24 +83,16 @@ export interface RunConfig {
 window.addEventListener('keydown', FocusRing.turnOnWhenTabbing);
 
 const UNAUTHORIZED = 401;
-const FORBIDDEN = 403;
 Axios.interceptors.response.use(
     response => response,
     error => {
-        const {status} = error.response;
-        let category = 'Error';
-        switch (status) {
-            case UNAUTHORIZED: {
-                category = 'Unauthorized';
-                window.location.href = '/user/login';
-                break;
-            }
-            case FORBIDDEN: {
-                category = 'Forbidden';
-                break;
-            }
+        const {status, statusText, config} = error.response;
+
+        MatomoEvents.pushEvent(statusText, config.method, config.url, status);
+
+        if (status === UNAUTHORIZED) {
+            window.location.href = '/user/login';
         }
-        MatomoEvents.pushEvent(category, error.response.data.method, error.response.data.url, status);
         return Promise.reject(error);
     }
 );


### PR DESCRIPTION
## Issue
Resolves #561 

## What was done
- [x] The matomo unauthorized action was showing up as undefined. Now it should look like this:
<img width="621" alt="Screen Shot 2020-11-20 at 10 42 27 AM" src="https://user-images.githubusercontent.com/74197928/99819865-06524400-2b1e-11eb-82df-a25df3b97532.png">


## How to test
1. Go to a space, delete your access token, then try to do something. It should redirect you to the login page and send the above kind of matomo event.

### FOR DEVS
Feature URL: See feature branch

### FOR APPROVAL
Approval URL: See Approval branch
