### PR TITLE
134 whats this

### DIFF
--- a/ui/src/Modal/Form.scss
+++ b/ui/src/Modal/Form.scss
@@ -53,14 +53,17 @@ select.formInput {
     margin-bottom: 12px;
 
     .formItemLabel {
-
-        font-size: 14px;
-        line-height: 14px;
-        font-weight: bold;
-        color: $gray-1;
+        margin-bottom: 0px;
     }
 }
 
+.formItemLabel {
+    font-size: 14px;
+    line-height: 14px;
+    font-weight: bold;
+    color: $gray-1;
+    margin-bottom: 12px;
+}
 
 
 .formInputLabel {

--- a/ui/src/Modal/Form.scss
+++ b/ui/src/Modal/Form.scss
@@ -47,15 +47,21 @@ select.formInput {
     padding-left:4px;
 }
 
-.formItemLabel {
-    display: block;
+.formItemLabelContainer {
+    display: flex;
+    align-items: center;
     margin-bottom: 12px;
 
-    font-size: 14px;
-    line-height: 14px;
-    font-weight: bold;
-    color: $gray-1;
+    .formItemLabel {
+
+        font-size: 14px;
+        line-height: 14px;
+        font-weight: bold;
+        color: $gray-1;
+    }
 }
+
+
 
 .formInputLabel {
     display: block;

--- a/ui/src/ModalFormComponents/SelectWithCreateOption.tsx
+++ b/ui/src/ModalFormComponents/SelectWithCreateOption.tsx
@@ -91,6 +91,7 @@ export interface Metadata {
     title: string;
     id: string;
     placeholder: string;
+    tooltip?: string;
 }
 
 export interface ReactSelectProps {
@@ -105,6 +106,7 @@ export interface ReactSelectProps {
     isMulti?: boolean;
     useColorBadge?: boolean;
     isLoading?: boolean;
+    toolTip?: JSX.Element;
 }
 
 const CreateNewText = (text: string): JSX.Element => (
@@ -156,6 +158,7 @@ function SelectWithCreateOption({
     isMulti = false,
     useColorBadge = false,
     isLoading,
+    toolTip,
 }: ReactSelectProps): JSX.Element {
     const [typedInValue, setTypedInValue] = useState<string>('');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -193,7 +196,7 @@ function SelectWithCreateOption({
 
     return (
         <div className={`formItem ${className}`}>
-            <label className="formItemLabel" htmlFor={id}>{title}</label>
+            <label className="formItemLabel" htmlFor={id}>{title} {toolTip}</label>
             <Creatable
                 name={id}
                 inputId={id}

--- a/ui/src/ModalFormComponents/SelectWithCreateOption.tsx
+++ b/ui/src/ModalFormComponents/SelectWithCreateOption.tsx
@@ -196,7 +196,10 @@ function SelectWithCreateOption({
 
     return (
         <div className={`formItem ${className}`}>
-            <label className="formItemLabel" htmlFor={id}>{title} {toolTip}</label>
+            <div className="formItemLabelContainer">
+                <label className="formItemLabel" htmlFor={id}>{title}</label>
+                {toolTip}
+            </div>
             <Creatable
                 name={id}
                 inputId={id}

--- a/ui/src/People/PersonForm.scss
+++ b/ui/src/People/PersonForm.scss
@@ -43,3 +43,8 @@
 .newBadgeContainer {
   padding-left: 46px;
 }
+
+.toolTipContent {
+  font-family: Helvetica, sans-serif;
+  letter-spacing: normal;
+}

--- a/ui/src/People/PersonForm.scss
+++ b/ui/src/People/PersonForm.scss
@@ -39,3 +39,7 @@
     margin-right: 6px;
   }
 }
+
+.newBadgeContainer {
+  padding-left: 46px;
+}

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -321,7 +321,9 @@ function PersonForm({
                 />
                 {window.location.hash === '#person-tags' &&
                 <>
-                    <NewBadge/>
+                    <div className="newBadgeContainer">
+                        <NewBadge/>
+                    </div>
                     <FormTagsField
                         tagsMetadata={MetadataReactSelectProps.PERSON_TAGS}
                         tagClient={PersonTagClient}

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -56,6 +56,7 @@ import {
     AllGroupedTagFilterOptions,
     FilterTypeListings,
 } from '../SortingAndFiltering/FilterLibraries';
+import NewBadge from '../ReusableComponents/NewBadge';
 
 interface PersonFormProps {
     isEditPersonForm: boolean;
@@ -319,14 +320,16 @@ function PersonForm({
                     onChange={changeProductName}
                 />
                 {window.location.hash === '#person-tags' &&
-                <FormTagsField
-                    tagsMetadata={MetadataReactSelectProps.PERSON_TAGS}
-                    tagClient={PersonTagClient}
-                    currentTagsState={{currentTags: person.tags}}
-                    selectedTagsState={{selectedTags: selectedPersonTags, setSelectedTags: setSelectedPersonTags}}
-                    loadingState={{isLoading, setIsLoading}}
-                    addGroupedTagFilterOptions={(trait: TagInterface): void => {addGroupedTagFilterOptions(FilterTypeListings.PersonTag.index, trait, allGroupedTagFilterOptions, setAllGroupedTagFilterOptions);}}
-                />
+                <>
+                    <NewBadge/>
+                    <FormTagsField
+                        tagsMetadata={MetadataReactSelectProps.PERSON_TAGS}
+                        tagClient={PersonTagClient}
+                        currentTagsState={{currentTags: person.tags}}
+                        selectedTagsState={{selectedTags: selectedPersonTags, setSelectedTags: setSelectedPersonTags}}
+                        loadingState={{isLoading, setIsLoading}}
+                        addGroupedTagFilterOptions={(trait: TagInterface): void => {addGroupedTagFilterOptions(FilterTypeListings.PersonTag.index, trait, allGroupedTagFilterOptions, setAllGroupedTagFilterOptions);}}
+                    /></>
                 }
                 <div className="formItem">
                     <FormNotesTextArea

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -57,6 +57,7 @@ import {
     FilterTypeListings,
 } from '../SortingAndFiltering/FilterLibraries';
 import NewBadge from '../ReusableComponents/NewBadge';
+import ToolTip from '../ReusableComponents/ToolTip';
 
 interface PersonFormProps {
     isEditPersonForm: boolean;
@@ -331,6 +332,7 @@ function PersonForm({
                         selectedTagsState={{selectedTags: selectedPersonTags, setSelectedTags: setSelectedPersonTags}}
                         loadingState={{isLoading, setIsLoading}}
                         addGroupedTagFilterOptions={(trait: TagInterface): void => {addGroupedTagFilterOptions(FilterTypeListings.PersonTag.index, trait, allGroupedTagFilterOptions, setAllGroupedTagFilterOptions);}}
+                        toolTip={<ToolTip contentText="blah blah blah"/>}
                     /></>
                 }
                 <div className="formItem">

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -272,6 +272,10 @@ function PersonForm({
         return filteredProducts.map(selectable => {return {value: selectable.name, label: selectable.name};});
     };
 
+    const hoverBoxContent = (): JSX.Element => {
+        return <p>Create tags based on your people. Example, skills, education, employee status, etc. Anything you would like to see it filter</p>;
+    };
+
     return (
         <div className="formContainer">
             <form className="form"
@@ -332,7 +336,7 @@ function PersonForm({
                         selectedTagsState={{selectedTags: selectedPersonTags, setSelectedTags: setSelectedPersonTags}}
                         loadingState={{isLoading, setIsLoading}}
                         addGroupedTagFilterOptions={(trait: TagInterface): void => {addGroupedTagFilterOptions(FilterTypeListings.PersonTag.index, trait, allGroupedTagFilterOptions, setAllGroupedTagFilterOptions);}}
-                        toolTip={<ToolTip contentText="blah blah blah"/>}
+                        toolTip={<ToolTip contentText={hoverBoxContent()}/>}
                     /></>
                 }
                 <div className="formItem">

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -272,8 +272,8 @@ function PersonForm({
         return filteredProducts.map(selectable => {return {value: selectable.name, label: selectable.name};});
     };
 
-    const hoverBoxContent = (): JSX.Element => {
-        return <p>Create tags based on your people. Example, skills, education, employee status, etc. Anything you would like to see it filter</p>;
+    const toolTipContent = (): JSX.Element => {
+        return <span className="toolTipContent">Create tags based on your people. Example, skills, education, employee status, etc. Anything on which you would like to filter.</span>;
     };
 
     return (
@@ -336,7 +336,7 @@ function PersonForm({
                         selectedTagsState={{selectedTags: selectedPersonTags, setSelectedTags: setSelectedPersonTags}}
                         loadingState={{isLoading, setIsLoading}}
                         addGroupedTagFilterOptions={(trait: TagInterface): void => {addGroupedTagFilterOptions(FilterTypeListings.PersonTag.index, trait, allGroupedTagFilterOptions, setAllGroupedTagFilterOptions);}}
-                        toolTip={<ToolTip contentText={hoverBoxContent()}/>}
+                        toolTip={<ToolTip contentText={toolTipContent()}/>}
                     /></>
                 }
                 <div className="formItem">

--- a/ui/src/ReusableComponents/FormTagsField.tsx
+++ b/ui/src/ReusableComponents/FormTagsField.tsx
@@ -40,6 +40,7 @@ interface Props {
     currentSpace: Space;
     tagClient: TagClient;
     tagsMetadata: Metadata;
+    toolTip?: JSX.Element;
 }
 
 function FormTagsField({
@@ -58,6 +59,7 @@ function FormTagsField({
     addGroupedTagFilterOptions,
     tagClient,
     tagsMetadata,
+    toolTip,
 }: Props): JSX.Element {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const uuid = currentSpace.uuid!;
@@ -127,6 +129,7 @@ function FormTagsField({
             onChange={onChange}
             onSave={handleCreateTag}
             isLoading={isLoading}
+            toolTip={toolTip}
         />
     );
 }

--- a/ui/src/ReusableComponents/NewBadge.scss
+++ b/ui/src/ReusableComponents/NewBadge.scss
@@ -24,7 +24,6 @@
     justify-content: center;
     background: $logo-gradient;
     border-radius: 8px;
-    position: absolute;
     margin-top: -5px;
     margin-left: -4px;
     width: 26px;

--- a/ui/src/ReusableComponents/NewBadge.scss
+++ b/ui/src/ReusableComponents/NewBadge.scss
@@ -17,7 +17,7 @@
 
 @import '../Application/Styleguide/Colors.scss';
 
-.newBadgeContainer {
+.newBadge {
     display: flex;
     flex-direction: column;
     text-align: center;
@@ -29,11 +29,6 @@
     width: 26px;
     height: 12px;
     font-size: 0.5rem;
-}
-
-.newBadgeText {
-    font-size: 8px;
     color: $white;
     font-weight: normal;
-    padding-top: 2px;
 }

--- a/ui/src/ReusableComponents/NewBadge.tsx
+++ b/ui/src/ReusableComponents/NewBadge.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import './NewBadge.scss';
 
 function NewBadge(): JSX.Element {
-    return <span className="newBadgeContainer" data-testid="newBadge"><span className="newBadgeText">NEW</span></span>;
+    return <span className="newBadge" data-testid="newBadge">NEW</span>;
 }
 
 export default NewBadge;

--- a/ui/src/ReusableComponents/ToolTip.scss
+++ b/ui/src/ReusableComponents/ToolTip.scss
@@ -17,23 +17,57 @@
 
 @import '../Application/Styleguide/Main.scss';
 
-.whatIsThisLabel {
-  font-size: 12px;
-  line-height: 14px;
-  text-decoration-line: underline;
-  color: $prime-1;
+.whatIsThisContainer {
+  position: relative;
+  padding-left: 10px;
+
+  .whatIsThisLabel {
+    font-size: 12px;
+    line-height: 14px;
+    text-decoration-line: underline;
+    color: $prime-1;
+    font-weight: normal;
+  }
+
+  .whatIsThisHover{
+    display: none;
+    font-size: 12px;
+    font-weight: normal;
+    line-height: 16px;
+    color: $gray-1;
+    border-radius: 7px;
+    background-color: white;
+    z-index: 2;
+    width: 160px;
+    padding: 0 8px;
+    border: 1px solid $prime-1;
+
+  }
+
+  .whatIsThisHoverNotch {
+    position: absolute;
+    top: -10px;
+    left: 20px;
+    margin: 0;
+    border-top: 0;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-bottom: 10px solid white;
+    padding: 0;
+    width: 0;
+    height: 0;
+  }
+
+
+  .whatIsThisHover .whatIsThisHoverNotchBorder-notch { border-bottom-color: $prime-1;
+    top: -11px;
+  }
+
+}
+.whatIsThisContainer:hover .whatIsThisHover {
+  display: block;
+  position: absolute;
+  top: 32px;
 }
 
-.whatIsThisHover{
-  display: none;
-  font-size: 12px;
-  line-height: 14px;
-  color: $gray-1;
-  text-decoration-line: none;
-  border: $prime-1 1px;
-}
 
-.whatIsThisLabel:hover .whatIsThisHover {
-  display: block;;
-
-}

--- a/ui/src/ReusableComponents/ToolTip.scss
+++ b/ui/src/ReusableComponents/ToolTip.scss
@@ -1,0 +1,39 @@
+/*
+ *   Copyright (c) 2021 Ford Motor Company
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+@import '../Application/Styleguide/Main.scss';
+
+.whatIsThisLabel {
+  font-size: 12px;
+  line-height: 14px;
+  text-decoration-line: underline;
+  color: $prime-1;
+}
+
+.whatIsThisHover{
+  display: none;
+  font-size: 12px;
+  line-height: 14px;
+  color: $gray-1;
+  text-decoration-line: none;
+  border: $prime-1 1px;
+}
+
+.whatIsThisLabel:hover .whatIsThisHover {
+  display: block;;
+
+}

--- a/ui/src/ReusableComponents/ToolTip.scss
+++ b/ui/src/ReusableComponents/ToolTip.scss
@@ -33,13 +33,12 @@
 
   .whatIsThisHover{
     font-size: 12px;
-    line-height: 16px;
     color: $gray-1;
     border-radius: 7px;
     background-color: white;
     z-index: 2;
     width: 160px;
-    padding: 0 8px;
+    padding: 8px;
     border: 1px solid $prime-1;
     position: absolute;
     top: 32px;

--- a/ui/src/ReusableComponents/ToolTip.scss
+++ b/ui/src/ReusableComponents/ToolTip.scss
@@ -19,7 +19,9 @@
 
 .whatIsThisContainer {
   position: relative;
-  padding-left: 10px;
+  padding-left: 6px;
+  background-color: white;
+  margin-left: 6px;
 
   .whatIsThisLabel {
     font-size: 12px;
@@ -30,9 +32,7 @@
   }
 
   .whatIsThisHover{
-    display: none;
     font-size: 12px;
-    font-weight: normal;
     line-height: 16px;
     color: $gray-1;
     border-radius: 7px;
@@ -41,33 +41,34 @@
     width: 160px;
     padding: 0 8px;
     border: 1px solid $prime-1;
-
+    position: absolute;
+    top: 32px;
+    text-align: left;
   }
 
   .whatIsThisHoverNotch {
     position: absolute;
     top: -10px;
     left: 20px;
-    margin: 0;
     border-top: 0;
     border-left: 10px solid transparent;
     border-right: 10px solid transparent;
     border-bottom: 10px solid white;
-    padding: 0;
     width: 0;
     height: 0;
   }
 
-
   .whatIsThisHover .whatIsThisHoverNotchBorder-notch { border-bottom-color: $prime-1;
     top: -11px;
   }
-
 }
-.whatIsThisContainer:hover .whatIsThisHover {
+
+.whatIsThisHoverShow {
   display: block;
-  position: absolute;
-  top: 32px;
+
 }
 
+.whatIsThisHoverNotShow {
+  display: none;
+}
 

--- a/ui/src/ReusableComponents/ToolTip.scss
+++ b/ui/src/ReusableComponents/ToolTip.scss
@@ -29,6 +29,7 @@
     text-decoration-line: underline;
     color: $prime-1;
     font-weight: normal;
+    letter-spacing: normal;
   }
 
   .whatIsThisHover{

--- a/ui/src/ReusableComponents/ToolTip.test.tsx
+++ b/ui/src/ReusableComponents/ToolTip.test.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import {fireEvent, render, RenderResult} from '@testing-library/react';
+import ToolTip from './ToolTip';
+
+describe('ToolTip', () => {
+    let app: RenderResult;
+
+    beforeEach(() => {
+        app = render(<ToolTip contentText={<p>something </p>}/>);
+    });
+    
+    it('should show the tip on mouse hover',  async () => {
+        let button = await app.findByText('What\'s this?');
+        let tip = await app.findByTestId('whatIsThisTip');
+
+        expect(tip.classList.contains('whatIsThisHoverNotShow')).toBe(true);
+        expect(tip.classList.contains('whatIsThisHoverShow')).toBe(false);
+        fireEvent.mouseOver(button);
+        expect(tip.classList.contains('whatIsThisHoverNotShow')).toBe(false);
+        expect(tip.classList.contains('whatIsThisHoverShow')).toBe(true);
+        fireEvent.mouseLeave(button);
+        expect(tip.classList.contains('whatIsThisHoverNotShow')).toBe(true);
+        expect(tip.classList.contains('whatIsThisHoverShow')).toBe(false);
+    });
+
+    it('should show the tip on focus',  async () => {
+        let button = await app.findByText('What\'s this?');
+        let tip = await app.findByTestId('whatIsThisTip');
+
+        expect(tip.classList.contains('whatIsThisHoverNotShow')).toBe(true);
+        expect(tip.classList.contains('whatIsThisHoverShow')).toBe(false);
+        fireEvent.focus(button);
+        expect(tip.classList.contains('whatIsThisHoverNotShow')).toBe(false);
+        expect(tip.classList.contains('whatIsThisHoverShow')).toBe(true);
+        fireEvent.blur(button);
+        expect(tip.classList.contains('whatIsThisHoverNotShow')).toBe(true);
+        expect(tip.classList.contains('whatIsThisHoverShow')).toBe(false);
+    });
+});

--- a/ui/src/ReusableComponents/ToolTip.tsx
+++ b/ui/src/ReusableComponents/ToolTip.tsx
@@ -31,6 +31,7 @@ const ToolTip = (props: ToolTipProps): JSX.Element => {
             onMouseLeave={(): void => setIsHovering(false)}
             onFocus={(): void => setIsHovering(true)}
             onBlur={(): void => setIsHovering(false)}
+            onClick={ (event): void => event.preventDefault()}
             className="whatIsThisContainer">
             <span className="whatIsThisLabel">What&apos;s this?</span>
             <div data-testid="whatIsThisTip" className={ isHovering ? 'whatIsThisHover whatIsThisHoverShow' : 'whatIsThisHover whatIsThisHoverNotShow'}>

--- a/ui/src/ReusableComponents/ToolTip.tsx
+++ b/ui/src/ReusableComponents/ToolTip.tsx
@@ -1,0 +1,34 @@
+/*
+ *   Copyright (c) 2021 Ford Motor Company
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+import React from 'react';
+import './ToolTip.scss';
+
+interface ToolTipProps {
+    contentText: string;
+}
+
+const ToolTip = (props: ToolTipProps): JSX.Element => {
+    return (
+        <div className="whatIsThisLabel">
+            <span>What&apos;s This?</span>
+            <div className="whatIsThisHover"><p>{props.contentText}</p></div>
+        </div>
+    );
+};
+
+export default ToolTip;

--- a/ui/src/ReusableComponents/ToolTip.tsx
+++ b/ui/src/ReusableComponents/ToolTip.tsx
@@ -19,14 +19,18 @@ import React from 'react';
 import './ToolTip.scss';
 
 interface ToolTipProps {
-    contentText: string;
+    contentText: JSX.Element;
 }
 
 const ToolTip = (props: ToolTipProps): JSX.Element => {
     return (
-        <div className="whatIsThisLabel">
-            <span>What&apos;s This?</span>
-            <div className="whatIsThisHover"><p>{props.contentText}</p></div>
+        <div className="whatIsThisContainer">
+            <span className="whatIsThisLabel">What&apos;s This?</span>
+            <div className="whatIsThisHover">
+                {props.contentText}
+                <b className="whatIsThisHoverNotchBorder-notch whatIsThisHoverNotch"/>
+                <b className="whatIsThisHoverNotch"/>
+            </div>
         </div>
     );
 };

--- a/ui/src/ReusableComponents/ToolTip.tsx
+++ b/ui/src/ReusableComponents/ToolTip.tsx
@@ -15,7 +15,7 @@
  *   limitations under the License.
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 import './ToolTip.scss';
 
 interface ToolTipProps {
@@ -23,15 +23,22 @@ interface ToolTipProps {
 }
 
 const ToolTip = (props: ToolTipProps): JSX.Element => {
+    const [isHovering, setIsHovering] = useState<boolean>(false);
+
+
     return (
-        <div className="whatIsThisContainer">
-            <span className="whatIsThisLabel">What&apos;s This?</span>
-            <div className="whatIsThisHover">
+        <button onMouseOver={(): void => setIsHovering(true)}
+            onMouseLeave={(): void => setIsHovering(false)}
+            onFocus={(): void => setIsHovering(true)}
+            onBlur={(): void => setIsHovering(false)}
+            className="whatIsThisContainer">
+            <span className="whatIsThisLabel">What&apos;s this?</span>
+            <div data-testid="whatIsThisTip" className={ isHovering ? 'whatIsThisHover whatIsThisHoverShow' : 'whatIsThisHover whatIsThisHoverNotShow'}>
                 {props.contentText}
                 <b className="whatIsThisHoverNotchBorder-notch whatIsThisHoverNotch"/>
                 <b className="whatIsThisHoverNotch"/>
             </div>
-        </div>
+        </button>
     );
 };
 


### PR DESCRIPTION
## Issue
Resolves 134
## What was done
- [x] Add a hover board to the person tag form.
- [x] Made it accessible on tab too 

## How to test
1. add the #person-tags and go to the person form. Over the 'What's this ' and see the hover box appears!
2. Tab to the tool tip and see the tool tip show 

## Accessiblity Criteria
### Testing
- [ ] Add jest-axe unit tests (for new ui components)

### Manual Checks
- [ ] Text and background color meets a minimum color contrast ratio of 4.5:1
- [ ] All non-text content (e.g. images, icon) has alt text
- [ ] Web page includes appropriate headings to communicate structure/hierarchy (h1>h2>h3)
- [ ] All functionality is available to a keyboard
  - [ ] Focus styles are highly visible 
  - [ ] Tab order is logical and aligns with the visual order 
- [ ] Voice over is understandable and logical
  - [ ] Aria labels are added to elements with no visible text 
  - [ ] Decorative elements (e.g. non-informative icons) are hidden from screen readers  
- [ ] Form fields have appropriately coded labels that are visible during input 
- [ ] Links are visually identifiable and have a clear focus and active state 
