### PR TITLE
Add permission to user mapping object and set permission on create an…

### DIFF
--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/LocalDataGenerator.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/LocalDataGenerator.kt
@@ -3,6 +3,7 @@ package com.ford.internalprojects.peoplemover
 import com.ford.internalprojects.peoplemover.assignment.AssignmentService
 import com.ford.internalprojects.peoplemover.assignment.CreateAssignmentsRequest
 import com.ford.internalprojects.peoplemover.assignment.ProductPlaceholderPair
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_EDITOR
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.color.ColorService
@@ -64,7 +65,7 @@ class LocalDataGenerator(
         )
         productService.createDefaultProducts(createdSpace);
 
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = createdSpace.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = createdSpace.uuid, permission = PERMISSION_EDITOR))
 
         var colors = colorService.getColors()
         if (colors.isEmpty() && addColors) {

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/UserSpaceMapping.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/UserSpaceMapping.kt
@@ -13,6 +13,12 @@ data class UserSpaceMapping(
         val userId: String?,
 
         @Column(name = "space_uuid")
-        val spaceUuid: String
+        val spaceUuid: String,
+
+        @Column(name = "permission")
+        val permission: String
 
 ) : Auditable()
+
+const val PERMISSION_EDITOR = "editor"
+const val PERMISSION_OWNER = "owner"

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
@@ -18,6 +18,7 @@
 package com.ford.internalprojects.peoplemover.space
 
 import com.ford.internalprojects.peoplemover.auth.AuthInviteUsersToSpaceRequest
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_EDITOR
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.utilities.BasicLogger
@@ -78,7 +79,7 @@ class SpaceController(
         request.emails.forEach { email ->
             val userId = email.substringBefore('@').toUpperCase().trim()
             try {
-                userSpaceMappingRepository.save(UserSpaceMapping(userId = userId, spaceUuid = uuid))
+                userSpaceMappingRepository.save(UserSpaceMapping(userId = userId, spaceUuid = uuid, permission = PERMISSION_EDITOR))
             } catch (e: DataIntegrityViolationException) {
                 logger.logInfoMessage("$userId already has access to this space.")
             } catch (e: Exception) {

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
@@ -17,6 +17,7 @@
 
 package com.ford.internalprojects.peoplemover.space
 
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.product.ProductService
@@ -56,7 +57,8 @@ class SpaceService(
             userSpaceMappingRepository.save(
                 UserSpaceMapping(
                     userId = userId,
-                    spaceUuid = createdSpace.uuid
+                    spaceUuid = createdSpace.uuid,
+                    permission = PERMISSION_OWNER
                 )
             )
             return SpaceResponse(createdSpace)

--- a/api/src/main/resources/db/h2/V001__baseline.sql
+++ b/api/src/main/resources/db/h2/V001__baseline.sql
@@ -110,7 +110,9 @@ create table user_space_mapping
     last_modified_by varchar(30),
     created_date datetime,
     created_by varchar(30),
+    permission varchar(36) NOT NULL default 'editor',
 
     FOREIGN KEY (space_uuid) REFERENCES space (uuid) on delete cascade,
     constraint UQ_User_Space_Mapping unique (user_id, space_uuid)
 );
+

--- a/api/src/main/resources/db/mysql/V014__add_permission_to_user_space_mapping.sql
+++ b/api/src/main/resources/db/mysql/V014__add_permission_to_user_space_mapping.sql
@@ -1,0 +1,4 @@
+ALTER TABLE user_space_mapping ADD COLUMN permission varchar(36) NOT NULL default 'editor';
+
+update user_space_mapping usm inner JOIN space s ON usm.space_uuid = s.uuid AND usm.user_id = s.created_by
+SET usm.permission = 'owner';

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerInTimeApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerInTimeApiTest.kt
@@ -18,6 +18,7 @@
 package com.ford.internalprojects.peoplemover.assignment
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.location.SpaceLocationRepository
@@ -111,7 +112,7 @@ class AssignmentControllerInTimeApiTest {
         unassignedProduct = productRepository.save(Product(name = "unassigned", spaceUuid = editableSpace.uuid))
         person = personRepository.save(Person(name = "Benjamin Britten", newPerson = true, spaceUuid = editableSpace.uuid))
         personInReadOnlySpace = personRepository.save(Person(name = "Arnold Britten", newPerson = true, spaceUuid = readOnlySpace.uuid))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = editableSpace.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = editableSpace.uuid, permission = PERMISSION_OWNER))
     }
 
     @After

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerReassignmentsApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerReassignmentsApiTest.kt
@@ -18,6 +18,7 @@
 package com.ford.internalprojects.peoplemover.assignment
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.location.SpaceLocationRepository
@@ -104,7 +105,7 @@ class AssignmentControllerReassignmentsApiTest {
         person = personRepository.save(Person(name = "Benjamin Britten", newPerson = true, spaceUuid = editableSpace.uuid))
         personTwo = personRepository.save(Person(name = "Joey Britten", newPerson = true, spaceUuid = editableSpace.uuid))
         personInReadOnlySpace = personRepository.save(Person(name = "Wallace Britten", newPerson = true, spaceUuid = editableSpace.uuid))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = editableSpace.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = editableSpace.uuid, permission = PERMISSION_OWNER))
     }
 
     @After

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/auth/AuthControllerTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/auth/AuthControllerTest.kt
@@ -98,7 +98,7 @@ class AuthControllerTest {
 
         val savedSpace = spaceRepository.save(Space(name = "spaceThree", uuid = uuid))
 
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = savedSpace.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = savedSpace.uuid, permission = PERMISSION_OWNER))
 
         val request = AuthCheckScopesRequest(
                 accessToken = accessToken,

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/location/LocationControllerApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/location/LocationControllerApiTest.kt
@@ -18,6 +18,7 @@
 package com.ford.internalprojects.peoplemover.location
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.product.Product
@@ -77,7 +78,7 @@ class LocationControllerApiTest {
         spaceWithoutAccess = spaceRepository.save(Space(name = "tik"))
 
         baseLocationsUrl = getBaseLocationsUrl(space.uuid)
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
 
     }
 

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/person/PersonControllerApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/person/PersonControllerApiTest.kt
@@ -20,6 +20,7 @@ package com.ford.internalprojects.peoplemover.person
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ford.internalprojects.peoplemover.assignment.Assignment
 import com.ford.internalprojects.peoplemover.assignment.AssignmentRepository
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.location.SpaceLocationRepository
@@ -91,7 +92,7 @@ class PersonControllerApiTest {
 
         basePeopleUrl = getBasePeopleUrl(space.uuid)
 
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
     }
 
     @After
@@ -195,7 +196,7 @@ class PersonControllerApiTest {
     @Test
     fun `GET should return an empty set when no people belong to a space`() {
         val emptySpace: Space = spaceRepository.save(Space(name = "ChuckECheese"))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = emptySpace.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = emptySpace.uuid, permission = PERMISSION_OWNER))
 
         val result = mockMvc
                 .perform(get(getBasePeopleUrl(emptySpace.uuid))

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerApiTest.kt
@@ -20,6 +20,7 @@ package com.ford.internalprojects.peoplemover.product
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ford.internalprojects.peoplemover.assignment.Assignment
 import com.ford.internalprojects.peoplemover.assignment.AssignmentRepository
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.location.SpaceLocationRepository
@@ -86,7 +87,7 @@ class ProductControllerApiTest {
         space = spaceRepository.save(Space(name = "tok"))
         spaceWithoutAccess = spaceRepository.save(Space(name = "tik"))
         baseProductsUrl = getBaseProductUrl(space.uuid)
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
     }
 
     @After

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerInTimeApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerInTimeApiTest.kt
@@ -20,6 +20,7 @@ package com.ford.internalprojects.peoplemover.product
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ford.internalprojects.peoplemover.assignment.Assignment
 import com.ford.internalprojects.peoplemover.assignment.AssignmentRepository
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.person.Person
@@ -117,7 +118,7 @@ class ProductControllerInTimeApiTest {
         ))
         baseProductsUrl = getBaseProductsUrl(spaceWithEditAccess.uuid)
 
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = spaceWithEditAccess.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = spaceWithEditAccess.uuid, permission = PERMISSION_OWNER))
 
     }
 

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagControllerTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/producttag/ProductTagControllerTest.kt
@@ -18,6 +18,7 @@
 package com.ford.internalprojects.peoplemover.producttag
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.product.Product
@@ -73,7 +74,7 @@ class ProductTagControllerTest {
     fun setUp() {
         space = spaceRepository.save(Space(name = "anotherSpaceName"))
         baseProductTagsUrl = getBaseProductTagsUrl(space.uuid)
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
     }
 
     @After

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorControllerTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorControllerTest.kt
@@ -20,6 +20,8 @@ package com.ford.internalprojects.peoplemover.report
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ford.internalprojects.peoplemover.assignment.Assignment
 import com.ford.internalprojects.peoplemover.assignment.AssignmentRepository
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_EDITOR
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.person.Person
@@ -103,10 +105,10 @@ class ReportGeneratorControllerTest {
         person1 = personRepository.save(Person(name = "person 1", spaceRole = spaceRole, notes = "Notes", spaceUuid = space1.uuid))
         person2 = personRepository.save(Person(name = "Person 2", spaceUuid = space1.uuid))
         person3 = personRepository.save(Person(name = "Person 3", spaceRole = spaceRole2, spaceUuid = space1.uuid))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space1.uuid))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "SSQUAREP", spaceUuid = space1.uuid))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "PSTAR", spaceUuid = space1.uuid))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "PSTAR", spaceUuid = space2.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space1.uuid, permission = PERMISSION_EDITOR))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "SSQUAREP", spaceUuid = space1.uuid, permission = PERMISSION_OWNER))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "PSTAR", spaceUuid = space1.uuid, permission = PERMISSION_EDITOR))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "PSTAR", spaceUuid = space2.uuid, permission = PERMISSION_OWNER))
         assignmentRepository.save(Assignment(person = person1, productId = productA.id!!, effectiveDate = LocalDate.parse(mar1), spaceUuid = space1.uuid))
         assignmentRepository.save(Assignment(person = person2, productId = productB.id!!, effectiveDate = LocalDate.parse(mar2), spaceUuid = space1.uuid))
         assignmentRepository.save(Assignment(person = person3, productId = productA.id!!, effectiveDate = LocalDate.parse(mar2), spaceUuid = space1.uuid))

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/role/RoleControllerApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/role/RoleControllerApiTest.kt
@@ -18,6 +18,7 @@
 package com.ford.internalprojects.peoplemover.role
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.color.Color
@@ -82,7 +83,7 @@ class RoleControllerApiTest {
         spaceWithoutAccess = spaceRepository.save(Space(name = "tik"))
 
         baseRolesUrl = getBaseRolesUrl(space.uuid)
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
     }
 
     @After

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceControllerApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceControllerApiTest.kt
@@ -97,6 +97,7 @@ class SpaceControllerApiTest {
         assertThat(userSpaceMappings).hasSize(1)
         assertThat(userSpaceMappings[0].userId).isEqualTo(expectedUserId)
         assertThat(userSpaceMappings[0].spaceUuid).isEqualTo(actualSpaceResponse.space.uuid)
+        assertThat(userSpaceMappings[0].permission).isEqualTo(PERMISSION_OWNER)
     }
 
     @Test
