### PR TITLE
220 Matomo Add which tag are being assign to a user

### DIFF
--- a/ui/src/People/People.test.tsx
+++ b/ui/src/People/People.test.tsx
@@ -143,6 +143,9 @@ describe('People actions', () => {
 
             fireEvent.click(app.getByLabelText('Mark as New'));
 
+            const personTagsLabel = await app.findByLabelText('Person Tags');
+            await selectEvent.create(personTagsLabel, 'Low Achiever');
+
             fireEvent.click(app.getByText(submitFormButtonText));
 
             await wait(() => {
@@ -151,10 +154,13 @@ describe('People actions', () => {
                     ...emptyPerson(),
                     name: 'New Bobby',
                     newPerson: true,
-                    tags: [],
+                    tags: [{id: 1337,
+                        spaceUuid:'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+                        name: 'Low Achiever'}],
                 };
                 const spy = jest.spyOn(PeopleClient, 'createPersonForSpace');
-                expect(spy.mock.calls[0]).toEqual([TestUtils.space, expectedPerson]);
+
+                expect(spy.mock.calls[0]).toEqual([TestUtils.space, expectedPerson, ['Low Achiever']]);
             });
         });
 
@@ -206,7 +212,7 @@ describe('People actions', () => {
                     spaceRole: {name: 'Product Manager', id: 2, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', color: TestUtils.color2},
                 };
                 const spy = jest.spyOn(PeopleClient, 'createPersonForSpace');
-                expect(spy.mock.calls[0]).toEqual([TestUtils.space, expectedPerson]);
+                expect(spy.mock.calls[0]).toEqual([TestUtils.space, expectedPerson, []]);
             });
         });
 
@@ -232,7 +238,7 @@ describe('People actions', () => {
                     spaceRole: {name: 'Product Owner', id: 1, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', color: {color: '1', id: 2}},
                 };
                 const spy = jest.spyOn(PeopleClient, 'createPersonForSpace');
-                expect(spy.mock.calls[0]).toEqual([TestUtils.space, expectedPerson]);
+                expect(spy.mock.calls[0]).toEqual([TestUtils.space, expectedPerson, []]);
             });
         });
 
