### PR TITLE
100 label editors and owners

### DIFF
--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/LocalDataGenerator.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/LocalDataGenerator.kt
@@ -3,7 +3,7 @@ package com.ford.internalprojects.peoplemover
 import com.ford.internalprojects.peoplemover.assignment.AssignmentService
 import com.ford.internalprojects.peoplemover.assignment.CreateAssignmentsRequest
 import com.ford.internalprojects.peoplemover.assignment.ProductPlaceholderPair
-import com.ford.internalprojects.peoplemover.auth.PERMISSION_EDITOR
+import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import com.ford.internalprojects.peoplemover.color.ColorService
@@ -65,7 +65,7 @@ class LocalDataGenerator(
         )
         productService.createDefaultProducts(createdSpace);
 
-        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = createdSpace.uuid, permission = PERMISSION_EDITOR))
+        userSpaceMappingRepository.save(UserSpaceMapping(userId = "USER_ID", spaceUuid = createdSpace.uuid, permission = PERMISSION_OWNER))
 
         var colors = colorService.getColors()
         if (colors.isEmpty() && addColors) {

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
@@ -67,6 +67,8 @@ class SpaceController(
         return spaceService.getSpacesForUser(accessToken.replace("Bearer ", ""))
     }
 
+    // todo: Remove this endpoint
+    @Deprecated("No longer used. Use /{uuid}/users instead")
     @PreAuthorize("hasPermission(#uuid, 'modify')")
     @GetMapping("/{uuid}/editors")
     fun getAllEditors(@PathVariable uuid: String): List<String> {

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
@@ -73,6 +73,12 @@ class SpaceController(
         return spaceService.getEditorsForSpace(uuid)
     }
 
+    @PreAuthorize("hasPermission(#uuid, 'modify')")
+    @GetMapping("/{uuid}/users")
+    fun getAllUsers(@PathVariable uuid: String): List<UserSpaceMapping> {
+        return spaceService.getUsersForSpace(uuid)
+    }
+
 
     @PreAuthorize("hasPermission(#uuid, 'modify')")
     @PutMapping("/{uuid}:invite")

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
@@ -106,4 +106,8 @@ class SpaceService(
             }
         }.toList()
     }
+
+    fun getUsersForSpace(uuid: String): List<UserSpaceMapping> {
+        return userSpaceMappingRepository.findAllBySpaceUuid(uuid)
+    }
 }

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
@@ -95,6 +95,8 @@ class SpaceService(
         return spacesForUser.contains(spaceUuid)
     }
 
+    // todo: Remove this service call
+    @Deprecated("No longer used. Use getUserForSpace instead")
     fun getEditorsForSpace(uuid: String): List<String> {
         val userSpaceMappings: List<UserSpaceMapping> = userSpaceMappingRepository.findAllBySpaceUuid(uuid)
 

--- a/ui/cypress/e2e/share_access_form.test.js
+++ b/ui/cypress/e2e/share_access_form.test.js
@@ -63,7 +63,7 @@ describe('Share Access Form', () => {
             const spaceUuid = Cypress.env('SPACE_UUID');
             const baseUrl = Cypress.config().baseUrl;
 
-            cy.get('[data-testid=editorId]').eq(0).should('contain.text', 'USER_ID');
+            cy.get('[data-testid=userIdName]').eq(0).should('contain.text', 'USER_ID');
 
             cy.get('[data-testid=inviteEditorsFormEmailTextarea]').focus().clear().type('aaaaaa');
             cy.get('.primaryButton').should('be.disabled');
@@ -93,8 +93,10 @@ describe('Share Access Form', () => {
             openShareAccessForm();
             expandInviteToEditModalCard();
 
-            cy.get('[data-testid=editorId]').eq(0).should('contain.text', 'USER_ID');
-            cy.get('[data-testid=editorId]').eq(1).should('contain.text', 'ELISE');
+            cy.get('[data-testid=userIdName]').eq(0).should('contain.text', 'USER_ID');
+            cy.get('[data-testid=userIdPermission]').eq(0).should('contain.text', 'owner');
+            cy.get('[data-testid=userIdName]').eq(1).should('contain.text', 'ELISE');
+            cy.get('[data-testid=userIdPermission]').eq(1).should('contain.text', 'editor');
         });
     });
 });

--- a/ui/src/AccountDropdown/InviteEditorsFormSection.scss
+++ b/ui/src/AccountDropdown/InviteEditorsFormSection.scss
@@ -44,7 +44,7 @@
     font-size: 14px;
     line-height: 16px;
     min-height: 32px;
-    height: 64px;
+    height: 36px;
     width: 100%;
     box-sizing: border-box;
     resize: vertical;
@@ -60,22 +60,38 @@
     }
   }
 
