### PR TITLE
109 owner confirmation modal

### DIFF
--- a/ui/cypress/e2e/share_access_form.test.js
+++ b/ui/cypress/e2e/share_access_form.test.js
@@ -137,6 +137,8 @@ describe('Share Access Form', () => {
             cy.get('[data-testid=userAccessOptionLabel]').eq(1).should('contain.text', 'Owner')
                 .click();
 
+            cy.get('[data-testid=confirmDeleteButton]').should('contain.text', 'Yes').click();
+
             cy.wait('@putChangeOwner')
                 .should((xhrs) => {
                     expect(xhrs.status).to.equal(200);

--- a/ui/src/AccountDropdown/InviteEditorsFormSection.test.tsx
+++ b/ui/src/AccountDropdown/InviteEditorsFormSection.test.tsx
@@ -19,7 +19,7 @@ import TestUtils, {renderWithRedux} from '../tests/TestUtils';
 import React from 'react';
 import InviteEditorsFormSection from './InviteEditorsFormSection';
 import {GlobalStateProps} from '../Redux/Reducers';
-import {findByText, fireEvent, wait} from '@testing-library/dom';
+import {fireEvent, wait} from '@testing-library/dom';
 import {act} from 'react-dom/test-utils';
 import Axios, {AxiosResponse} from 'axios';
 import Cookies from 'universal-cookie';

--- a/ui/src/Modal/ConfirmationModal.tsx
+++ b/ui/src/Modal/ConfirmationModal.tsx
@@ -20,18 +20,18 @@ import FormButton from '../ModalFormComponents/FormButton';
 import ModalCardBanner from './ModalCardBanner';
 
 export interface ConfirmationModalProps {
-    submit(itemToDelete?: unknown): void | Promise<void>;
+    submit(item?: unknown): void | Promise<void>;
     close(): void;
     submitButtonLabel?: string;
     title?: string;
-    content?: JSX.Element;
+    content: JSX.Element;
     secondaryButton?: JSX.Element;
 }
 
 function ConfirmationModal({
     submit,
     close,
-    submitButtonLabel,
+    submitButtonLabel = 'Delete',
     title = 'Are you sure?',
     content,
     secondaryButton,
@@ -42,7 +42,7 @@ function ConfirmationModal({
             onClick={submit}
             buttonStyle="primary"
             testId="confirmDeleteButton">
-            {submitButtonLabel ? submitButtonLabel : 'Delete'}
+            {submitButtonLabel}
         </FormButton>
     );
 

--- a/ui/src/Modal/ConfirmationModal.tsx
+++ b/ui/src/Modal/ConfirmationModal.tsx
@@ -21,42 +21,26 @@ import ModalCardBanner from './ModalCardBanner';
 
 export interface ConfirmationModalProps {
     submit(itemToDelete?: unknown): void | Promise<void>;
-    archiveCallback?(): void;
     close(): void;
-
-    canArchive?: boolean;
-    isArchived?: boolean;
     submitButtonLabel?: string;
     content?: JSX.Element;
+    secondaryButton?: JSX.Element;
 }
 
 function ConfirmationModal({
     submit,
-    archiveCallback,
     close,
-    canArchive,
-    isArchived,
     submitButtonLabel,
     content,
+    secondaryButton,
 }: ConfirmationModalProps): JSX.Element {
-    const isArchivable = (): boolean => Boolean(canArchive && !isArchived);
-    
-    const DeleteButton = (): JSX.Element => (
+    const SubmitButton = (): JSX.Element => (
         <FormButton
             className="confirmationModalDelete"
             onClick={submit}
             buttonStyle="primary"
             testId="confirmDeleteButton">
             {submitButtonLabel ? submitButtonLabel : 'Delete'}
-        </FormButton>
-    );
-    
-    const ArchiveButton = (): JSX.Element => (
-        <FormButton
-            buttonStyle="secondary"
-            testId="confirmationModalArchive"
-            onClick={archiveCallback}>
-            Archive
         </FormButton>
     );
 
@@ -80,12 +64,12 @@ function ConfirmationModal({
                     <div className="confirmationModalContent">
                         {content}
                     </div>
-                    <div className={`yesNoButtons confirmationControlButtons confirmationModalControls ${canArchive ? 'archivable' : ''}`}>
-                        <div className={`cancelAndArchiveContainer ${isArchivable() ? 'archivable' : ''}`}>
+                    <div className={`yesNoButtons confirmationControlButtons confirmationModalControls ${secondaryButton ? 'secondaryButtonContainer' : ''}`}>
+                        <div className={`cancelAndArchiveContainer ${secondaryButton ? 'secondaryButtonContainer' : ''}`}>
                             <CancelButton />
-                            {isArchivable() && <ArchiveButton />}
+                            {secondaryButton}
                         </div>
-                        <DeleteButton />
+                        <SubmitButton />
                     </div>
                 </div>
             </div>

--- a/ui/src/Modal/ConfirmationModal.tsx
+++ b/ui/src/Modal/ConfirmationModal.tsx
@@ -23,6 +23,7 @@ export interface ConfirmationModalProps {
     submit(item?: unknown): void | Promise<void>;
     close(): void;
     submitButtonLabel?: string;
+    closeButtonLabel?: string;
     title?: string;
     content: JSX.Element;
     secondaryButton?: JSX.Element;
@@ -32,6 +33,7 @@ function ConfirmationModal({
     submit,
     close,
     submitButtonLabel = 'Delete',
+    closeButtonLabel = 'Cancel',
     title = 'Are you sure?',
     content,
     secondaryButton,
@@ -51,7 +53,7 @@ function ConfirmationModal({
             buttonStyle="secondary"
             testId="confirmationModalCancel"
             onClick={close}>
-            Cancel
+            {closeButtonLabel}
         </FormButton>
     );
 

--- a/ui/src/Modal/ConfirmationModal.tsx
+++ b/ui/src/Modal/ConfirmationModal.tsx
@@ -26,7 +26,6 @@ export interface ConfirmationModalProps {
 
     canArchive?: boolean;
     isArchived?: boolean;
-    warningMessage: string;
     submitButtonLabel?: string;
     content?: JSX.Element;
 }
@@ -37,7 +36,6 @@ function ConfirmationModal({
     close,
     canArchive,
     isArchived,
-    warningMessage,
     submitButtonLabel,
     content,
 }: ConfirmationModalProps): JSX.Element {
@@ -80,7 +78,6 @@ function ConfirmationModal({
                         onCloseBtnClick={close}
                     />
                     <div className="confirmationModalContent">
-                        <div>{warningMessage}</div>
                         {content}
                     </div>
                     <div className={`yesNoButtons confirmationControlButtons confirmationModalControls ${canArchive ? 'archivable' : ''}`}>

--- a/ui/src/Modal/ConfirmationModal.tsx
+++ b/ui/src/Modal/ConfirmationModal.tsx
@@ -26,9 +26,9 @@ export interface ConfirmationModalProps {
 
     canArchive?: boolean;
     isArchived?: boolean;
-    confirmClose?: boolean;
     warningMessage: string;
     submitButtonLabel?: string;
+    content?: JSX.Element;
 }
 
 function ConfirmationModal({
@@ -36,20 +36,12 @@ function ConfirmationModal({
     archiveCallback,
     close,
     canArchive,
-    confirmClose,
     isArchived,
     warningMessage,
     submitButtonLabel,
+    content,
 }: ConfirmationModalProps): JSX.Element {
     const isArchivable = (): boolean => Boolean(canArchive && !isArchived);
-
-    const ArchiveMessage = (): JSX.Element => (
-        <div><br/>You can also choose to archive this product to be able to access it later.</div>
-    );
-
-    const CloseConfirmationMessage = (): JSX.Element => (
-        <div><br/>Are you sure you want to close the window?</div>
-    );
     
     const DeleteButton = (): JSX.Element => (
         <FormButton
@@ -89,8 +81,7 @@ function ConfirmationModal({
                     />
                     <div className="confirmationModalContent">
                         <div>{warningMessage}</div>
-                        {(isArchivable()) && <ArchiveMessage />}
-                        {(confirmClose) && <CloseConfirmationMessage />}
+                        {content}
                     </div>
                     <div className={`yesNoButtons confirmationControlButtons confirmationModalControls ${canArchive ? 'archivable' : ''}`}>
                         <div className={`cancelAndArchiveContainer ${isArchivable() ? 'archivable' : ''}`}>

--- a/ui/src/Modal/ConfirmationModal.tsx
+++ b/ui/src/Modal/ConfirmationModal.tsx
@@ -23,6 +23,7 @@ export interface ConfirmationModalProps {
     submit(itemToDelete?: unknown): void | Promise<void>;
     close(): void;
     submitButtonLabel?: string;
+    title?: string;
     content?: JSX.Element;
     secondaryButton?: JSX.Element;
 }
@@ -31,6 +32,7 @@ function ConfirmationModal({
     submit,
     close,
     submitButtonLabel,
+    title = 'Are you sure?',
     content,
     secondaryButton,
 }: ConfirmationModalProps): JSX.Element {
@@ -58,7 +60,7 @@ function ConfirmationModal({
             <div className="modalContents">
                 <div className="modalCard">
                     <ModalCardBanner
-                        title="Are you sure?"
+                        title={title}
                         onCloseBtnClick={close}
                     />
                     <div className="confirmationModalContent">

--- a/ui/src/Modal/Modal.scss
+++ b/ui/src/Modal/Modal.scss
@@ -100,7 +100,7 @@
     line-height: 16px;
 }
 
-.confirmationModalControls.archivable {
+.confirmationModalControls.secondaryButtonContainer {
     justify-content: space-between;
 }
 
@@ -121,7 +121,7 @@
     justify-content: flex-start;
 }
 
-.cancelAndArchiveContainer.archivable {
+.cancelAndArchiveContainer.secondaryButtonContainer {
     display: flex;
     flex-direction: row;
     min-width: 218px;

--- a/ui/src/Modal/Modal.scss
+++ b/ui/src/Modal/Modal.scss
@@ -102,6 +102,8 @@
 
 .confirmationModalControls.secondaryButtonContainer {
     justify-content: space-between;
+    width: unset;
+    align-self: unset;
 }
 
 .confirmationModalDelete {
@@ -109,12 +111,11 @@
     flex-grow:0;
 }
 
-.yesNoButtons.confirmationModalControls {
-    padding: 0 52px;
-}
-
 .confirmationControlButtons {
     margin-top: 32px;
+    justify-content: space-evenly;
+    width: 50%;
+    align-self: center;
 }
 
 .cancelAndArchiveContainer {

--- a/ui/src/Modal/Modal.tsx
+++ b/ui/src/Modal/Modal.tsx
@@ -57,9 +57,18 @@ function Modal({ modalMetadata = null, closeModal }: ModalProps): JSX.Element | 
                 closeConfirmationModal();
             },
             close: closeConfirmationModal,
-            warningMessage: 'You have unsaved changes. Closing the window will result in the changes being discarded.',
             submitButtonLabel: 'Close',
-            content: <div><br/>Are you sure you want to close the window?</div>,
+            content: (
+                <>
+                    <div>
+                        You have unsaved changes. Closing the window will result in the changes being discarded.
+                    </div>
+                    <div>
+                        <br/>
+                        Are you sure you want to close the window?
+                    </div>
+                </>
+            ),
         };
         const confirmConfirmationModal: JSX.Element = ConfirmationModal(propsForCloseConfirmationModal);
         setConfirmCloseModal(confirmConfirmationModal);

--- a/ui/src/Modal/Modal.tsx
+++ b/ui/src/Modal/Modal.tsx
@@ -57,9 +57,9 @@ function Modal({ modalMetadata = null, closeModal }: ModalProps): JSX.Element | 
                 closeConfirmationModal();
             },
             close: closeConfirmationModal,
-            confirmClose: true,
             warningMessage: 'You have unsaved changes. Closing the window will result in the changes being discarded.',
             submitButtonLabel: 'Close',
+            content: <div><br/>Are you sure you want to close the window?</div>,
         };
         const confirmConfirmationModal: JSX.Element = ConfirmationModal(propsForCloseConfirmationModal);
         setConfirmCloseModal(confirmConfirmationModal);

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -236,7 +236,7 @@ function PersonForm({
             close: () => {
                 setConfirmDeleteModal(null);
             },
-            warningMessage: 'Removing this person will remove all instances of them from your entire space.',
+            content: <div>Removing this person will remove all instances of them from your entire space.</div>,
         };
         const deleteConfirmationModal: JSX.Element = ConfirmationModal(propsForDeleteConfirmationModal);
         setConfirmDeleteModal(deleteConfirmationModal);

--- a/ui/src/Products/ProductForm.test.tsx
+++ b/ui/src/Products/ProductForm.test.tsx
@@ -100,13 +100,23 @@ describe('ProductForm', function() {
         });
     });
 
-    it('should show delete modal with archive text when an archive product is being deleted', async () => {
+    it('should show delete modal with archive text when a non-archived product is being deleted', async () => {
         await act(async () => {
             const app = renderWithRedux(<ProductForm editing={true} product={TestUtils.productWithoutLocation}/>, store, undefined);
             const deleteSpan = await app.findByTestId('deleteProduct');
             fireEvent.click(deleteSpan);
             expect(app.getByText('Deleting this product will permanently remove it from this space.')).toBeTruthy();
             expect(app.queryByText('You can also choose to archive this product to be able to access it later.')).toBeTruthy();
+        });
+    });
+
+    it('should show delete modal without archive text when an archived product is being deleted', async () => {
+        await act(async () => {
+            const app = renderWithRedux(<ProductForm editing={true} product={TestUtils.archivedProduct}/>, store, undefined);
+            const deleteSpan = await app.findByTestId('deleteProduct');
+            fireEvent.click(deleteSpan);
+            expect(app.getByText('Deleting this product will permanently remove it from this space.')).toBeTruthy();
+            expect(app.queryByText('You can also choose to archive this product to be able to access it later.')).toBeFalsy();
         });
     });
 });

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -144,6 +144,7 @@ function ProductForm({
             archiveCallback: archiveProduct,
             isArchived: determineIfProductIsArchived(),
             warningMessage: 'Deleting this product will permanently remove it from this space.',
+            content: determineIfProductIsArchived() ? <></> : <div><br/>You can also choose to archive this product to be able to access it later.</div>,
         };
         const deleteConfirmationModal: JSX.Element = ConfirmationModal(propsForDeleteConfirmationModal);
         setConfirmDeleteModal(deleteConfirmationModal);

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -143,8 +143,12 @@ function ProductForm({
             },
             archiveCallback: archiveProduct,
             isArchived: determineIfProductIsArchived(),
-            warningMessage: 'Deleting this product will permanently remove it from this space.',
-            content: determineIfProductIsArchived() ? <></> : <div><br/>You can also choose to archive this product to be able to access it later.</div>,
+            content: (
+                <>
+                    <div>Deleting this product will permanently remove it from this space.</div>
+                    {determineIfProductIsArchived() ? <></> : <div><br/>You can also choose to archive this product to be able to access it later.</div>}
+                </>
+            ),
         };
         const deleteConfirmationModal: JSX.Element = ConfirmationModal(propsForDeleteConfirmationModal);
         setConfirmDeleteModal(deleteConfirmationModal);

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -137,12 +137,16 @@ function ProductForm({
     function displayDeleteProductModal(): void {
         const propsForDeleteConfirmationModal: ConfirmationModalProps = {
             submit: deleteProduct,
-            canArchive: true,
             close: () => {
                 setConfirmDeleteModal(null);
             },
-            archiveCallback: archiveProduct,
-            isArchived: determineIfProductIsArchived(),
+            secondaryButton: determineIfProductIsArchived() ? undefined : (
+                <FormButton
+                    buttonStyle="secondary"
+                    testId="confirmationModalArchive"
+                    onClick={archiveProduct}>
+                    Archive
+                </FormButton>),
             content: (
                 <>
                     <div>Deleting this product will permanently remove it from this space.</div>

--- a/ui/src/ReusableComponents/UserAccessList.tsx
+++ b/ui/src/ReusableComponents/UserAccessList.tsx
@@ -21,12 +21,13 @@ import {
     isUserTabbingAndFocusedOnElement,
     reactSelectStyles,
 } from '../ModalFormComponents/ReactSelectStyles';
-import React, {CSSProperties} from 'react';
+import React, {CSSProperties, useState} from 'react';
 import {Space} from '../Space/Space';
 import {UserSpaceMapping} from '../Space/UserSpaceMapping';
 
 import './UserAccessList.scss';
 import SpaceClient from '../Space/SpaceClient';
+import ConfirmationModal from '../Modal/ConfirmationModal';
 
 interface PermissionType {
     label: string;
@@ -110,6 +111,7 @@ function UserAccessList({
     owner,
     isUserOwner,
 }: UserAccessListProps): JSX.Element {
+    const [displayConfirmationModal, setDisplayConfirmationModal] = useState(false);
 
     // @ts-ignore
     const onChangeEvent = (value): void => {
@@ -118,23 +120,38 @@ function UserAccessList({
                 SpaceClient.removeUser(currentSpace, user).then(onChange);
                 break;
             case 'owner':
-                SpaceClient.changeOwner(currentSpace, owner, user).then(onChange);
+                setDisplayConfirmationModal(true);
         }
     };
 
+    const onSubmitOwnerChange = (): void => {
+        SpaceClient.changeOwner(currentSpace, owner, user).then(onChange);
+    };
+
     return (
-        <Select
-            styles={userAccessStyle}
-            id="userAccess-dropdown"
-            className="userAccess-dropdown"
-            classNamePrefix="userAccess"
-            inputId="userAccess-dropdown-input"
-            aria-label={user.permission}
-            options={getPermissionOption(isUserOwner)}
-            value={permissionOption[0]}
-            onChange={onChangeEvent}
-            isSearchable={false}
-            components={{Option: UserAccessListOption, DropdownIndicator: CustomIndicator}}/>
+        <>
+            {displayConfirmationModal &&
+                <ConfirmationModal
+                    submit={onSubmitOwnerChange}
+                    close={(): void => setDisplayConfirmationModal(false)}
+                    submitButtonLabel="Yes"
+                    closeButtonLabel="No"
+                    title="Make this person the owner?"
+                    content={<div>By making this person the owner, you will only have editor privileges for this space and will lose the ability to delete the space.</div>} />
+            }
+            <Select
+                styles={userAccessStyle}
+                id="userAccess-dropdown"
+                className="userAccess-dropdown"
+                classNamePrefix="userAccess"
+                inputId="userAccess-dropdown-input"
+                aria-label={user.permission}
+                options={getPermissionOption(isUserOwner)}
+                value={permissionOption[0]}
+                onChange={onChangeEvent}
+                isSearchable={false}
+                components={{Option: UserAccessListOption, DropdownIndicator: CustomIndicator}}/>
+        </>
     );
 }
 

--- a/ui/src/Roles/RoleTags.tsx
+++ b/ui/src/Roles/RoleTags.tsx
@@ -35,7 +35,7 @@ const RoleTags = ({ colors, roles, setRoles, updateFilterOptions, currentSpace }
         const propsForDeleteConfirmationModal: ConfirmationModalProps = {
             submit: () => deleteRole(roleToDelete),
             close: () => setConfirmDeleteModal(null),
-            warningMessage: `Deleting this role will remove it from any person that has been given this role.`,
+            content: <div>Deleting this role will remove it from any person that has been given this role.</div>,
         };
         const deleteConfirmationModal: JSX.Element = ConfirmationModal(propsForDeleteConfirmationModal);
         setConfirmDeleteModal(deleteConfirmationModal);

--- a/ui/src/Tags/LocationTags.tsx
+++ b/ui/src/Tags/LocationTags.tsx
@@ -55,7 +55,7 @@ const LocationTags = ({
         const propsForDeleteConfirmationModal: ConfirmationModalProps = {
             submit: () => deleteLocation(locationToDelete),
             close: () => setConfirmDeleteModal(null),
-            warningMessage: 'Deleting this location will remove it from any product that has been given this location.',
+            content: <div>Deleting this location will remove it from any product that has been given this location.</div>,
         };
         const deleteConfirmationModal: JSX.Element = ConfirmationModal(propsForDeleteConfirmationModal);
         setConfirmDeleteModal(deleteConfirmationModal);

--- a/ui/src/Tags/ProductTags.tsx
+++ b/ui/src/Tags/ProductTags.tsx
@@ -55,7 +55,7 @@ const ProductTags = ({
         const propsForDeleteConfirmationModal: ConfirmationModalProps = {
             submit: () => deleteProductTag(productTagToDelete),
             close: () => setConfirmDeleteModal(null),
-            warningMessage: `Deleting this product tag will remove it from any product that has been given this product tag.`,
+            content: <div>Deleting this product tag will remove it from any product that has been given this product tag.</div>,
         };
         const deleteConfirmationModal: JSX.Element = ConfirmationModal(propsForDeleteConfirmationModal);
         setConfirmDeleteModal(deleteConfirmationModal);

--- a/ui/src/tests/ConfirmationModal.test.tsx
+++ b/ui/src/tests/ConfirmationModal.test.tsx
@@ -24,7 +24,9 @@ import FormButton from '../ModalFormComponents/FormButton';
 describe('the confirmation modal for deleting a board', () => {
     it('should call back properly when the archive button is clicked', async () => {
         let archiveClicked = false;
-        const component = render(<ConfirmationModal close={noop}
+        const component = render(<ConfirmationModal
+            content={<></>}
+            close={noop}
             submit={(): void => undefined}
             secondaryButton={(
                 <FormButton
@@ -40,13 +42,17 @@ describe('the confirmation modal for deleting a board', () => {
     });
 
     it('should not show the "Archive" option if you are deleting a person', () => {
-        const component = render(<ConfirmationModal close={noop}
+        const component = render(<ConfirmationModal
+            content={<></>}
+            close={noop}
             submit={(): void => undefined}/>);
         expect(component.queryByText('Archive')).not.toBeInTheDocument();
     });
 
     it('should show the "Archive" option if you are deleting a product', () => {
-        const productComponent = render(<ConfirmationModal close={noop}
+        const productComponent = render(<ConfirmationModal
+            content={<></>}
+            close={noop}
             submit={(): void => undefined}
             secondaryButton={(
                 <FormButton

--- a/ui/src/tests/ConfirmationModal.test.tsx
+++ b/ui/src/tests/ConfirmationModal.test.tsx
@@ -19,15 +19,20 @@ import ConfirmationModal from '../Modal/ConfirmationModal';
 import React from 'react';
 import {fireEvent, render} from '@testing-library/react';
 import {noop} from '@babel/types';
+import FormButton from '../ModalFormComponents/FormButton';
 
 describe('the confirmation modal for deleting a board', () => {
     it('should call back properly when the archive button is clicked', async () => {
         let archiveClicked = false;
         const component = render(<ConfirmationModal close={noop}
             submit={(): void => undefined}
-            archiveCallback={(): void => {archiveClicked = true;}}
-            warningMessage=""
-            canArchive={true}/>);
+            secondaryButton={(
+                <FormButton
+                    buttonStyle="secondary"
+                    testId="confirmationModalArchive"
+                    onClick={(): void => {archiveClicked = true;}}>
+                    Archive
+                </FormButton>)}/>);
 
         expect(archiveClicked).toBeFalsy();
         fireEvent.click(component.getByTestId('confirmationModalArchive'));
@@ -36,18 +41,20 @@ describe('the confirmation modal for deleting a board', () => {
 
     it('should not show the "Archive" option if you are deleting a person', () => {
         const component = render(<ConfirmationModal close={noop}
-            submit={(): void => undefined}
-            archiveCallback={noop}
-            warningMessage=""/>);
+            submit={(): void => undefined}/>);
         expect(component.queryByText('Archive')).not.toBeInTheDocument();
     });
 
     it('should show the "Archive" option if you are deleting a product', () => {
         const productComponent = render(<ConfirmationModal close={noop}
             submit={(): void => undefined}
-            archiveCallback={noop}
-            warningMessage=""
-            canArchive={true}/>);
+            secondaryButton={(
+                <FormButton
+                    buttonStyle="secondary"
+                    testId="confirmationModalArchive"
+                    onClick={noop}>
+                   Archive
+                </FormButton>)}/>);
         expect(productComponent.getByText('Archive')).toBeInTheDocument();
     });
 });

--- a/ui/src/tests/TestUtils.tsx
+++ b/ui/src/tests/TestUtils.tsx
@@ -390,7 +390,7 @@ class TestUtils {
         name: 'I am archived',
         spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         startDate: '',
-        endDate: '2020-11-02',
+        endDate: '2019-11-02',
         spaceLocation: TestUtils.detroit,
         assignments: [],
         archived: true,


### PR DESCRIPTION
## Issue
Resolves 109

## What was done
- [x] Added a confirmation modal when attempting to assign ownership to someone else

## How to test
1. Open the share access form with the #perm feature tag in the url
2. Add an editor if there isn't one currently
3. Assign ownership to that editor from the share access form
4. No should close the confirmation modal and leave you as the owner
5. Yes should close the confirmation modal and change the owner

## Accessiblity Criteria

### Manual Checks
- [x] Text and background color meets a minimum color contrast ratio of 4.5:1
- [x] All functionality is available to a keyboard
  - [x] Focus styles are highly visible 
  - [x] Tab order is logical and aligns with the visual order 
