### PR TITLE
Change verbage to create tags in dropdown and fix focus state styling

### DIFF
--- a/ui/cypress/e2e/form_field_dropdowns.test.js
+++ b/ui/cypress/e2e/form_field_dropdowns.test.js
@@ -17,6 +17,8 @@
 
 /// <reference types="Cypress" />
 
+import TestUtils from '../../src/tests/TestUtils';
+
 describe('Form Dropdown Fields', () => {
 
     beforeEach(() => {
@@ -60,7 +62,7 @@ describe('Form Dropdown Fields', () => {
         cy.get('@productForm')
             .find('.location__option')
             .should('have.length', 1)
-            .should('contain', `Create "${newLocation1}"`);
+            .should('contain', TestUtils.expectedCreateOptionText(newLocation1));
 
         cy.get('@productLocationInput')
             .type('{enter}');
@@ -82,7 +84,7 @@ describe('Form Dropdown Fields', () => {
         cy.get('@productForm')
             .find('.location__option')
             .should('have.length', 1)
-            .should('contain', 'Create "Chilto"');
+            .should('contain', TestUtils.expectedCreateOptionText('Chilto'));
 
 
         cy.get('@productLocationInput')
@@ -106,7 +108,7 @@ describe('Form Dropdown Fields', () => {
         cy.get('@productForm')
             .find('.location__option')
             .should('have.length', 1)
-            .should('contain', `Create "${newLocation2}"`);
+            .should('contain', TestUtils.expectedCreateOptionText(newLocation2));
     });
 
     it('Add Product Tags Workflow', () => {
@@ -137,7 +139,7 @@ describe('Form Dropdown Fields', () => {
         cy.get('@productForm')
             .find('.productTags__option')
             .should('have.length', 1)
-            .should('contain', `Create "${newProductTag1}"`);
+            .should('contain', TestUtils.expectedCreateOptionText(newProductTag1));
 
         cy.get('@productTagsInput')
             .type('{enter}');
@@ -165,7 +167,7 @@ describe('Form Dropdown Fields', () => {
         cy.get('@productForm')
             .find('.productTags__option')
             .should('have.length', 1)
-            .should('contain', `Create "${newProductTag2}"`);
+            .should('contain', TestUtils.expectedCreateOptionText(newProductTag2));
 
         cy.get('@productTagsInput')
             .type('{enter}');

--- a/ui/cypress/e2e/form_field_dropdowns.test.js
+++ b/ui/cypress/e2e/form_field_dropdowns.test.js
@@ -18,6 +18,7 @@
 /// <reference types="Cypress" />
 
 describe('Form Dropdown Fields', () => {
+
     beforeEach(() => {
         cy.server();
         cy.route('POST', Cypress.env('API_LOCATION_PATH')).as('postNewLocation');
@@ -59,7 +60,7 @@ describe('Form Dropdown Fields', () => {
         cy.get('@productForm')
             .find('.location__option')
             .should('have.length', 1)
-            .should('contain', `Press Enter to add "${newLocation1}"`);
+            .should('contain', `Create "${newLocation1}"`);
 
         cy.get('@productLocationInput')
             .type('{enter}');
@@ -81,7 +82,7 @@ describe('Form Dropdown Fields', () => {
         cy.get('@productForm')
             .find('.location__option')
             .should('have.length', 1)
-            .should('contain', 'Press Enter to add "Chilto"');
+            .should('contain', 'Create "Chilto"');
 
 
         cy.get('@productLocationInput')
@@ -105,7 +106,7 @@ describe('Form Dropdown Fields', () => {
         cy.get('@productForm')
             .find('.location__option')
             .should('have.length', 1)
-            .should('contain', `Press Enter to add "${newLocation2}"`);
+            .should('contain', `Create "${newLocation2}"`);
     });
 
     it('Add Product Tags Workflow', () => {
@@ -136,7 +137,7 @@ describe('Form Dropdown Fields', () => {
         cy.get('@productForm')
             .find('.productTags__option')
             .should('have.length', 1)
-            .should('contain', `Press Enter to add "${newProductTag1}"`);
+            .should('contain', `Create "${newProductTag1}"`);
 
         cy.get('@productTagsInput')
             .type('{enter}');
@@ -164,7 +165,7 @@ describe('Form Dropdown Fields', () => {
         cy.get('@productForm')
             .find('.productTags__option')
             .should('have.length', 1)
-            .should('contain', `Press Enter to add "${newProductTag2}"`);
+            .should('contain', `Create "${newProductTag2}"`);
 
         cy.get('@productTagsInput')
             .type('{enter}');

--- a/ui/src/Assignments/AssignmentForm.test.tsx
+++ b/ui/src/Assignments/AssignmentForm.test.tsx
@@ -133,7 +133,7 @@ describe('AssignmentForm', () => {
             const { app } = renderComponent();
             const labelElement = await app.findByLabelText('Name');
             fireEvent.change(labelElement, {target: {value: 'Barbara Jordan'}});
-            await app.findByText('Press Enter to add "Barbara Jordan"');
+            await app.findByText( TestUtils.expectedCreateOptionText('Barbara Jordan'));
         });
 
         it('populates the person name field of the Create Person modal on open', async () => {
@@ -145,7 +145,8 @@ describe('AssignmentForm', () => {
             const labelElement = await app.findByLabelText('Name');
             await selectEvent.openMenu(labelElement);
             await prefillReactSelectField(app, 'Name', 'XYZ ABC 123');
-            fireEvent.click(getByText(await app.findByTestId('assignmentForm'), 'Press Enter to add "XYZ ABC 123"'));
+            const createOptionText = TestUtils.expectedCreateOptionText('XYZ ABC 123');
+            fireEvent.click(getByText(await app.findByTestId('assignmentForm'),  createOptionText));
 
             expect(store.dispatch).toBeCalledWith(setCurrentModalAction({
                 modal: AvailableModals.CREATE_PERSON,

--- a/ui/src/ModalFormComponents/ReactSelectStyles.tsx
+++ b/ui/src/ModalFormComponents/ReactSelectStyles.tsx
@@ -48,7 +48,7 @@ export const reactSelectStyles = {
     }),
     option: (provided: CSSProperties, props: Props): CSSProperties => ({
         ...provided,
-        backgroundColor: 'transparent',
+        backgroundColor: props.isFocused ? '#F2F2F2' : 'transparent',
         color: props.data.__isNew__ ? '#5463B0' : '#403D3D',
         fontFamily: 'Helvetica, sans-serif',
         fontSize: '12px',
@@ -63,7 +63,6 @@ export const reactSelectStyles = {
         // @ts-ignore
         '&:hover': {
             cursor: 'pointer',
-            backgroundColor: '#F2F2F2',
         },
     }),
     input: (provided: CSSProperties): CSSProperties => ({
@@ -396,6 +395,6 @@ export const CustomOption = (allTheProps: OptionProps<OptionTypeBase>): JSX.Elem
 
 export const CreateNewText = (text: string): JSX.Element => (
     <span>
-        {`Press Enter to add "${text}"`}
+        {`Create "${text}"`}
     </span>
 );

--- a/ui/src/ModalFormComponents/ReactSelectStyles.tsx
+++ b/ui/src/ModalFormComponents/ReactSelectStyles.tsx
@@ -50,6 +50,8 @@ export const reactSelectStyles = {
         ...provided,
         backgroundColor: props.isFocused ? '#F2F2F2' : 'transparent',
         color: props.data.__isNew__ ? '#5463B0' : '#403D3D',
+        border: props.isFocused ? '2px solid #4C8EF5' : 'none',
+        borderRadius: '2px',
         fontFamily: 'Helvetica, sans-serif',
         fontSize: '12px',
         lineHeight: '13.8px',

--- a/ui/src/ModalFormComponents/SelectWithNoCreateOption.tsx
+++ b/ui/src/ModalFormComponents/SelectWithNoCreateOption.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, {CSSProperties} from 'react';
-import Select from 'react-select';
+import Select, {Props} from 'react-select';
 import {CustomIndicator, reactSelectStyles} from './ReactSelectStyles';
 import {ReactSelectProps} from './SelectWithCreateOption';
 
@@ -27,9 +27,11 @@ export const multiSelectStyles = {
         overflow:'unset',
         padding: '0 8px 0 6px',
     }),
-    option: (provided: CSSProperties): CSSProperties => ({
+    option: (provided: CSSProperties, props: Props): CSSProperties => ({
         ...provided,
-        backgroundColor: 'transparent',
+        backgroundColor: props.isFocused ? '#F2F2F2' : 'transparent',
+        border: props.isFocused ? '2px solid #4C8EF5' : 'none',
+        borderRadius: '2px',
         fontFamily: 'Helvetica, sans-serif',
         fontSize: '12px',
         display: 'flex',
@@ -41,7 +43,6 @@ export const multiSelectStyles = {
         // @ts-ignore
         '&:hover': {
             cursor: 'pointer',
-            backgroundColor: '#F2F2F2',
         },
     }),
     placeholder: (provided: CSSProperties): CSSProperties => ({

--- a/ui/src/People/People.test.tsx
+++ b/ui/src/People/People.test.tsx
@@ -215,7 +215,7 @@ describe('People actions', () => {
         it('allows user to create a new role when creating a person', async () => {
             const personForm = await app.findByTestId('personForm');
             const labelElement = await app.findByLabelText('Role');
-            const containerToFindOptionsIn = {container: personForm, createOptionText: 'Press Enter to add "Product Owner"'};
+            const containerToFindOptionsIn = {container: personForm, createOptionText: TestUtils.expectedCreateOptionText('Product Owner')};
 
             await wait(() => {
                 selectEvent.create(labelElement, 'Product Owner', containerToFindOptionsIn);

--- a/ui/src/tests/FilterProducts.test.tsx
+++ b/ui/src/tests/FilterProducts.test.tsx
@@ -115,7 +115,8 @@ describe('Filter products', () => {
 
             await app.findByLabelText('Name');
             await act(async () => {
-                await createTag('Location', 'Press Enter to add "Ahmedabad"', 'Ahmedabad');
+                const createOptionText = TestUtils.expectedCreateOptionText('Ahmedabad');
+                await createTag('Location', createOptionText, 'Ahmedabad');
                 const productForm = await app.findByTestId('productForm');
 
                 await wait(() => {
@@ -138,7 +139,8 @@ describe('Filter products', () => {
 
             await app.findByLabelText('Name');
             await act(async () => {
-                await createTag('Product Tags', 'Press Enter to add "Fin Tech"', 'Fin Tech');
+                const expectedCreateOptionText = TestUtils.expectedCreateOptionText('Fin Tech');
+                await createTag('Product Tags', expectedCreateOptionText, 'Fin Tech');
                 expect(ProductTagClient.add).toBeCalledTimes(1);
 
                 const productForm = await app.findByTestId('productForm');

--- a/ui/src/tests/Product.test.tsx
+++ b/ui/src/tests/Product.test.tsx
@@ -282,7 +282,7 @@ describe('Products', () => {
                 const locationLabelElement = await app.findByLabelText('Location');
                 const containerToFindOptionsIn = {
                     container: await app.findByTestId('productForm'),
-                    createOptionText: 'Press Enter to add "Ahmedabad"',
+                    createOptionText: TestUtils.expectedCreateOptionText('Ahmedabad'),
                 };
                 await selectEvent.create(locationLabelElement, 'Ahmedabad', containerToFindOptionsIn);
                 const productForm = await app.findByTestId('productForm');
@@ -316,7 +316,7 @@ describe('Products', () => {
                 const tagsLabelElement = await app.findByLabelText('Product Tags');
                 const containerToCreateFinTech = {
                     container: await app.findByTestId('productForm'),
-                    createOptionText: 'Press Enter to add "Fin Tech"',
+                    createOptionText: 'Create "Fin Tech"',
                 };
                 await selectEvent.create(tagsLabelElement, 'Fin Tech', containerToCreateFinTech);
                 expect(ProductTagClient.add).toBeCalledTimes(1);
@@ -327,7 +327,7 @@ describe('Products', () => {
 
                 const containerToCreateSomeTag = {
                     container: await app.findByTestId('productForm'),
-                    createOptionText: 'Press Enter to add "Some tag"',
+                    createOptionText: TestUtils.expectedCreateOptionText('Some tag'),
                 };
 
                 await selectEvent.create(tagsLabelElement, 'Some tag', containerToCreateSomeTag);

--- a/ui/src/tests/TestUtils.tsx
+++ b/ui/src/tests/TestUtils.tsx
@@ -447,6 +447,10 @@ class TestUtils {
             options: [],
         },
     ]
+
+    static expectedCreateOptionText(expectedCreationString: string): string {
+        return `Create "${expectedCreationString}"`;
+    }
 }
 
 export default TestUtils;


### PR DESCRIPTION
Co-authored-by: Elise Griffiths <egriff38@ford.com>
Co-authored-by: Alex Wojtala <alexwojtala@gmail.com>

## Issue
Resolves #80 

## What was done
- [x] Fixed focus state styling so that it is obvious what will be created when the user presses enter on a dropdown
- [x] Changed verbage back to 'Create "x"' for the create option on a dropdown

## How to test
1. Create or edit a person, or a product
2. Open a dropdown for role and/or location and/or product tag
3. See that when there are options while typing (partial matches), the highlighted option is obvious. 
4. Use arrow keys to choose whichever option you like

### FOR DEVS
Feature URL: See feature branch

### FOR APPROVAL
Approval URL: See Approval branch
