### PR TITLE
Add FordLabs campaign url to ford labs logo

### DIFF
--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/environmentconfiguration/EnvironmentConfiguration.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/environmentconfiguration/EnvironmentConfiguration.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component
 @ConfigurationProperties(prefix = "react.app")
 class EnvironmentConfiguration {
     var auth_enabled: Boolean = false
+    var ford_labs_url: String = ""
     var invite_users_to_space_enabled: Boolean = false
     var adfs_url_template: String = ""
     var adfs_client_id: String = ""

--- a/ui/src/LandingPage/LandingPage.scss
+++ b/ui/src/LandingPage/LandingPage.scss
@@ -38,10 +38,10 @@
   width: 760px;
   margin: auto;
 
-  .branding-container {
+  .brandingContainer {
     padding-top: 3rem;
 
-    p.branding-message {
+    .brandingMessage {
       color: white;
     }
   }

--- a/ui/src/ReusableComponents/Branding.scss
+++ b/ui/src/ReusableComponents/Branding.scss
@@ -17,23 +17,22 @@
 
 @import '../Application/Styleguide/Colors.scss';
 
-.branding-image {
+.brandingImage {
   vertical-align: middle;
   margin: 0 3px;
 }
 
-.branding-message {
+.brandingMessage {
   display: inline;
   font-size: 12px;
-  color: $gray-4;
+  color: $gray-2;
   margin: 0;
 }
 
-.branding-container {
+.brandingContainer {
   display: flex;
   justify-content: center;
   align-items: center;
-
   margin-top: auto;
   padding: 16px 0;
 }

--- a/ui/src/ReusableComponents/Branding.scss
+++ b/ui/src/ReusableComponents/Branding.scss
@@ -1,4 +1,4 @@
-/*!
+/*
  * Copyright (c) 2020 Ford Motor Company
  * All rights reserved.
  *

--- a/ui/src/ReusableComponents/Branding.test.tsx
+++ b/ui/src/ReusableComponents/Branding.test.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import {renderWithRedux} from '../tests/TestUtils';
+import Branding from './Branding';
+import {RunConfig} from '../index';
+
+describe('Branding', () => {
+    const expectedUrl = 'http://url.com';
+
+    beforeEach(() => {
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        window.runConfig = {ford_labs_url: expectedUrl} as RunConfig;
+    });
+    
+    it('should get url from config', () => {
+        const comp = renderWithRedux(<Branding />);
+        const actualUrl = comp.getByText('FordLabs');
+        expect(actualUrl).toHaveAttribute('href', expectedUrl);
+    });
+});

--- a/ui/src/ReusableComponents/Branding.tsx
+++ b/ui/src/ReusableComponents/Branding.tsx
@@ -32,6 +32,7 @@ function Branding(): JSX.Element {
                 width="20"
                 height="20"/>
             <a target="_blank"
+                rel="noopener noreferrer"
                 href={fordLabsUrl}
                 className="brandingMessage">
                 FordLabs

--- a/ui/src/ReusableComponents/Branding.tsx
+++ b/ui/src/ReusableComponents/Branding.tsx
@@ -17,19 +17,25 @@
 
 import React from 'react';
 import './Branding.scss';
+import FordLabsLogo from '../Application/Assets/fordlabs_logo.svg';
 
 function Branding(): JSX.Element {
+    const fordLabsUrl = window.runConfig.ford_labs_url || '';
     return (
-        <div className="branding-container"
+        <div className="brandingContainer"
             aria-label="Powered by Ford Labs">
-            <p className="branding-message">Powered by</p>
-            <img className="branding-image"
-                src={require('../Application/Assets/fordlabs_logo.svg')}
+            <span className="brandingMessage">Powered by</span>
+            <img className="brandingImage"
+                src={FordLabsLogo}
                 alt=""
                 aria-hidden
                 width="20"
                 height="20"/>
-            <p className="branding-message">FordLabs</p>
+            <a target="_blank"
+                href={fordLabsUrl}
+                className="brandingMessage">
+                FordLabs
+            </a>
         </div>
     );
 }

--- a/ui/src/ReusableComponents/Branding.tsx
+++ b/ui/src/ReusableComponents/Branding.tsx
@@ -20,7 +20,7 @@ import './Branding.scss';
 import FordLabsLogo from '../Application/Assets/fordlabs_logo.svg';
 
 function Branding(): JSX.Element {
-    const fordLabsUrl = window.runConfig.ford_labs_url || '';
+    const fordLabsUrl = window?.runConfig?.ford_labs_url || '';
     return (
         <div className="brandingContainer"
             aria-label="Powered by Ford Labs">

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -68,6 +68,7 @@ declare global {
 
 export interface RunConfig {
     auth_enabled: boolean;
+    ford_labs_url: string;
     invite_users_to_space_enabled: boolean;
     adfs_url_template: string;
     adfs_client_id: string;


### PR DESCRIPTION
## Issue
Resolves #89

## What was done
- [x] Added the ford labs url to the ford labs "powered by" logo

Note: Stage/Feature/Approval should just have "http://fordlabs.com" whereas prod should have the campaign url.

## How to test
1. Go to the landing page, dashboard, and space, and ensure that the "powered by fordLabs" text both matches the mocks and that "fordLabs" is underlined and is a link to the ford labs site.

### FOR DEVS
Feature URL: See feature branch

### FOR APPROVAL
Approval URL: See Approval branch
