### PR TITLE
146 placeholder read only bug

### DIFF
--- a/ui/src/Assignments/AssignmentCard.scss
+++ b/ui/src/Assignments/AssignmentCard.scss
@@ -124,19 +124,6 @@ div.Placeholder {
   }
 }
 
-.borderedPeople {
-  border: 1px solid $gray-5;
-}
-
-.borderedPeople:hover {
-  border: 1px solid #FFFFFF;
-}
-
-.borderedPeople .personRoleColor {
-  border-top-right-radius: 1px;
-  border-bottom-right-radius: 1px;
-}
-
 .chrisBoyer {
   cursor: url(https://emoji.slack-edge.com/T56ARKB1Q/cboyer17/6d69a2301aef49de.png), auto;
 }

--- a/ui/src/Assignments/AssignmentCard.tsx
+++ b/ui/src/Assignments/AssignmentCard.tsx
@@ -177,19 +177,37 @@ function AssignmentCard({
             }];
     }
 
-    const classNames = `personContainer 
-        ${container === 'productDrawerContainer' ? 'borderedPeople' : ''}
-        ${!isReadOnly && assignment.placeholder ? 'Placeholder' : 'NotPlaceholder'}
-        ${isReadOnly ? 'readOnlyAssignmentCard' : ''}`;
-
     const cssRoleColor = assignment.person.spaceRole?.color?.color ? assignment.person.spaceRole.color.color : 'transparent';