@@ -143,8 +144,8 @@ class SpaceControllerApiTest {
         val space2: Space = spaceRepository.save(Space(name = "SpaceTwo"))
         spaceRepository.save(Space(name = "SpaceThree"))
 
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space1.uuid))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space2.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space1.uuid, permission = PERMISSION_OWNER))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space2.uuid, permission = PERMISSION_OWNER))
 
         val accessToken = "TOKEN"
 
@@ -168,7 +169,7 @@ class SpaceControllerApiTest {
     @Test
     fun `GET should return correct space for current user`() {
         val space1: Space = spaceRepository.save(Space(name = "SpaceOne"))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space1.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space1.uuid, permission = PERMISSION_OWNER))
 
         val result = mockMvc.perform(
             get(baseSpaceUrl + "/" + space1.uuid)
@@ -231,7 +232,7 @@ class SpaceControllerApiTest {
     @Test
     fun `Edit Space Request should return 200 if space is edited correctly`() {
         val space = spaceRepository.save(Space(name = "test"))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
         val editedSpace = EditSpaceRequest(name = "edited")
 
         val result = mockMvc.perform(
@@ -256,7 +257,7 @@ class SpaceControllerApiTest {
     @Test
     fun `Edit Space Request should change public view flag correctly`() {
         val space = spaceRepository.save(Space(name = "test", todayViewIsPublic = false))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
         val spaceRequest = EditSpaceRequest(todayViewIsPublic = true)
 
         mockMvc.perform(
@@ -275,7 +276,7 @@ class SpaceControllerApiTest {
     @Test
     fun `Edit Space Request should change both the name and the public view flag correctly`() {
         val space = spaceRepository.save(Space(name = "oldname", todayViewIsPublic = false))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
 
         val expectedName = "newname"
         val expectedReadOnlyFlag = true
@@ -305,7 +306,7 @@ class SpaceControllerApiTest {
                         lastModifiedDate = expectedTimeStamp
                 )
         )
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
 
         val spaceRequest = EditSpaceRequest()
 
@@ -331,7 +332,7 @@ class SpaceControllerApiTest {
     @Test
     fun `Edit Space Request New Space Name is Too Long`() {
         val space = spaceRepository.save(Space(name = "space"))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
 
         val editedSpace = EditSpaceRequest(name = "12345678901234567890123456789012345678901")
 
@@ -363,7 +364,7 @@ class SpaceControllerApiTest {
     fun `Edit Space Request should not change the name of a space if name is null`() {
         val expectedName = "oldname"
         val space = spaceRepository.save(Space(name = expectedName))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
         val editedSpace = EditSpaceRequest(name = null)
 
         mockMvc.perform(
@@ -384,7 +385,7 @@ class SpaceControllerApiTest {
         val emails = listOf("email_1@email.com", "email_2@otheremail.com")
 
         val space = spaceRepository.save(Space(name = "spaceName"))
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = space.uuid, permission = PERMISSION_OWNER))
 
         val request = AuthInviteUsersToSpaceRequest(emails = emails)
 
@@ -399,12 +400,12 @@ class SpaceControllerApiTest {
 
         assertThat(result.response.contentLength).isEqualTo(0)
 
-        val savedIds: List<String> = userSpaceMappingRepository.findAll().map { it.userId!! }
+        val savedIds = userSpaceMappingRepository.findAll().map { Pair(it.userId!!, it.permission)}
 
         assertThat(userSpaceMappingRepository.count()).isEqualTo(3)
-        assertThat(savedIds).contains("USER_ID")
-        assertThat(savedIds).contains("EMAIL_1")
-        assertThat(savedIds).contains("EMAIL_2")
+        assertThat(savedIds).contains(Pair("USER_ID", PERMISSION_OWNER))
+        assertThat(savedIds).contains(Pair("EMAIL_1", PERMISSION_EDITOR))
+        assertThat(savedIds).contains(Pair("EMAIL_2", PERMISSION_EDITOR))
     }
 
     @Test


### PR DESCRIPTION

Co-authored-by: Vianney Willot <vianney.willot@gmail.com>
Co-authored-by: chris dorman <cdorman1@ford.com>

## Issue
Resolves 139
## What was done
- [x] added a permission column to user_space_mapping
- [x] set permission to "owner" when creating space 
- [x] set permission to "editor" when adding people to space 

## How to test
1. create a space and add editor to the space and check the user_space_mapping table and see the permission column
