### PR TITLE
Make focus ring around circular calendar date more visible

### DIFF
--- a/ui/src/Calendar/Calendar.scss
+++ b/ui/src/Calendar/Calendar.scss
@@ -42,7 +42,7 @@
             height: 2px;
             width: 10px;
             position: absolute;
-            bottom: 6px;
+            bottom: 4px;
             left: 0;
             right: 0;
             margin: 0 auto;
@@ -59,20 +59,9 @@
           background: $logo-gradient;
           border-radius: 50%;
           font-weight: bold;
+          border: 2px solid $white;
+          padding: 8px;
           position: relative;
-
-          &::before {
-            content: "";
-            background: transparent;
-            border: 5px solid white;
-            position: absolute;
-            border-radius: 50%;
-            margin: auto;
-            height: 80%;
-            width: 80%;
-            top: -1px;
-            left: -1px;
-          }
         }
 
         .react-datepicker__day--disabled {


### PR DESCRIPTION
Co-authored-by: Max Wilkinson <mwilki71@ford.com>
Co-authored-by: Chris Atkinson <christopher.w.atkinson.1989@gmail.com>

## Issue
Partially Resolves #110

## What was done
- [x] Improved highlighted calendar's focus ring visibility

## How to test
1. Use keyboard to navigate to calendar entry
2. Observe focus ring