### PR TITLE
62 Update Matomo error convention naming and add error events

### DIFF
--- a/ui/src/Assignments/AssignmentCard.tsx
+++ b/ui/src/Assignments/AssignmentCard.tsx
@@ -47,6 +47,7 @@ interface AssignmentCardProps {
     startDraggingAssignment?(ref: RefObject<HTMLDivElement>, assignment: Assignment, e: React.MouseEvent): void;
 
     setCurrentModal(modalState: CurrentModalState): void;
+
     fetchProducts(): void;
 }
 
@@ -124,7 +125,12 @@ function AssignmentCard({
             } else {
                 MatomoEvents.pushEvent(currentSpace.name, 'unmarkAsPlaceholder', assignment.person.name);
             }
-            if (fetchProducts) { fetchProducts(); }
+            if (fetchProducts) {
+                fetchProducts();
+            }
+        }).catch((error) => {
+            MatomoEvents.pushEvent(currentSpace.name, 'placeholderError', assignment.person.name, error.code);
+            return Promise.reject(error);
         });
     }
 
@@ -148,7 +154,12 @@ function AssignmentCard({
 
         AssignmentClient.createAssignmentForDate(assignmentToUpdate, currentSpace, false).then(() => {
             MatomoEvents.pushEvent(currentSpace.name, 'cancelAssignment', assignment.person.name);
-            if (fetchProducts) { fetchProducts(); }
+            if (fetchProducts) {
+                fetchProducts();
+            }
+        }).catch((error) => {
+            MatomoEvents.pushEvent(currentSpace.name, 'cancelAssignmentError', assignment.person.name, error.code);
+            return Promise.reject(error);
         });
     }
 
@@ -213,21 +224,23 @@ function AssignmentCard({
             <PersonAndRoleInfo
                 isReadOnly={isReadOnly}
                 assignment={assignment}
-                isUnassignedProduct={isUnassignedProduct} />
+                isUnassignedProduct={isUnassignedProduct}/>
             <div ref={assignmentEditRef}
                 className="personRoleColor"
                 data-testid={createDataTestId('editPersonIconContainer', assignment.person.name)}
                 onClick={toggleEditMenu}
-                onKeyDown={(e): void => {handleKeyDownForToggleEditMenu(e);}}>
+                onKeyDown={(e): void => {
+                    handleKeyDownForToggleEditMenu(e);
+                }}>
                 {
                     !isReadOnly && <i className="material-icons personEditIcon greyIcon">more_vert</i>
                 }
             </div>
             {editMenuIsOpened &&
-                <EditMenu
-                    menuOptionList={getMenuOptionList()}
-                    onClosed={onEditMenuClosed}
-                />
+            <EditMenu
+                menuOptionList={getMenuOptionList()}
+                onClosed={onEditMenuClosed}
+            />
             }
         </div>
     );

--- a/ui/src/Products/ProductClient.ts
+++ b/ui/src/Products/ProductClient.ts
@@ -82,6 +82,9 @@ class ProductClient {
         return Axios.delete(url, config).then(result => {
             MatomoEvents.pushEvent(space.name, 'deleteProduct', product.name);
             return result;
+        }).catch((error) => {
+            MatomoEvents.pushEvent(space.name, 'deleteProductError', product.name, error.code);
+            return Promise.reject(error);
         });
     }
 

--- a/ui/src/ReassignedDrawer/ReassignedDrawer.tsx
+++ b/ui/src/ReassignedDrawer/ReassignedDrawer.tsx
@@ -58,8 +58,8 @@ function ReassignedDrawer({
     ));
 
     const containee: JSX.Element = (
-        <div 
-            className="reassignmentContainer" 
+        <div
+            className="reassignmentContainer"
             data-testid="reassignmentContainer">
             {listOfHTMLReassignments}
         </div>
@@ -112,7 +112,7 @@ function ReassignedDrawer({
                 fetchProducts();
                 MatomoEvents.pushEvent(currentSpace.name, 'revert', `From: ${reassignment?.fromProductName} To: ${reassignment?.toProductName}`);
             }).catch(err => {
-                MatomoEvents.pushEvent(currentSpace.name, 'revert', `From: ${reassignment?.fromProductName} To: ${reassignment?.toProductName}`, err.code);
+                MatomoEvents.pushEvent(currentSpace.name, 'revertError', `From: ${reassignment?.fromProductName} To: ${reassignment?.toProductName}`, err.code);
                 return Promise.reject(err);
             });
     }

--- a/ui/src/Space/SpaceClient.ts
+++ b/ui/src/Space/SpaceClient.ts
@@ -93,6 +93,9 @@ class SpaceClient {
         return Axios.put(url, data, config).then((result) => {
             MatomoEvents.pushEvent(space.name, 'inviteUser', emails.join(', '));
             return result;
+        }).catch((error) => {
+            MatomoEvents.pushEvent(space.name, 'inviteUserError', emails.join(', '), error.code);
+            return Promise.reject(error);
         });
     }
 }

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -86,7 +86,8 @@ Axios.interceptors.response.use(
             removeToken();
             RedirectToADFS();
         } else {
-            MatomoEvents.pushEvent(statusText, config.method, config.url, status);
+            let conventionizedErrorName = `${statusText} - ${status}`;
+            MatomoEvents.pushEvent(conventionizedErrorName, config.method, config.url, status);
         }
         return Promise.reject(error);
     }


### PR DESCRIPTION
## Issue
Resolves 62

## What was done
- [x] Added error events for Matomo events related to Axios calls
- [x] Changed naming convention for automatic Axios Matomo events 

## How to test
1. Check to see how the events are showing in prod when the errors happen. (can't really test error handling while it's in the pipeline)