-  .editorList {
+  .userList {
     padding-left: 0;
     margin-top: 0;
     margin-bottom: 2rem;
 
-    .editorListItem {
+    .userListItem {
       list-style: none;
       display: flex;
       align-items: center;
       font-size: 1rem;
       color: $gray-1;
-      text-transform: lowercase;
       margin-bottom: 1rem;
 
       .editorIcon {
         margin-right: 0.75rem;
+      }
+
+      .userName {
+        width: 19rem;
+        justify-content: left;
+        text-transform: lowercase;
+      }
+
+      .userPermission {
+        width: 3rem;
+        justify-content: right;
+        text-transform: capitalize;
+        font-size: 14px;
+      }
+
+      .editorCaret {
+        width: 1.2rem;
       }
     }
   }

--- a/ui/src/AccountDropdown/InviteEditorsFormSection.test.tsx
+++ b/ui/src/AccountDropdown/InviteEditorsFormSection.test.tsx
@@ -27,9 +27,11 @@ describe('Invite Editors Form', function() {
         TestUtils.mockClientCalls();
     });
 
-    it('should show editors for the space', async function() {
+    it('should show owners and editors for the space', async function() {
         const component = renderWithRedux(<InviteEditorsFormSection/>, undefined, {currentSpace: TestUtils.space} as GlobalStateProps);
         await component.findByText('user_id');
+        await component.findByText('owner');
         await component.findByText('user_id_2');
+        await component.findByText('editor');
     });
 });

--- a/ui/src/Space/SpaceClient.test.tsx
+++ b/ui/src/Space/SpaceClient.test.tsx
@@ -102,10 +102,10 @@ describe('Space Client', function() {
         });
     });
 
-    it('should get all the editors for a space', function(done) {
-        const expectedUrl = baseSpaceUrl + '/uuidbob/editors';
+    it('should get all the users for a space', function(done) {
+        const expectedUrl = baseSpaceUrl + '/uuidbob/users';
 
-        SpaceClient.getEditorsForSpace('uuidbob').then(() => {
+        SpaceClient.getUsersForSpace('uuidbob').then(() => {
             expect(Axios.get).toHaveBeenCalledWith(expectedUrl, expectedConfig);
             done();
         });

--- a/ui/src/Space/SpaceClient.ts
+++ b/ui/src/Space/SpaceClient.ts
@@ -19,6 +19,7 @@ import Axios, {AxiosResponse} from 'axios';
 import {Space} from './Space';
 import {SpaceWithAccessTokenResponse} from './SpaceWithAccessTokenResponse';
 import {getToken} from '../Auth/TokenProvider';
+import {UserSpaceMapping} from './UserSpaceMapping';
 import MatomoEvents from '../Matomo/MatomoEvents';
 
 const baseSpaceUrl = `/api/spaces`;
@@ -49,8 +50,9 @@ class SpaceClient {
         return Axios.get(url, config);
     }
 
-    static async getEditorsForSpace(spaceUuid: string): Promise<AxiosResponse<string[]>> {
-        const url = `${baseSpaceUrl}/${spaceUuid}/editors`;
+
+    static async getUsersForSpace(spaceUuid: string): Promise<AxiosResponse<UserSpaceMapping[]>> {
+        const url = `${baseSpaceUrl}/${spaceUuid}/users`;
         const config = {
             headers: {
                 'Content-Type': 'application/json',

--- a/ui/src/Space/UserSpaceMapping.ts
+++ b/ui/src/Space/UserSpaceMapping.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface UserSpaceMapping {
+    id: string;
+    userId: string;
+    permission: string;
+    spaceUuid: string;
+}

--- a/ui/src/tests/TestUtils.tsx
+++ b/ui/src/tests/TestUtils.tsx
@@ -131,8 +131,8 @@ class TestUtils {
             data: TestUtils.space,
         } as AxiosResponse));
 
-        SpaceClient.getEditorsForSpace = jest.fn(() => Promise.resolve({
-            data: ['user_id', 'user_id_2'],
+        SpaceClient.getUsersForSpace = jest.fn(() => Promise.resolve({
+            data: [{'userId': 'user_id_2', 'permission': 'editor'}, {'userId': 'user_id', 'permission': 'owner'}],
         } as AxiosResponse));
 
         AssignmentClient.createAssignmentForDate = jest.fn(() => Promise.resolve({


### PR DESCRIPTION
## Issue
Resolves 100

## What was done
- [x] Add endpoint to support getting user and their permission on a given space
- [x] On the UI, show the users of a space and their permissions

## How to test
1. Open Share Access modal
2. Expand 'Invite others to edit'
3. The owner of the space should be listed as 'Owner' (and no caret next to it)
4. Add an editor (or two)
5. Reopen Share Access modal
6. The owner and editors of the space should be listed as 'Owner' or 'Editor'. All of the editors should have a caret next to them (The caret doesn't do anything yet. That will be the next story.)

## Accessiblity Criteria

- [ ] Text and background color meets a minimum color contrast ratio of 4.5:1
- [ ] All non-text content (e.g. images, icon) has alt text
- [ ] Web page includes appropriate headings to communicate structure/hierarchy (h1>h2>h3)
- [ ] All functionality is available to a keyboard
  - [ ] Focus styles are highly visible 
  - [ ] Tab order is logical and aligns with the visual order 
- [ ] Voice over is understandable and logical
  - [ ] Aria labels are added to elements with no visible text 
  - [ ] Decorative elements (e.g. non-informative icons) are hidden from screen readers  
- [ ] Form fields have appropriately coded labels that are visible during input 
- [ ] Links are visually identifiable and have a clear focus and active state 