@@ -278,7 +284,7 @@ describe('People actions', () => {
 
         const checkForCreatedPerson = async (): Promise<void> => {
             expect(PeopleClient.createPersonForSpace).toBeCalledTimes(1);
-            expect(PeopleClient.createPersonForSpace).toBeCalledWith(TestUtils.space, expectedPerson);
+            expect(PeopleClient.createPersonForSpace).toBeCalledWith(TestUtils.space, expectedPerson, []);
 
             expect(AssignmentClient.createAssignmentForDate).toBeCalledTimes(1);
             expect(AssignmentClient.createAssignmentForDate).toBeCalledWith(

--- a/ui/src/People/PeopleClient.test.tsx
+++ b/ui/src/People/PeopleClient.test.tsx
@@ -67,7 +67,7 @@ describe('People Client', function() {
 
     it('should create a person and return that person', function(done) {
         const newPerson = TestUtils.person1;
-        PeopleClient.createPersonForSpace(TestUtils.space, newPerson)
+        PeopleClient.createPersonForSpace(TestUtils.space, newPerson, [])
             .then((response) => {
                 expect(Axios.post).toHaveBeenCalledWith(basePeopleUrl, newPerson, expectedConfig);
                 expect(response.data).toBe('Created Person');
@@ -78,7 +78,7 @@ describe('People Client', function() {
     it('should edit a person and return that person', function(done) {
         const updatedPerson = TestUtils.person1;
         const expectedUrl = basePeopleUrl + `/${updatedPerson.id}`;
-        PeopleClient.updatePerson(TestUtils.space, updatedPerson)
+        PeopleClient.updatePerson(TestUtils.space, updatedPerson, [])
             .then((response) => {
                 expect(Axios.put).toHaveBeenCalledWith(expectedUrl, updatedPerson, expectedConfig);
                 expect(response.data).toBe('Updated Person');
@@ -117,9 +117,10 @@ describe('People Client', function() {
         });
 
         it('should send an event to matomo when a person is created', async () => {
-            await PeopleClient.createPersonForSpace(TestUtils.space, person);
+            await PeopleClient.createPersonForSpace(TestUtils.space, person, ['bob']);
             // @ts-ignore
             expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'addPerson', expectedName]);
+            expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'assignPersonTagToANewPerson', 'bob']);
         });
     });
 });

--- a/ui/src/People/PeopleClient.ts
+++ b/ui/src/People/PeopleClient.ts
@@ -38,7 +38,7 @@ class PeopleClient {
         return Axios.get(url, config);
     }
 
-    static async createPersonForSpace(space: Space, person: Person): Promise<AxiosResponse> {
+    static async createPersonForSpace(space: Space, person: Person, personTagModified: string[]): Promise<AxiosResponse> {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const url = this.getBasePeopleUrl(space.uuid!);
         let config = {
@@ -50,6 +50,7 @@ class PeopleClient {
 
         return Axios.post(url, person, config).then(result => {
             MatomoEvents.pushEvent(space.name, 'addPerson', person.name);
+            if (personTagModified.length > 0 ) MatomoEvents.pushEvent(space.name, 'assignPersonTagToANewPerson', personTagModified.toString());
             return result;
         }).catch( err => {
             MatomoEvents.pushEvent(space.name, 'addPersonError', person.name, err.code);
@@ -57,7 +58,7 @@ class PeopleClient {
         });
     }
 
-    static async updatePerson(space: Space, person: Person): Promise<AxiosResponse> {
+    static async updatePerson(space: Space, person: Person, personTagModified: string[]): Promise<AxiosResponse> {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const url = this.getBasePeopleUrl(space.uuid!!) + `/${person.id}`;
         let config = {
@@ -69,6 +70,7 @@ class PeopleClient {
 
         return Axios.put(url, person, config).then(result => {
             MatomoEvents.pushEvent(space.name, 'editPerson', person.name);
+            if (personTagModified.length > 0 ) MatomoEvents.pushEvent(space.name, 'assignPersonTagToAnAlreadyExistingPerson', personTagModified.toString());
             return result;
         }).catch( err => {
             MatomoEvents.pushEvent(space.name, 'editPersonError', person.name, err.code);

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -165,6 +165,18 @@ function PersonForm({
 
     };
 
+    const getAddedPersonTag = (): string[] => {
+        let result: string[] = [];
+        if (person.tags !== selectedPersonTags) {
+            result = selectedPersonTags.filter(tag => {
+                return !person.tags.includes(tag);
+            }).map(tag => {
+                return tag.name;
+            });
+        }
+        return result;
+    };
+
     const handleSubmit = async (event: FormEvent): Promise<void> => {
         event.preventDefault();
 
@@ -172,13 +184,15 @@ function PersonForm({
             setIsPersonNameInvalid(true);
         } else {
             setIsPersonNameInvalid(false);
+
+            let personTagModified = getAddedPersonTag();
             person.tags = selectedPersonTags;
 
             if (selectedProducts.length === 0) {
                 setIsUnassignedDrawerOpen(true);
             }
             if (isEditPersonForm && assignment) {
-                const response = await PeopleClient.updatePerson(currentSpace, person);
+                const response = await PeopleClient.updatePerson(currentSpace, person, personTagModified);
                 await AssignmentClient.createAssignmentForDate(
                     moment(viewingDate).format('YYYY-MM-DD'),
                     getSelectedProductPairs(),
@@ -188,7 +202,7 @@ function PersonForm({
                 const updatedPerson: Person = response.data;
                 editPerson(updatedPerson);
             } else {
-                const response = await PeopleClient.createPersonForSpace(currentSpace, person);
+                const response = await PeopleClient.createPersonForSpace(currentSpace, person, personTagModified);
                 const newPerson: Person = response.data;
                 addPerson(newPerson);
                 await AssignmentClient.createAssignmentForDate(

--- a/ui/src/tests/TestUtils.tsx
+++ b/ui/src/tests/TestUtils.tsx
@@ -212,7 +212,7 @@ class TestUtils {
             data: TestUtils.personTags,
         } as AxiosResponse));
         PersonTagClient.add = jest.fn(() => Promise.resolve({
-            data: {id: 1337, name: 'Low Achiever'},
+            data: {id: 1337, name: 'Low Achiever', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'},
         } as AxiosResponse));
         PersonTagClient.edit = jest.fn(() => Promise.resolve({
             data: {id: 6, name: 'Halo Group', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'},


### PR DESCRIPTION
Co-authored-by: Vianney Willot <vianney.willot@gmail.com>
Co-authored-by: John Cherney <jwcherney@hotmail.com>

## Issue
Resolves XXX (where XXX is the related issue)

## What was done
- [x] added matomo events to track what tags are being assigned to people

## How to test
1. When push to prod see matomo event appear with the correct info
