### PR TITLE
Ensure calendar updates with highlighted dates

### DIFF
--- a/ui/src/Calendar/Calendar.tsx
+++ b/ui/src/Calendar/Calendar.tsx
@@ -50,12 +50,14 @@ function Calendar({
     const calendarRef = createRef<ReactDatePicker>();
 
     useEffect(() => {
-        AssignmentClient.getAssignmentEffectiveDates(uuid)
-            .then(response => {
-                const dates: Array<Date> = (response.data as string[]).map(date => moment(date).toDate());
-                setDaysHighlighted(dates);
-            });
-    }, [uuid]);
+        if (isCalendarOpen) {
+            AssignmentClient.getAssignmentEffectiveDates(uuid)
+                .then(response => {
+                    const dates: Array<Date> = (response.data as string[]).map(date => moment(date).toDate());
+                    setDaysHighlighted(dates);
+                });
+        }
+    }, [uuid, isCalendarOpen]);
 
     function toggleCalendar(isOpen: boolean): void {
         setIsCalendarOpen(isOpen);

--- a/ui/src/ReassignedDrawer/ReassignedDrawer.tsx
+++ b/ui/src/ReassignedDrawer/ReassignedDrawer.tsx
@@ -47,9 +47,10 @@ function ReassignedDrawer({
 
     /* eslint-disable */
     useEffect(() => {
-        const reassignments = AssignmentClient.getReassignments(currentSpace.uuid!, viewingDate).then( reassignmentResponse =>
-            setReassignments(reassignmentResponse.data)
-        );
+        AssignmentClient.getReassignments(currentSpace.uuid!, viewingDate)
+            .then( reassignmentResponse =>
+                setReassignments(reassignmentResponse.data)
+            );
     }, [products]);
     /* eslint-enable */
 


### PR DESCRIPTION
Co-authored-by: Ashley Clifton <aclift19@ford.com>
Co-authored-by: Vianney Willot <vianney.willot@gmail.com>

## Issue
Resolves #68 

## What was done
- [x] Ensured that the calendar updates the highlighted dates whenever it is opened up.

## How to test
1. Go to a space, make a new assignment on a day that isn't highlighted, and ensure that that date gets highlighted in the calendar without refreshing the page.

### FOR DEVS
Feature URL: See feature branch

### FOR APPROVAL
Approval URL: See Approval branch
