### PR TITLE
152 people tag filter

### DIFF
--- a/ui/src/Assignments/AssignmentCardList.test.tsx
+++ b/ui/src/Assignments/AssignmentCardList.test.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import TestUtils, {renderWithRedux} from '../tests/TestUtils';
+import AssignmentCardList from './AssignmentCardList';
+import moment from 'moment';
+import {GlobalStateProps} from '../Redux/Reducers';
+import {AllGroupedTagFilterOptions} from '../SortingAndFiltering/FilterLibraries';
+import {Product} from '../Products/Product';
+
+describe('Assignment card list', () => {
+
+
+    let product: Product = {
+        id: 1,
+        name: 'Product 1',
+        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        startDate: '2011-01-01',
+        endDate: '2022-02-02',
+        spaceLocation: TestUtils.southfield,
+        assignments: TestUtils.assignmentsFilterTest,
+        archived: false,
+        tags: [],
+        notes: '',
+    };
+
+    describe('filtering person by role and person tag',  () => {
+
+        it('should not filter people if no role or tag are selected', async () => {
+            let allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions> = [
+                {
+                    label:'Location Tags:',
+                    options: [],
+                },
+                {
+                    label:'Product Tags:',
+                    options: [],
+                },
+                {
+                    label:'Role Tags:',
+                    options: [{
+                        label: 'Software Engineer',
+                        value: '1_Software Engineer',
+                        selected: false,
+                    }],
+                },
+                {
+                    label:'Person Tags:',
+                    options: [{
+                        label: 'The lil boss',
+                        value: '1_The_lil_boss',
+                        selected: false,
+                    }],
+                },
+            ];
+
+            const initialState = {
+                allGroupedTagFilterOptions: allGroupedTagFilterOptions,
+                viewingDate: moment().toDate(),
+                currentSpace: TestUtils.space,
+            } as GlobalStateProps;
+
+            let component = await renderWithRedux(<AssignmentCardList product={product}/>, undefined, initialState);
+
+            await expect(component.queryByTestId('assignmentCard__person_1')).toBeTruthy();
+            await expect(component.queryByTestId('assignmentCard__bob_se')).toBeTruthy();
+            await expect(component.queryByTestId('assignmentCard__bob_pm')).toBeTruthy();
+            await expect(component.queryByTestId('assignmentCard__bob_norole_notag')).toBeTruthy();
+
+        });
+
+        it('should filter people that do not have selected role', async () => {
+
+            let allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions> = [
+                {
+                    label:'Location Tags:',
+                    options: [],
+                },
+                {
+                    label:'Product Tags:',
+                    options: [],
+                },
+                {
+                    label:'Role Tags:',
+                    options: [{
+                        label: 'Software Engineer',
+                        value: '1_Software Engineer',
+                        selected: true,
+                    }],
+                },
+                {
+                    label:'Person Tags:',
+                    options: [{
+                        label: 'The lil boss',
+                        value: '1_The_lil_boss',
+                        selected: false,
+                    }],
+                },
+            ];
+
+            const initialState = {
+                allGroupedTagFilterOptions: allGroupedTagFilterOptions,
+                viewingDate: moment().toDate(),
+                currentSpace: TestUtils.space,
+            } as GlobalStateProps;
+
+            let component = await renderWithRedux(<AssignmentCardList product={product}/>, undefined, initialState);
+
+            await expect(component.queryByTestId('assignmentCard__person_1')).toBeTruthy();
+            await expect(component.queryByTestId('assignmentCard__bob_se')).toBeTruthy();
+            await expect(component.queryByTestId('assignmentCard__bob_pm')).toBeNull();
+            await expect(component.queryByTestId('assignmentCard__bob_norole_notag')).toBeNull();
+        });
+
+        it('should filter people that do not have the person tag selected', async () => {
+            let allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions> = [
+                {
+                    label:'Location Tags:',
+                    options: [],
+                },
+                {
+                    label:'Product Tags:',
+                    options: [],
+                },
+                {
+                    label:'Role Tags:',
+                    options: [{
+                        label: 'Software Engineer',
+                        value: '1_Software Engineer',
+                        selected: false,
+                    }],
+                },
+                {
+                    label:'Person Tags:',
+                    options: [{
+                        label: 'The lil boss',
+                        value: '1_The_lil_boss',
+                        selected: true,
+                    }],
+                },
+            ];
+
+            const initialState = {
+                allGroupedTagFilterOptions: allGroupedTagFilterOptions,
+                viewingDate: moment().toDate(),
+                currentSpace: TestUtils.space,
+            } as GlobalStateProps;
+
+            let component = await renderWithRedux(<AssignmentCardList product={product}/>, undefined, initialState);
+
+            await expect(component.queryByTestId('assignmentCard__person_1')).toBeNull();
+            await expect(component.queryByTestId('assignmentCard__bob_se')).toBeTruthy();
+            await expect(component.queryByTestId('assignmentCard__bob_pm')).toBeTruthy();
+            await expect(component.queryByTestId('assignmentCard__bob_norole_notag')).toBeNull();
+        });
+
+        it('should filter people that do not have the role and person tag selected', async () => {
+            let allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions> = [
+                {
+                    label:'Location Tags:',
+                    options: [],
+                },
+                {
+                    label:'Product Tags:',
+                    options: [],
+                },
+                {
+                    label:'Role Tags:',
+                    options: [{
+                        label: 'Software Engineer',
+                        value: '1_Software Engineer',
+                        selected: true,
+                    }],
+                },
+                {
+                    label:'Person Tags:',
+                    options: [{
+                        label: 'The lil boss',
+                        value: '1_The_lil_boss',
+                        selected: true,
+                    }],
+                },
+            ];
+
+            const initialState = {
+                allGroupedTagFilterOptions: allGroupedTagFilterOptions,
+                viewingDate: moment().toDate(),
+                currentSpace: TestUtils.space,
+            } as GlobalStateProps;
+
+            let component = await renderWithRedux(<AssignmentCardList product={product}/>, undefined, initialState);
+
+            await expect(component.queryByTestId('assignmentCard__person_1')).toBeNull();
+            await expect(component.queryByTestId('assignmentCard__bob_se')).toBeTruthy();
+            await expect(component.queryByTestId('assignmentCard__bob_pm')).toBeNull();
+            await expect(component.queryByTestId('assignmentCard__bob_norole_notag')).toBeNull();
+        });
+    });
+});
+

