### PR TITLE
Add 'Contact Us' and remove underline from 'a' tags

### DIFF
--- a/ui/src/ReusableComponents/Branding.tsx
+++ b/ui/src/ReusableComponents/Branding.tsx
@@ -21,6 +21,13 @@ import FordLabsLogo from '../Application/Assets/fordlabs_logo.svg';
 
 function Branding(): JSX.Element {
     const fordLabsUrl = window?.runConfig?.ford_labs_url || '';
+    const padLeftAndRemoveUnderline = {
+        textDecoration: 'none',
+        paddingLeft: '6px',
+    };
+    const removeUnderline = {
+        textDecoration: 'none',
+    };
     return (
         <div className="brandingContainer"
             aria-label="Powered by Ford Labs">
@@ -34,9 +41,13 @@ function Branding(): JSX.Element {
             <a target="_blank"
                 rel="noopener noreferrer"
                 href={fordLabsUrl}
+                style={removeUnderline}
                 className="brandingMessage">
                 FordLabs
             </a>
+            <span className="brandingMessage" style={padLeftAndRemoveUnderline}>|
+                <a href="mailto:matieh@ford.com" className="brandingMessage" style={padLeftAndRemoveUnderline}>Contact Us</a>
+            </span>
         </div>
     );
 }


### PR DESCRIPTION
Co-authored-by: John Cherney <jwcherney@hotmail.com>
Co-authored-by: Stephen Graham <sgraha75@ford.com>

## Issue
Resolves 197 - Add Contact us and mail link

## What was done
- [x] Added text, updated styles (Currently set to matieh@ford.com. Will need to be changed to pplmover@ford.com the future, when the team owns that CDSID)

## How to test
1. Look at main page
2. see magestic "Contact Us"
3. notice that FordLabs and Contact Us aren't underlined
4. go to any board you have access to
5. see magestic "Contact Us" again
6. finish testing
7. have a drink

## Accessiblity Criteria
### Testing
- [ ] Add jest-axe unit tests (for new ui components)

### Manual Checks
- [ ] Text and background color meets a minimum color contrast ratio of 4.5:1
- [ ] All non-text content (e.g. images, icon) has alt text
- [ ] Web page includes appropriate headings to communicate structure/hierarchy (h1>h2>h3)
- [ ] All functionality is available to a keyboard
  - [ ] Focus styles are highly visible 
  - [ ] Tab order is logical and aligns with the visual order 
- [ ] Voice over is understandable and logical
  - [ ] Aria labels are added to elements with no visible text 
  - [ ] Decorative elements (e.g. non-informative icons) are hidden from screen readers  
- [ ] Form fields have appropriately coded labels that are visible during input 
- [ ] Links are visually identifiable and have a clear focus and active state 
