### PR TITLE
169 add filters readonly

### DIFF
--- a/ui/src/Header/NewSubHeader.tsx
+++ b/ui/src/Header/NewSubHeader.tsx
@@ -61,14 +61,14 @@ function NewSubHeader({ isReadOnly, setCurrentModal }: Props): JSX.Element {
                     </span>
                 )}
             </div>
-            {isReadOnly ? <></> : <div className="rightContent">
+            <div className="rightContent">
                 <NavigationSection label="Filter by" icon="filter_list">
                     <NewFilter filterType={FilterTypeListings.Location}/>
                     <NewFilter filterType={FilterTypeListings.ProductTag}/>
                     <NewFilter filterType={FilterTypeListings.Role}/>
                 </NavigationSection>
                 <NewProductSortBy/>
-            </div>}
+            </div>
         </div>
     );
 }

--- a/ui/src/SortingAndFiltering/NewFilter.test.tsx
+++ b/ui/src/SortingAndFiltering/NewFilter.test.tsx
@@ -21,7 +21,7 @@ import {AvailableActions} from '../Redux/Actions';
 import NewFilter from './NewFilter';
 import {FilterTypeListings} from './FilterConstants';
 import {createStore} from 'redux';
-import rootReducer from '../Redux/Reducers';
+import rootReducer, {GlobalStateProps} from '../Redux/Reducers';
 import {AvailableModals} from '../Modal/AvailableModals';
 import {RenderResult} from '@testing-library/react';
 
@@ -41,6 +41,21 @@ describe('Filter Dropdown', () => {
             const addLocationButton = await app.findByText('Add/Edit your Product Location');
             addLocationButton.click();
             expect(store.dispatch).toHaveBeenCalledWith({type: AvailableActions.SET_CURRENT_MODAL, modal: AvailableModals.MY_LOCATION_TAGS });
+        });
+    });
+
+    describe('Read-only', () => {
+        it('should not display the add new filter button', async () => {
+            const initialState = {
+                isReadOnly: true,
+                allGroupedTagFilterOptions: [],
+            };
+
+            const app = renderWithRedux(<NewFilter filterType={FilterTypeListings.Location}/>, undefined, initialState as GlobalStateProps);
+            let locationFilterTestId = FilterTypeListings.Location.label.replace(' ', '_');
+            const dropdownButton = await app.findByTestId(`dropdown_button_${locationFilterTestId}`);
+            dropdownButton.click();
+            expect(app.queryByTestId(`open_${locationFilterTestId}_modal_button`)).toBeNull();
         });
     });
 

--- a/ui/src/SortingAndFiltering/NewFilter.tsx
+++ b/ui/src/SortingAndFiltering/NewFilter.tsx
@@ -33,6 +33,7 @@ function toggleOption(option: FilterOption): FilterOption {
 interface NewFilterProps {
     filterType: FilterType;
     allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions>;
+    isReadOnly: boolean;
     setAllGroupedTagFilterOptions(groupedTagFilterOptions: Array<AllGroupedTagFilterOptions>): void;
     setCurrentModal(modalState: CurrentModalState): void;
 }
@@ -40,6 +41,7 @@ interface NewFilterProps {
 function NewFilter({
     filterType,
     allGroupedTagFilterOptions,
+    isReadOnly,
     setAllGroupedTagFilterOptions,
     setCurrentModal,
 }: NewFilterProps): JSX.Element {
@@ -154,13 +156,13 @@ function NewFilter({
                         );
                     })}
             </div>
-            <button className="add-edit-tags-dropdown-button"
+            {!isReadOnly && <button className="add-edit-tags-dropdown-button"
                 data-testid={`open_${formattedFilterTypeValue}_modal_button`}
                 onClick={(): void => { setCurrentModal({modal: filterType.modal}); }}
             >
                 <span>{`Add/Edit your ${filterType.label}`}</span>
                 <i className="material-icons">keyboard_arrow_right</i>
-            </button>
+            </button>}
         </>;
 
     const dropdownButtonContent =
@@ -196,6 +198,7 @@ function NewFilter({
 /* eslint-disable */
 const mapStateToProps = (state: GlobalStateProps) => ({
     allGroupedTagFilterOptions: state.allGroupedTagFilterOptions,
+    isReadOnly: state.isReadOnly
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/ui/src/SortingAndFiltering/NewFilterOrSortBy.scss
+++ b/ui/src/SortingAndFiltering/NewFilterOrSortBy.scss
@@ -114,8 +114,9 @@
         font-size: 12px;
 
         .sortby-option-container {
-          max-height: 250px;
           overflow-y: auto;
+          max-height: 250px;
+          min-width: 120px;
           max-width: 250px;
 
           .sortby-option {

--- a/ui/src/SortingAndFiltering/NewFilterOrSortBy.scss
+++ b/ui/src/SortingAndFiltering/NewFilterOrSortBy.scss
@@ -116,7 +116,7 @@
         .sortby-option-container {
           overflow-y: auto;
           max-height: 250px;
-          min-width: 120px;
+          min-width: 150px;
           max-width: 250px;
 
           .sortby-option {


### PR DESCRIPTION
## Issue
Resolves 169

## What was done
- [x] Removed conditional rendering on filters so that they'd also show up for read-only users
- [x] Added conditional rendering on filter dropdown 'add filter' buttons so that they DON'T show up for read-only users
- [x] Added some styling to filter dropdowns to add a minimum width to them
 
## How to test
1. Open a read-only space with the `#newui` hash
2. Observe filter dropdowns in the subnav
3. Open a filter dropdown
4. Observe that there's no "Add filter" button
5. Select a filter
6. Observe that the filter still applies to the products