--- a/ui/src/Assignments/AssignmentCardList.tsx
+++ b/ui/src/Assignments/AssignmentCardList.tsx
@@ -65,13 +65,7 @@ function AssignmentCardList({
     const antiHighlightCoverRef: RefObject<HTMLDivElement> = React.useRef<HTMLDivElement>(null);
     let assignmentCardRectHeight  = 0;
     const getSelectedRoleFilters = (): Array<string> => getSelectedFilterLabels(allGroupedTagFilterOptions[2].options);
-    const [roleFilters, setRoleFilters] = useState<Array<string>>(getSelectedRoleFilters());
-
-    /* eslint-disable */
-    useEffect(() => {
-        setRoleFilters(getSelectedRoleFilters());
-    }, [allGroupedTagFilterOptions]);
-    /* eslint-enable */
+    const getSelectedPersonTagFilters = (): Array<string> => getSelectedFilterLabels(allGroupedTagFilterOptions[3].options);
 
     function assignmentsSortedByPersonRoleStably(): Array<Assignment> {
         const assignments: Array<Assignment> = product.assignments;
@@ -86,11 +80,30 @@ function AssignmentCardList({
             return 0;
         });
     }
+    
+    function filterAssignmentByRoleAndProductTag(assignment: Assignment): boolean {
+        let isMatchingRole = false;
+        let isMatchingPersonTag = false;
 
-    function filterAssignmentByRole(assignment: Assignment): boolean {
-        if (roleFilters.length === 0) return true;
+        if (getSelectedRoleFilters().length === 0) {
+            isMatchingRole = true;
+        } else {
+            if (assignment.person.spaceRole && getSelectedRoleFilters().includes(assignment.person.spaceRole.name)) {
+                isMatchingRole = true;
+            }
+        }
 
-        return !!(assignment.person.spaceRole && roleFilters.includes(assignment.person.spaceRole.name));
+        if (getSelectedPersonTagFilters().length === 0) {
+            isMatchingPersonTag = true;
+        } else {
+            assignment.person.tags.forEach(personTag => {
+                if (getSelectedPersonTagFilters().includes(personTag.name)) {
+                    isMatchingPersonTag = true;
+                }
+            });
+        }
+
+        return isMatchingRole && isMatchingPersonTag;
     }
 
     function startDraggingAssignment(ref: RefObject<HTMLDivElement>, assignment: Assignment, e: React.MouseEvent): void {
@@ -229,7 +242,7 @@ function AssignmentCardList({
                 className={classNameAndDataTestId}
                 data-testid={classNameAndDataTestId}>
                 {assignmentsSortedByPersonRoleStably()
-                    .filter(filterAssignmentByRole)
+                    .filter(filterAssignmentByRoleAndProductTag)
                     .map((assignment: Assignment) =>
                         <AssignmentCard assignment={assignment}
                             isUnassignedProduct={isUnassignedProduct(product)}

--- a/ui/src/Assignments/AssignmentCardList.tsx
+++ b/ui/src/Assignments/AssignmentCardList.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, {RefObject, useEffect, useState} from 'react';
+import React, {RefObject} from 'react';
 import '../Products/Product.scss';
 import {connect} from 'react-redux';
 import {fetchProductsAction, setCurrentModalAction, setIsDragging} from '../Redux/Actions';

--- a/ui/src/Assignments/AssignmentCardList.tsx
+++ b/ui/src/Assignments/AssignmentCardList.tsx
@@ -35,8 +35,9 @@ import {ProductPlaceholderPair} from './CreateAssignmentRequest';
 import moment from 'moment';
 import {getSelectedFilterLabels} from '../Redux/Reducers/allGroupedTagOptionsReducer';
 import {Space} from '../Space/Space';
-import {AllGroupedTagFilterOptions} from '../SortingAndFiltering/FilterLibraries';
+import {AllGroupedTagFilterOptions, FilterTypeListings} from '../SortingAndFiltering/FilterLibraries';
 import {AvailableModals} from '../Modal/AvailableModals';
+import {isPersonMatchingSelectedFilters} from '../People/Person';
 
 interface AssignmentCardListProps {
     product: Product;
@@ -64,8 +65,8 @@ function AssignmentCardList({
     let draggingAssignmentRef: AssignmentCardRefAndAssignmentPair | undefined = undefined;
     const antiHighlightCoverRef: RefObject<HTMLDivElement> = React.useRef<HTMLDivElement>(null);
     let assignmentCardRectHeight  = 0;
-    const getSelectedRoleFilters = (): Array<string> => getSelectedFilterLabels(allGroupedTagFilterOptions[2].options);
-    const getSelectedPersonTagFilters = (): Array<string> => getSelectedFilterLabels(allGroupedTagFilterOptions[3].options);
+    const getSelectedRoleFilters = (): Array<string> => getSelectedFilterLabels(allGroupedTagFilterOptions[FilterTypeListings.Role.index].options);
+    const getSelectedPersonTagFilters = (): Array<string> => getSelectedFilterLabels(allGroupedTagFilterOptions[FilterTypeListings.PersonTag.index].options);
 
     function assignmentsSortedByPersonRoleStably(): Array<Assignment> {
         const assignments: Array<Assignment> = product.assignments;
@@ -80,30 +81,9 @@ function AssignmentCardList({
             return 0;
         });
     }
-    
+
     function filterAssignmentByRoleAndProductTag(assignment: Assignment): boolean {
-        let isMatchingRole = false;
-        let isMatchingPersonTag = false;
-
-        if (getSelectedRoleFilters().length === 0) {
-            isMatchingRole = true;
-        } else {
-            if (assignment.person.spaceRole && getSelectedRoleFilters().includes(assignment.person.spaceRole.name)) {
-                isMatchingRole = true;
-            }
-        }
-
-        if (getSelectedPersonTagFilters().length === 0) {
-            isMatchingPersonTag = true;
-        } else {
-            assignment.person.tags.forEach(personTag => {
-                if (getSelectedPersonTagFilters().includes(personTag.name)) {
-                    isMatchingPersonTag = true;
-                }
-            });
-        }
-
-        return isMatchingRole && isMatchingPersonTag;
+        return isPersonMatchingSelectedFilters(assignment.person, getSelectedRoleFilters(), getSelectedPersonTagFilters());
     }
 
     function startDraggingAssignment(ref: RefObject<HTMLDivElement>, assignment: Assignment, e: React.MouseEvent): void {

--- a/ui/src/Header/SubHeader.tsx
+++ b/ui/src/Header/SubHeader.tsx
@@ -50,6 +50,7 @@ function SubHeader({ isReadOnly, setCurrentModal }: Props): JSX.Element {
                 <NavigationSection label="Filter by" icon="filter_list">
                     <Filter filterType={FilterTypeListings.Location}/>
                     <Filter filterType={FilterTypeListings.ProductTag}/>
+                    {window.location.hash === '#person-tags' &&  <Filter filterType={FilterTypeListings.PersonTag}/>}
                     <Filter filterType={FilterTypeListings.Role}/>
                 </NavigationSection>
                 <ProductSortBy/>

--- a/ui/src/People/Person.ts
+++ b/ui/src/People/Person.ts
@@ -37,3 +37,28 @@ export function emptyPerson(): Person {
         tags: [],
     };
 }
+
+export function isPersonMatchingSelectedFilters(person: Person, selectedRoleFilters: Array<string>, selectedPersonTagFilters: Array<string>): boolean {
+    let isMatchingRole = false;
+    let isMatchingPersonTag = false;
+
+    if (selectedRoleFilters.length === 0) {
+        isMatchingRole = true;
+    } else {
+        if (person.spaceRole && selectedRoleFilters.includes(person.spaceRole.name)) {
+            isMatchingRole = true;
+        }
+    }
+
+    if (selectedPersonTagFilters.length === 0) {
+        isMatchingPersonTag = true;
+    } else {
+        person.tags.forEach(personTag => {
+            if (selectedPersonTagFilters.includes(personTag.name)) {
+                isMatchingPersonTag = true;
+            }
+        });
+    }
+
+    return isMatchingRole && isMatchingPersonTag;
+}

--- a/ui/src/tests/TestUtils.tsx
+++ b/ui/src/tests/TestUtils.tsx
@@ -313,6 +313,32 @@ class TestUtils {
         tags: [],
     };
 
+    static person2: Person = {
+        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        id: 103,
+        name: 'bob se',
+        spaceRole: TestUtils.softwareEngineer,
+        newPerson: false,
+        tags: TestUtils.personTags,
+    };
+
+    static person3: Person = {
+        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        id: 104,
+        name: 'bob pm',
+        spaceRole: TestUtils.productManager,
+        newPerson: false,
+        tags: [TestUtils.personTag1],
+    };
+
+    static personNoRoleNoTag: Person = {
+        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        id: 105,
+        name: 'bob norole notag',
+        newPerson: false,
+        tags: [],
+    };
+
     static people: Array<Person> = [
         TestUtils.person1,
         TestUtils.hank,
@@ -346,10 +372,44 @@ class TestUtils {
         effectiveDate: new Date(2020, 4, 15),
     };
 
+    static assignmentForPerson2: Assignment = {
+        id: 15,
+        productId: 1,
+        person: TestUtils.person2,
+        placeholder: false,
+        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        effectiveDate: new Date(2020, 4, 15),
+    };
+
+    static assignmentForPerson3: Assignment = {
+        id: 17,
+        productId: 1,
+        person: TestUtils.person3,
+        placeholder: false,
+        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        effectiveDate: new Date(2020, 4, 15),
+    };
+
+    static assignmentForPersonNoRoleNoTag: Assignment = {
+        id: 19,
+        productId: 1,
+        person: TestUtils.personNoRoleNoTag,
+        placeholder: false,
+        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        effectiveDate: new Date(2020, 4, 15),
+    };
+
     static assignments: Array<Assignment> = [
         TestUtils.assignmentForPerson1,
         TestUtils.assignmentForHank,
         TestUtils.assignmentForUnassigned,
+    ];
+
+    static assignmentsFilterTest: Array<Assignment> = [
+        TestUtils.assignmentForPerson1,
+        TestUtils.assignmentForPerson2,
+        TestUtils.assignmentForPerson3,
+        TestUtils.assignmentForPersonNoRoleNoTag,
     ];
 
     static unassignedProduct: Product = {


### PR DESCRIPTION
## Issue
Resolves 152

## What was done
- [x] Add personTag filter with 3person-tags
- [x] Can select a personTag and see assignment being filter out

## How to test
1. Open PeopleMover
2. append '#person-tags' to the address
3. observe a Person Tags filter in the subheader
4. Selecting items in the Person Tags filter changes the people seen in the space

Note: The modal for creating/editing/deleting PersonTags has not yet been implemented/updated
Note: The Counter has not yet been implemented/updated

## Accessiblity Criteria
### Testing
- [ ] Add jest-axe unit tests (for new ui components)

### Manual Checks
- [ ] Text and background color meets a minimum color contrast ratio of 4.5:1
- [ ] All non-text content (e.g. images, icon) has alt text
- [ ] Web page includes appropriate headings to communicate structure/hierarchy (h1>h2>h3)
- [ ] All functionality is available to a keyboard
  - [ ] Focus styles are highly visible 
  - [ ] Tab order is logical and aligns with the visual order 
- [ ] Voice over is understandable and logical
  - [ ] Aria labels are added to elements with no visible text 
  - [ ] Decorative elements (e.g. non-informative icons) are hidden from screen readers  
- [ ] Form fields have appropriately coded labels that are visible during input 
- [ ] Links are visually identifiable and have a clear focus and active state 