+
+    const assignmentCardState = (): string => {
+        if (isReadOnly)
+            return 'readOnly';
+        else if (assignment.placeholder)
+            return 'placeholder';
+        else
+            return 'default';
+    };
+
+    let classNameAndRoleColor = {className: '', roleColor: ''};
+    switch (assignmentCardState()) {
+        case 'readOnly':
+            classNameAndRoleColor = {className: 'personContainer NotPlaceholder readOnlyAssignmentCard', roleColor: '1px solid #EDEBEB'};
+            break;
+        case 'placeholder':
+            classNameAndRoleColor = {className: 'personContainer Placeholder', roleColor: `2px solid ${cssRoleColor}`};
+            break;
+        case 'default':
+        default:
+            classNameAndRoleColor = {className: 'personContainer NotPlaceholder', roleColor: '1px solid #EDEBEB'};
+    }
+
 
     return (
         <div
-            className={classNames}
+            className={classNameAndRoleColor.className}
             data-testid={createDataTestId('assignmentCard', assignment.person.name)}
             ref={assignmentRef}
-            style={{border: assignment.placeholder ? `2px solid ${cssRoleColor}` :  '1px solid #EDEBEB' }}
+            style={{border: classNameAndRoleColor.roleColor}}
             onMouseDown={(e): void => {
                 if (!isReadOnly && startDraggingAssignment) {
                     startDraggingAssignment(assignmentRef, assignment, e);

--- a/ui/src/Assignments/AssignmentCard.tsx
+++ b/ui/src/Assignments/AssignmentCard.tsx
@@ -179,28 +179,19 @@ function AssignmentCard({
 
     const cssRoleColor = assignment.person.spaceRole?.color?.color ? assignment.person.spaceRole.color.color : 'transparent';
 
-    const assignmentCardState = (): string => {
-        if (isReadOnly)
-            return 'readOnly';
-        else if (assignment.placeholder)
-            return 'placeholder';
-        else
-            return 'default';
+    let classNameAndRoleColor = {
+        className: 'personContainer NotPlaceholder',
+        roleColor: '1px solid #EDEBEB',
     };
 
-    let classNameAndRoleColor = {className: '', roleColor: ''};
-    switch (assignmentCardState()) {
-        case 'readOnly':
-            classNameAndRoleColor = {className: 'personContainer NotPlaceholder readOnlyAssignmentCard', roleColor: '1px solid #EDEBEB'};
-            break;
-        case 'placeholder':
-            classNameAndRoleColor = {className: 'personContainer Placeholder', roleColor: `2px solid ${cssRoleColor}`};
-            break;
-        case 'default':
-        default:
-            classNameAndRoleColor = {className: 'personContainer NotPlaceholder', roleColor: '1px solid #EDEBEB'};
+    if (isReadOnly) {
+        classNameAndRoleColor.className += ' readOnlyAssignmentCard';
+    } else if (assignment.placeholder) {
+        classNameAndRoleColor = {
+            className: 'personContainer Placeholder',
+            roleColor: `2px solid ${cssRoleColor}`,
+        };
     }
-
 
     return (
         <div

--- a/ui/src/Assignments/AssignmentCard.tsx
+++ b/ui/src/Assignments/AssignmentCard.tsx
@@ -38,7 +38,6 @@ interface AssignmentCardProps {
     currentSpace: Space;
     viewingDate: Date;
     assignment: Assignment;
-    container?: string;
     isUnassignedProduct: boolean;
     isReadOnly: boolean;
 
@@ -53,7 +52,6 @@ function AssignmentCard({
     currentSpace,
     viewingDate,
     assignment = {id: 0} as Assignment,
-    container,
     isUnassignedProduct,
     isReadOnly,
     startDraggingAssignment,

--- a/ui/src/Assignments/AssignmentCardList.tsx
+++ b/ui/src/Assignments/AssignmentCardList.tsx
@@ -26,7 +26,7 @@ import {
     ProductCardRefAndProductPair,
 } from '../Products/ProductDnDHelper';
 import AssignmentCard from '../Assignments/AssignmentCard';
-import {Product} from '../Products/Product';
+import {isUnassignedProduct, Product} from '../Products/Product';
 import {GlobalStateProps} from '../Redux/Reducers';
 import {Assignment} from './Assignment';
 import {CurrentModalState} from '../Redux/Reducers/currentModalReducer';
@@ -34,11 +34,10 @@ import AssignmentClient from './AssignmentClient';
 import {ProductPlaceholderPair} from './CreateAssignmentRequest';
 import moment from 'moment';
 import {AllGroupedTagFilterOptions} from '../ReusableComponents/ProductFilter';
-import { getSelectedFilterLabels } from '../Redux/Reducers/allGroupedTagOptionsReducer';
+import {getSelectedFilterLabels} from '../Redux/Reducers/allGroupedTagOptionsReducer';
 import {Space} from '../Space/Space';
 
 interface AssignmentCardListProps {
-    container: string;
     product: Product;
     productRefs: Array<ProductCardRefAndProductPair>;
     currentSpace: Space;
@@ -50,7 +49,6 @@ interface AssignmentCardListProps {
 }
 
 function AssignmentCardList({
-    container,
     product,
     productRefs,
     currentSpace,
@@ -221,24 +219,21 @@ function AssignmentCardList({
         }
     }
 
-    function containerClass(container: string): string {
-        return container === 'productDrawerContainer' ? 'unassignedPeopleContainer' : 'productPeopleContainer';
-    }
+    const classNameAndDataTestId = isUnassignedProduct(product) ? 'unassignedPeopleContainer' : 'productPeopleContainer';
 
     return (
         <React.Fragment>
             <div className="antiHighlightCover" ref={antiHighlightCoverRef}/>
             <div
-                className={containerClass(container)}
-                data-testid={containerClass(container)}>
+                className={classNameAndDataTestId}
+                data-testid={classNameAndDataTestId}>
                 {assignmentsSortedByPersonRoleStably()
                     .filter(filterAssignmentByRole)
                     .map((assignment: Assignment) =>
                         <AssignmentCard assignment={assignment}
-                            isUnassignedProduct={product.name === 'unassigned'}
+                            isUnassignedProduct={isUnassignedProduct(product)}
                             startDraggingAssignment={startDraggingAssignment}
                             key={assignment.id}
-                            container={container}
                         />
                     )}
             </div>

--- a/ui/src/Assignments/UnassignedDrawer.tsx
+++ b/ui/src/Assignments/UnassignedDrawer.tsx
@@ -38,8 +38,7 @@ function UnassignedDrawer({
     product,
 }: UnassignedDrawerProps): JSX.Element {
     const containee =
-        <ProductCard product={product}
-            container={'productDrawerContainer'}/>;
+        <ProductCard product={product} />;
     return (
         <DrawerContainer
             drawerIcon="supervisor_account"

--- a/ui/src/Products/Product.ts
+++ b/ui/src/Products/Product.ts
@@ -47,3 +47,9 @@ export function emptyProduct(spaceUuid?: string): Product {
         assignments: [],
     };
 }
+
+const unassignedProductName = 'unassigned';
+
+export function isUnassignedProduct(product: Product): boolean {
+    return product.name === unassignedProductName;
+}

--- a/ui/src/Products/ProductCard.tsx
+++ b/ui/src/Products/ProductCard.tsx
@@ -27,7 +27,7 @@ import {
 import EditMenu, {EditMenuOption} from '../ReusableComponents/EditMenu';
 import ProductClient from './ProductClient';
 import {ProductCardRefAndProductPair} from './ProductDnDHelper';
-import {Product} from './Product';
+import {isUnassignedProduct, Product} from './Product';
 import {GlobalStateProps} from '../Redux/Reducers';
 import {CurrentModalState} from '../Redux/Reducers/currentModalReducer';
 import {AxiosResponse} from 'axios';
@@ -39,7 +39,6 @@ import {createDataTestId} from '../tests/TestUtils';
 import './Product.scss';
 
 interface ProductCardProps {
-    container: string;
     product: Product;
     currentSpace: Space;
     viewingDate: Date;
@@ -52,7 +51,6 @@ interface ProductCardProps {
 }
 
 function ProductCard({
-    container,
     product,
     currentSpace,
     viewingDate,
@@ -151,10 +149,12 @@ function ProductCard({
             : <></>;
     };
 
+    const classNameAndDataTestId = isUnassignedProduct(product) ? 'productDrawerContainer' : 'productCardContainer';
+
     return (
-        <div className={container} data-testid={createDataTestId(container, product.name)} ref={productRef}>
+        <div className={classNameAndDataTestId} data-testid={createDataTestId(classNameAndDataTestId, product.name)} ref={productRef}>
             <div key={product.name}>
-                {container === 'productCardContainer' && (
+                {!isUnassignedProduct(product) && (
                     <div>
                         <div className="productNameEditContainer">
                             <div className="productDetails">
@@ -198,7 +198,7 @@ function ProductCard({
                         )}
                     </div>
                 )}
-                <AssignmentCardList container={container} product={product} />
+                <AssignmentCardList product={product} />
             </div>
         </div>
     );

--- a/ui/src/Products/ProductListGrouped.tsx
+++ b/ui/src/Products/ProductListGrouped.tsx
@@ -106,9 +106,7 @@ function GroupedByList({
                         <div className="groupedProducts">
                             {filteredProducts.map(product => (
                                 <span key={product.id}>
-                                    <ProductCard
-                                        product={product}
-                                        container="productCardContainer"/>
+                                    <ProductCard product={product} />
                                 </span>
                             ))}
                             <NewProductButton modalState={modalState}/>

--- a/ui/src/Products/ProductListSorted.tsx
+++ b/ui/src/Products/ProductListSorted.tsx
@@ -64,9 +64,7 @@ function SortedByList({ products, productSortBy}: Props): JSX.Element {
             {sortedProducts && sortedProducts.map((product: Product) => {
                 return (
                     <span key={product.id}>
-                        <ProductCard
-                            product={product}
-                            container="productCardContainer"/>
+                        <ProductCard product={product} />
                     </span>
                 );
             })}


### PR DESCRIPTION
## Issue
Resolves 146

## What was done
- [x] Fix bug, Placeholder outline showing up in View Only

## How to test
1. Create a space that has a person that is a placeholder and a person that is not a placeholder
2. Enable view-only on the space
3. Copy link
4. Have another person use that link to look at the space. the placeholder and non-placeholder person should appear identical. 

## Accessiblity Criteria

- [ ] Text and background color meets a minimum color contrast ratio of 4.5:1
- [ ] All non-text content (e.g. images, icon) has alt text
- [ ] Web page includes appropriate headings to communicate structure/hierarchy (h1>h2>h3)
- [ ] All functionality is available to a keyboard
  - [ ] Focus styles are highly visible 
  - [ ] Tab order is logical and aligns with the visual order 
- [ ] Voice over is understandable and logical
  - [ ] Aria labels are added to elements with no visible text 
  - [ ] Decorative elements (e.g. non-informative icons) are hidden from screen readers  
- [ ] Form fields have appropriately coded labels that are visible during input 
- [ ] Links are visually identifiable and have a clear focus and active state 
