### PR TITLE
Add link to skip to first product

### DIFF
--- a/ui/src/Application/PeopleMover.scss
+++ b/ui/src/Application/PeopleMover.scss
@@ -156,3 +156,22 @@ button.addPersonButton {
     border: 2px solid white;
   }
 }
+
+.skipToProducts {
+  z-index: 9;
+  position: absolute;
+  margin: 5px;
+  border: 2px solid transparent;
+  padding: 26px;
+  background: $prime-1;
+  border-radius: 6px;
+  font: 18px Helvetica, sans-serif;
+  color: white;
+  text-decoration: none;
+
+  transform: translateX(-120%);
+  &:focus {
+    transform: translateX(0%);
+    border: 2px solid white;
+  }
+}

--- a/ui/src/Application/PeopleMover.tsx
+++ b/ui/src/Application/PeopleMover.tsx
@@ -160,10 +160,11 @@ function PeopleMover({
         !hasProducts()
             ? <></>
             : <div className="App">
+                <a href="#product-container" className="skipToProducts" data-testid="skipToContentLink">Skip to main content</a>
                 <Header/>
                 <main>
                     {NEW_UI ? <SubHeader/> : <SpaceSelectionTabs/>}
-                    <div className="productAndAccordionContainer">
+                    <div className="productAndAccordionContainer" id="product-container">
                         <ProductList/>
                         {!isReadOnly && (
                             <div className="accordionContainer">


### PR DESCRIPTION
Co-authored-by: Max Wilkinson <mawilkin@umich.edu>
Co-authored-by: Chris Atkinson <christopher.w.atkinson.1989@gmail.com>

## Issue
Resolves 103

## What was done
- [x] Created a link to the product container that is hidden until focused
- [x] Investigated writing a UI test for this 

## How to test
1. Go to a space
2. Press "Tab" once
3. Press "Enter"
4. Press "Tab" again
5. Observe which component is focused

## Accessiblity Criteria

- [x] All functionality is available to a keyboard
  - [x] Focus styles are highly visible 
  - [x] Tab order is logical and aligns with the visual order 
- [x] Voice over is understandable and logical
- [x] Links are visually identifiable and have a clear focus and active state 

## Notes
We investigated writing a cypress test for this, but tab functionality in Cypress still does not exist - there's been [an open ticket in Cypress since 2016](https://github.com/cypress-io/cypress/issues/299) that they claim they're still working on...