### PR TITLE
149 make delete accessible

### DIFF
--- a/ui/src/Application/PeopleMover.scss
+++ b/ui/src/Application/PeopleMover.scss
@@ -115,9 +115,7 @@ textarea:focus {
 }
 
 // Use box shadow to make focus ring for all buttons, inputs, selects and textareas except in React Select Library
-:not([class*="css-"]) > div > *:focus,
-:not([class*="css-"]) > span > *:focus,
-{
+:not([class*="css-"]) > * > *:focus {
   box-shadow: 0 0 0 2px $outline-focus-blue;
 }
 

--- a/ui/src/Modal/Form.scss
+++ b/ui/src/Modal/Form.scss
@@ -28,6 +28,8 @@
 
 .formContainer {
     margin: auto;
+    display: flex;
+    flex-direction: column;
 }
 
 .formItem {

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -325,7 +325,7 @@ function PersonForm({
                     data-testid="deletePersonButton"
                     onClick={displayRemovePersonModal}
                 >
-                    <i className="material-icons">delete</i>
+                    <i className="material-icons" aria-hidden>delete</i>
                     <div className="trashCanSpacer"/>
                     <span className="obliterateLink">
                             Delete

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -250,7 +250,13 @@ function PersonForm({
     };
 
     function handleKeyDownForDisplayRemovePersonModal(event: React.KeyboardEvent): void {
+        event.preventDefault();
         if (event.key === 'Enter') displayRemovePersonModal();
+    }
+
+    function handleMouseClickForDisplayRemovePersonModal(event: React.MouseEvent): void {
+        event.preventDefault();
+        displayRemovePersonModal();
     }
 
     return (
@@ -323,13 +329,14 @@ function PersonForm({
                     </FormButton>
                 </div>
                 {isEditPersonForm && (
-                    <button className="deleteButtonContainer alignSelfCenter deleteLinkColor">
+                    <button className="deleteButtonContainer alignSelfCenter deleteLinkColor"
+                        data-testid="deletePersonButton"
+                        onClick={handleMouseClickForDisplayRemovePersonModal}
+                        onKeyDown={handleKeyDownForDisplayRemovePersonModal}
+                    >
                         <i className="material-icons">delete</i>
                         <div className="trashCanSpacer"/>
-                        <span className="obliterateLink"
-                            data-testid="deletePersonButton"
-                            onClick={displayRemovePersonModal}
-                            onKeyDown={handleKeyDownForDisplayRemovePersonModal}>
+                        <span className="obliterateLink">
                             Delete
                         </span>
                     </button>

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -323,7 +323,7 @@ function PersonForm({
                     </FormButton>
                 </div>
                 {isEditPersonForm && (
-                    <div className="deleteButtonContainer alignSelfCenter deleteLinkColor">
+                    <button className="deleteButtonContainer alignSelfCenter deleteLinkColor">
                         <i className="material-icons">delete</i>
                         <div className="trashCanSpacer"/>
                         <span className="obliterateLink"
@@ -332,7 +332,7 @@ function PersonForm({
                             onKeyDown={handleKeyDownForDisplayRemovePersonModal}>
                             Delete
                         </span>
-                    </div>
+                    </button>
                 )}
             </form>
             {confirmDeleteModal}

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -249,16 +249,6 @@ function PersonForm({
         return filteredProducts.map(selectable => {return {value: selectable.name, label: selectable.name};});
     };
 
-    function handleKeyDownForDisplayRemovePersonModal(event: React.KeyboardEvent): void {
-        event.preventDefault();
-        if (event.key === 'Enter') displayRemovePersonModal();
-    }
-
-    function handleMouseClickForDisplayRemovePersonModal(event: React.MouseEvent): void {
-        event.preventDefault();
-        displayRemovePersonModal();
-    }
-
     return (
         <div className="formContainer">
             <form className="form"
@@ -328,20 +318,20 @@ function PersonForm({
                         {isEditPersonForm ? 'Save' : 'Add'}
                     </FormButton>
                 </div>
-                {isEditPersonForm && (
-                    <button className="deleteButtonContainer alignSelfCenter deleteLinkColor"
-                        data-testid="deletePersonButton"
-                        onClick={handleMouseClickForDisplayRemovePersonModal}
-                        onKeyDown={handleKeyDownForDisplayRemovePersonModal}
-                    >
-                        <i className="material-icons">delete</i>
-                        <div className="trashCanSpacer"/>
-                        <span className="obliterateLink">
-                            Delete
-                        </span>
-                    </button>
-                )}
             </form>
+
+            {isEditPersonForm && (
+                <button className="deleteButtonContainer alignSelfCenter deleteLinkColor"
+                    data-testid="deletePersonButton"
+                    onClick={displayRemovePersonModal}
+                >
+                    <i className="material-icons">delete</i>
+                    <div className="trashCanSpacer"/>
+                    <span className="obliterateLink">
+                            Delete
+                    </span>
+                </button>
+            )}
             {confirmDeleteModal}
         </div>
     );

--- a/ui/src/Products/ProductForm.scss
+++ b/ui/src/Products/ProductForm.scss
@@ -63,6 +63,7 @@
 .deleteButtonContainer {
   display: flex;
   margin-top: 32px;
+  background-color: $white;
 }
 
 #start,

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -180,18 +180,6 @@ function ProductForm({
         updateProductField('notes', notes);
     }
 
-    function handleKeyDownForDisplayDeleteProductModal(event: React.KeyboardEvent): void {
-        event.preventDefault();
-        if (event.key === 'Enter') {
-            displayDeleteProductModal();
-        }
-    }
-
-    function handleMouseClickForDisplayRemovePersonModal(event: React.MouseEvent): void {
-        event.preventDefault();
-        displayDeleteProductModal();
-    }
-
     return currentSpace.uuid ? (
         <div className="formContainer">
             <form className="form"
@@ -252,17 +240,16 @@ function ProductForm({
                         {editing ? 'Save' : 'Add'}
                     </FormButton>
                 </div>
-                {editing && (
-                    <button className={'deleteButtonContainer alignSelfCenter deleteLinkColor'}
-                        data-testid="deleteProduct"
-                        onClick={handleMouseClickForDisplayRemovePersonModal}
-                        onKeyDown={handleKeyDownForDisplayDeleteProductModal}
-                    >
-                        <i className="material-icons">delete</i>
-                        <div className="trashCanSpacer"/>
-                        <span className="obliterateLink">Delete Product</span>
-                    </button>)}
             </form>
+            {editing && (
+                <button className={'deleteButtonContainer alignSelfCenter deleteLinkColor'}
+                    data-testid="deleteProduct"
+                    onClick={displayDeleteProductModal}
+                >
+                    <i className="material-icons">delete</i>
+                    <div className="trashCanSpacer"/>
+                    <span className="obliterateLink">Delete Product</span>
+                </button>)}
             {confirmDeleteModal}
         </div>
     ) : <></>;

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -247,14 +247,14 @@ function ProductForm({
                     </FormButton>
                 </div>
                 {editing && (
-                    <div className={'deleteButtonContainer alignSelfCenter deleteLinkColor'}>
+                    <button className={'deleteButtonContainer alignSelfCenter deleteLinkColor'}>
                         <i className="material-icons">delete</i>
                         <div className="trashCanSpacer"/>
                         <span className="obliterateLink"
                             data-testid="deleteProduct"
                             onClick={displayDeleteProductModal}
                             onKeyDown={(e): void => handleKeyDownForDisplayDeleteProductModal(e)}>Delete Product</span>
-                    </div>)}
+                    </button>)}
             </form>
             {confirmDeleteModal}
         </div>

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -181,9 +181,15 @@ function ProductForm({
     }
 
     function handleKeyDownForDisplayDeleteProductModal(event: React.KeyboardEvent): void {
+        event.preventDefault();
         if (event.key === 'Enter') {
             displayDeleteProductModal();
         }
+    }
+
+    function handleMouseClickForDisplayRemovePersonModal(event: React.MouseEvent): void {
+        event.preventDefault();
+        displayDeleteProductModal();
     }
 
     return currentSpace.uuid ? (
@@ -247,13 +253,14 @@ function ProductForm({
                     </FormButton>
                 </div>
                 {editing && (
-                    <button className={'deleteButtonContainer alignSelfCenter deleteLinkColor'}>
+                    <button className={'deleteButtonContainer alignSelfCenter deleteLinkColor'}
+                        data-testid="deleteProduct"
+                        onClick={handleMouseClickForDisplayRemovePersonModal}
+                        onKeyDown={handleKeyDownForDisplayDeleteProductModal}
+                    >
                         <i className="material-icons">delete</i>
                         <div className="trashCanSpacer"/>
-                        <span className="obliterateLink"
-                            data-testid="deleteProduct"
-                            onClick={displayDeleteProductModal}
-                            onKeyDown={(e): void => handleKeyDownForDisplayDeleteProductModal(e)}>Delete Product</span>
+                        <span className="obliterateLink">Delete Product</span>
                     </button>)}
             </form>
             {confirmDeleteModal}

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -246,7 +246,7 @@ function ProductForm({
                     data-testid="deleteProduct"
                     onClick={displayDeleteProductModal}
                 >
-                    <i className="material-icons">delete</i>
+                    <i className="material-icons" aria-hidden>delete</i>
                     <div className="trashCanSpacer"/>
                     <span className="obliterateLink">Delete Product</span>
                 </button>)}

--- a/ui/src/tests/ProductList.test.tsx
+++ b/ui/src/tests/ProductList.test.tsx
@@ -16,8 +16,6 @@
  */
 
 import React from 'react';
-import {act, fireEvent, RenderResult} from '@testing-library/react';
-import PeopleMover from '../Application/PeopleMover';
 import TestUtils, {renderWithRedux} from './TestUtils';
 import {AxiosResponse} from 'axios';
 import ProductClient from '../Products/ProductClient';
@@ -25,26 +23,16 @@ import ProductList from '../Products/ProductList';
 import {GlobalStateProps} from '../Redux/Reducers';
 import moment from 'moment';
 import {Product} from '../Products/Product';
-import {createBrowserHistory} from 'history';
-import {Router} from 'react-router-dom';
 
 describe('Product List tests', () => {
-    let app: RenderResult;
-    let initialState: GlobalStateProps;
 
     beforeEach(async () => {
         jest.clearAllMocks();
         TestUtils.mockClientCalls();
 
-        ProductClient.getProductsForDate = jest.fn(() => Promise.resolve(
-            {
-                data: TestUtils.products,
-            } as AxiosResponse
-        ));
-
-        initialState = {
-            currentSpace: TestUtils.space,
-        } as GlobalStateProps;
+        ProductClient.getProductsForDate = jest.fn(() =>
+            Promise.resolve({ data: TestUtils.products } as AxiosResponse)
+        );
     });
 
     describe('Product list test filtering', () => {


### PR DESCRIPTION
## Issue
Resolves 149

## What was done
- [x] Change delete from a div to a button, change style so button gets the proper outline

## How to test
1. Open space with a product. 
2. Edit product
3. Tab through fields. The Delete at the bottom of the modal is now part of the tab order
4. Repeat the test for Edit Person. That Delete is also now part of the tab order

## Accessiblity Criteria
### Testing
- [ ] Add jest-axe unit tests (for new ui components)

### Manual Checks
- [ ] Text and background color meets a minimum color contrast ratio of 4.5:1
- [ ] All non-text content (e.g. images, icon) has alt text
- [ ] Web page includes appropriate headings to communicate structure/hierarchy (h1>h2>h3)
- [ ] All functionality is available to a keyboard
  - [ ] Focus styles are highly visible 
  - [x] Tab order is logical and aligns with the visual order 
- [ ] Voice over is understandable and logical
  - [ ] Aria labels are added to elements with no visible text 
  - [ ] Decorative elements (e.g. non-informative icons) are hidden from screen readers  
- [ ] Form fields have appropriately coded labels that are visible during input 
- [ ] Links are visually identifiable and have a clear focus and active state 
