### PR TITLE
Add guards around people being already unassigned when deleting product

### DIFF
--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductService.kt
@@ -84,9 +84,15 @@ class ProductService(
                 .findProductByNameAndSpaceUuid("unassigned", productToDelete.spaceUuid)
                 ?: throw EntityNotExistsException()
 
+        val unassignedPeople = unassignedProduct.assignments.map{ it.person.id }
+
         productToDelete.assignments.forEach {
-            it.productId = unassignedProduct.id!!
-            assignmentService.updateAssignment(it)
+            if (unassignedPeople.contains(it.person.id)) {
+                assignmentService.deleteOneAssignment(it)
+            } else {
+                it.productId = unassignedProduct.id!!
+                assignmentService.updateAssignment(it)
+            }
         }
     }
 


### PR DESCRIPTION
Co-authored-by: Alex Wojtala <alexwojtala@gmail.com>
Co-authored-by: Vianney Willot <vianney.willot@gmail.com>

## Issue
Resolves 124

## What was done
- [x] Add guardrail around people being already unassigned when deleting a product

## How to test
-Open a fresh space
-Create two products
-Create one person
-Assign that person to both products
-Delete the first product
-Try and delete the second product, second product should now be deleted
