### PR TITLE
Gray out text on Add New Product button when in read only space

### DIFF
--- a/.guet/committers
+++ b/.guet/committers
@@ -8,3 +8,4 @@ ac,Ashley Clifton,aclift19@ford.com
 vw,Vianney Willot,vianney.willot@gmail.com
 eg,Elise Griffiths,egriff38@ford.com
 cd,chris dorman,cdorman1@ford.com
+jc,John Cherney,jwcherney@hotmail.com

--- a/ui/src/Products/NewProductButton.scss
+++ b/ui/src/Products/NewProductButton.scss
@@ -47,9 +47,9 @@ button.newProduct {
 
   &.readOnly:disabled {
     background-color: $gray-5;
+    color: $gray-4;
 
-    .addProductIcon.material-icons,
-    .newProductText {
+    .addProductIcon.material-icons {
       color: $gray-4;
     }
   }


### PR DESCRIPTION
Co-authored-by: Alex Wojtala <alexwojtala@gmail.com>
Co-authored-by: John Cherney <jwcherney@hotmail.com>

## Issue
Resolves #117

## What was done
- [x] Gray out the text on the Add New Product button when in a read-only space

## How to test
1. Go to a space that isn't owned by you. Look at the "Add New Product" button. It should be grayed out, the same color as the gray for the '+' icon. 

