### PR TITLE
Hide days that not part of current month

### DIFF
--- a/ui/src/Calendar/Calendar.scss
+++ b/ui/src/Calendar/Calendar.scss
@@ -66,6 +66,10 @@
           }
         }
 
+        .react-datepicker__day--outside-month {
+          visibility: hidden;
+        }
+
         .react-datepicker__day--selected,
         .react-datepicker__day--keyboard-selected {
           background: transparent;


### PR DESCRIPTION
Co-authored-by: Vianney Willot <vianney.willot@gmail.com>
Co-authored-by: Stephen Graham <sgraha75@ford.com>

## Issue
Resolves XXX (where XXX is the related issue)

## What was done
- [x] Hide days that not part of current month

## How to test
1. Select a month and you cannot see the end or the beginning of previous/next month

## Accessiblity Criteria
### Testing


### Manual Checks
