### PR TITLE
248 trim spaces from inputs

### DIFF
--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/LocalConfig.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/LocalConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/PeopleMoverApplication.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/PeopleMoverApplication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/Assignment.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/Assignment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/CreateAssignmentsRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/CreateAssignmentsRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/Reassignment.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/Reassignment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/AssignmentAlreadyExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/AssignmentAlreadyExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/AssignmentNotExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/AssignmentNotExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/InvalidDateFormatException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/assignment/exceptions/InvalidDateFormatException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AccessTokenRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AccessTokenRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthCheckScopesRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthCheckScopesRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/RefreshTokenRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/RefreshTokenRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/ValidateTokenRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/ValidateTokenRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/exceptions/InvalidTokenException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/exceptions/InvalidTokenException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryFactory.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryFactoryBean.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryFactoryBean.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryImpl.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/PeopleMoverRepositoryImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/exceptions/EntityAlreadyExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/baserepository/exceptions/EntityAlreadyExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/Color.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/Color.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/ColorService.kt
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Service
 class ColorService(private val colorRepository: ColorRepository) {
     fun addColors(colors: List<String>) {
         try {
-            colors.forEach { color: String -> colorRepository.save(Color(color = color)) }
+            colors.forEach { color: String -> colorRepository.save(Color(color = color.trim())) }
         } catch (e: DataIntegrityViolationException) {
             throw ColorAlreadyExistsException()
         }

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/exceptions/ColorAlreadyExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/exceptions/ColorAlreadyExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/exceptions/ColorDoesNotExistException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/color/exceptions/ColorDoesNotExistException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonRequest.kt
@@ -48,12 +48,12 @@ data class PersonRequest(
 
 fun PersonRequest.toPerson(spaceUuid: String, id: Int? = null): Person = Person(
         id = id,
-        name = this.name,
+        name = this.name.trim(),
         spaceRole = this.spaceRole,
-        notes = this.notes,
+        notes = this.notes?.trim(),
         newPerson = this.newPerson,
         newPersonDate = this.newPersonDate,
         spaceUuid = spaceUuid,
         tags = this.tags,
-        customField1 = this.customField1
+        customField1 = this.customField1?.trim()
 )

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/PersonService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/exceptions/PersonNotExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/person/exceptions/PersonNotExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/Product.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/Product.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductRequest.kt
@@ -50,15 +50,15 @@ data class ProductRequest(
 fun ProductRequest.toProduct(productId: Int? = null, spaceUuid: String): Product =
     Product(
         id = productId,
-        name = name,
+        name = name.trim(),
         tags = tags,
         startDate = startDate,
         endDate = endDate,
-        dorf = dorf,
+        dorf = dorf.trim(),
         spaceLocation = spaceLocation,
         archived = archived,
-        notes = notes,
-        url = url,
+        notes = notes.trim(),
+        url = url?.trim(),
         spaceUuid = spaceUuid
     )
 

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/ProductService.kt
@@ -49,11 +49,11 @@ class ProductService(
         productRepository.findProductByNameAndSpaceUuid(productRequest.name, spaceUuid)?.let {
             throw EntityAlreadyExistsException()
         }
-        validateLinkUrl(productRequest)
+        ensureValidUrlScheme(productRequest)
         return productRepository.createEntityAndUpdateSpaceLastModified(productRequest.toProduct(spaceUuid = spaceUuid))
     }
 
-    private fun validateLinkUrl(productRequest: ProductRequest) {
+    private fun ensureValidUrlScheme(productRequest: ProductRequest) {
         if (!productRequest.url.isNullOrEmpty()) {
             if ((productRequest.url!!.startsWith("https://", true) || productRequest.url!!.startsWith("http:", true))) {
                return
@@ -80,7 +80,7 @@ class ProductService(
             }
         }
 
-        validateLinkUrl(productRequest)
+        ensureValidUrlScheme(productRequest)
 
         val product: Product = productRequest.toProduct(productId, spaceUuid)
         return productRepository.updateEntityAndUpdateSpaceLastModified(product)

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/InvalidProductSpaceMappingException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/InvalidProductSpaceMappingException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/ProductFieldTooLongException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/product/exceptions/ProductFieldTooLongException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/report/PeopleReportRow.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/report/PeopleReportRow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/report/SpaceReportItem.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/report/SpaceReportItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/EditSpaceRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/EditSpaceRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/Space.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/Space.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/Space.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/Space.kt
@@ -48,7 +48,7 @@ data class Space (
 )
 
 fun Space.update(editSpaceRequest: EditSpaceRequest): Space {
-    val updatedName = editSpaceRequest.name ?: this.name
+    val updatedName = editSpaceRequest.name?.trim() ?: this.name
     val updatedTodayViewAsPublic = editSpaceRequest.todayViewIsPublic ?: this.todayViewIsPublic
     return this.copy(name = updatedName, todayViewIsPublic = updatedTodayViewAsPublic, lastModifiedDate = Timestamp(Date().time))
 }

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceComponent.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceComponent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceCreationRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceCreationRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceResponse.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
@@ -45,7 +45,7 @@ class SpaceService(
         } else {
             val savedSpace = spaceRepository.save(
                     Space(
-                            name = spaceName,
+                            name = spaceName.trim(),
                             lastModifiedDate = Timestamp(Date().time),
                             createdBy = createdBy,
                             createdDate = LocalDateTime.now()

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/TimestampResponse.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/TimestampResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceIsReadOnlyException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceIsReadOnlyException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceNameInvalidException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceNameInvalidException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceNameTooLongException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceNameTooLongException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceNotExistsException.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/exceptions/SpaceNotExistsException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/TagRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/TagRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/location/LocationController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/location/LocationController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/location/LocationService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/location/LocationService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/location/LocationService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/location/LocationService.kt
@@ -28,9 +28,9 @@ class LocationService(
 ) {
     fun addLocationToSpace(spaceUuid: String, locationAddRequest: TagRequest): SpaceLocation {
 
-        val spaceLocationToSave = SpaceLocation(name = locationAddRequest.name, spaceUuid = spaceUuid)
+        val spaceLocationToSave = SpaceLocation(name = locationAddRequest.name.trim(), spaceUuid = spaceUuid)
         return try {
-            spaceLocationRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, locationAddRequest.name)?.let { throw EntityAlreadyExistsException() }
+            spaceLocationRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, spaceLocationToSave.name)?.let { throw EntityAlreadyExistsException() }
             spaceLocationRepository.createEntityAndUpdateSpaceLastModified(spaceLocationToSave)
         } catch (e: DataIntegrityViolationException ) {
             throw EntityAlreadyExistsException()
@@ -41,11 +41,10 @@ class LocationService(
         spaceLocationRepository.findAllBySpaceUuid(spaceUuid)
 
     fun editLocation(spaceUuid: String, locationRequest: TagRequest, locationId: Int): SpaceLocation {
+        val spaceLocationToEdit = SpaceLocation(id = locationId, name = locationRequest.name.trim(), spaceUuid = spaceUuid)
         return try {
-            spaceLocationRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, locationRequest.name)?.let { throw EntityAlreadyExistsException() }
-            spaceLocationRepository.updateEntityAndUpdateSpaceLastModified(
-                SpaceLocation(id = locationId, name = locationRequest.name, spaceUuid = spaceUuid)
-            )
+            spaceLocationRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, spaceLocationToEdit.name)?.let { throw EntityAlreadyExistsException() }
+            spaceLocationRepository.updateEntityAndUpdateSpaceLastModified(spaceLocationToEdit)
         } catch (e: DataIntegrityViolationException) {
             throw EntityAlreadyExistsException()
         }

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/location/SpaceLocation.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/location/SpaceLocation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/location/SpaceLocationRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/location/SpaceLocationRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTag.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTag.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTagController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTagController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTagRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTagRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTagService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTagService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTagService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTagService.kt
@@ -28,9 +28,10 @@ class PersonTagService(
         private val personTagRepository: PersonTagRepository
 ) {
     fun createPersonTagForSpace(request: TagRequest, spaceUuid: String): PersonTag {
+        val personTagToCreate = PersonTag(name = request.name.trim(), spaceUuid = spaceUuid)
         return try {
-            personTagRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, request.name)?.let { throw EntityAlreadyExistsException() }
-            personTagRepository.createEntityAndUpdateSpaceLastModified(PersonTag(name = request.name, spaceUuid = spaceUuid))
+            personTagRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, personTagToCreate.name)?.let { throw EntityAlreadyExistsException() }
+            personTagRepository.createEntityAndUpdateSpaceLastModified(personTagToCreate)
         } catch (e: DataIntegrityViolationException) {
             throw EntityAlreadyExistsException()
         }
@@ -52,9 +53,10 @@ class PersonTagService(
             personTagId: Int,
             tagEditRequest: TagRequest
     ): PersonTag {
+        val personTagToEdit = PersonTag(id = personTagId, name = tagEditRequest.name.trim(), spaceUuid = spaceUuid)
         return try {
-            personTagRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, tagEditRequest.name)?.let { throw EntityAlreadyExistsException() }
-            personTagRepository.updateEntityAndUpdateSpaceLastModified(PersonTag(personTagId, spaceUuid, tagEditRequest.name))
+            personTagRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, personTagToEdit.name)?.let { throw EntityAlreadyExistsException() }
+            personTagRepository.updateEntityAndUpdateSpaceLastModified(personTagToEdit)
         } catch (e: DataIntegrityViolationException) {
             throw EntityAlreadyExistsException()
         }

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTag.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTag.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTagController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTagController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTagRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTagRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTagService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTagService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTagService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTagService.kt
@@ -28,9 +28,10 @@ class ProductTagService(
         private val productTagRepository: ProductTagRepository
 ) {
     fun createProductTagForSpace(request: TagRequest, spaceUuid: String): ProductTag {
+        val productTagToCreate = ProductTag(name = request.name.trim(), spaceUuid = spaceUuid)
         return try {
-            productTagRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, request.name)?.let { throw EntityAlreadyExistsException() }
-            productTagRepository.createEntityAndUpdateSpaceLastModified(ProductTag(name = request.name, spaceUuid = spaceUuid))
+            productTagRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, productTagToCreate.name)?.let { throw EntityAlreadyExistsException() }
+            productTagRepository.createEntityAndUpdateSpaceLastModified(productTagToCreate)
         } catch (e: DataIntegrityViolationException) {
             throw EntityAlreadyExistsException()
         }
@@ -52,9 +53,10 @@ class ProductTagService(
             productTagId: Int,
             tagEditRequest: TagRequest
     ): ProductTag {
+        val productTagToEdit = ProductTag(id = productTagId, name = tagEditRequest.name.trim(), spaceUuid = spaceUuid)
         return try {
-            productTagRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, tagEditRequest.name)?.let { throw EntityAlreadyExistsException() }
-            productTagRepository.updateEntityAndUpdateSpaceLastModified(ProductTag(productTagId, spaceUuid, tagEditRequest.name))
+            productTagRepository.findAllBySpaceUuidAndNameIgnoreCase(spaceUuid, productTagToEdit.name)?.let { throw EntityAlreadyExistsException() }
+            productTagRepository.updateEntityAndUpdateSpaceLastModified(productTagToEdit)
         } catch (e: DataIntegrityViolationException) {
             throw EntityAlreadyExistsException()
         }

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/RoleController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/RoleController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/RoleRequest.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/RoleRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/RoleService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/RoleService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/RoleService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/RoleService.kt
@@ -36,10 +36,10 @@ class RoleService(
     ): SpaceRole {
         spaceRolesRepository.findAllBySpaceUuidAndNameIgnoreCase(
                 spaceUuid,
-                role
+                role.trim()
         )?.let { throw EntityAlreadyExistsException() }
         val colorToAssign: Color? = getColorToAssign(spaceUuid, colorId)
-        val spaceRole = SpaceRole(name = role, color = colorToAssign, spaceUuid = spaceUuid)
+        val spaceRole = SpaceRole(name = role.trim(), color = colorToAssign, spaceUuid = spaceUuid)
         return spaceRolesRepository.createEntityAndUpdateSpaceLastModified(spaceRole)
     }
 
@@ -64,8 +64,8 @@ class RoleService(
                 SpaceRole(
                     id = roleId,
                     spaceUuid = spaceUuid,
-                    name = roleEditRequest.name,
-                        color = colorFound
+                    name = roleEditRequest.name.trim(),
+                    color = colorFound
                 )
         )
     }
@@ -92,7 +92,7 @@ class RoleService(
     private fun throwIfUpdatedRoleNameAlreadyUsed(roleEditRequest: RoleRequest, roleId: Int, spaceUuid: String) {
         spaceRolesRepository.findAllBySpaceUuidAndNameIgnoreCase(
                 spaceUuid,
-                roleEditRequest.name
+                roleEditRequest.name.trim()
         )?.let { spaceRole ->
             if (spaceRole.id != roleId) {
                 throw EntityAlreadyExistsException()

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/SpaceRole.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/SpaceRole.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/SpaceRolesRepository.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/tag/role/SpaceRolesRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/utilities/BasicLogger.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/utilities/BasicLogger.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/resources/application-cloud.properties
+++ b/api/src/main/resources/application-cloud.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Ford Motor Company
+# Copyright (c) 2021 Ford Motor Company
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/resources/application-mysql.properties
+++ b/api/src/main/resources/application-mysql.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Ford Motor Company
+# Copyright (c) 2021 Ford Motor Company
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Ford Motor Company
+# Copyright (c) 2021 Ford Motor Company
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerInTimeApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerInTimeApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerReassignmentsApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerReassignmentsApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/auth/AuthControllerTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/auth/AuthControllerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/color/ColorApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/color/ColorApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/person/PersonControllerApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/person/PersonControllerApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerInTimeApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/product/ProductControllerInTimeApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorControllerTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorControllerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorControllerUnauthorizedUserTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/report/ReportGeneratorControllerUnauthorizedUserTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/tag/location/LocationControllerApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/tag/location/LocationControllerApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTagControllerTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/tag/person/PersonTagControllerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTagControllerTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/tag/product/ProductTagControllerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/tag/role/RoleControllerApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/tag/role/RoleControllerApiTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/utilities/BasicLoggerTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/utilities/BasicLoggerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Ford Motor Company
+ * Copyright (c) 2021 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/test/resources/application.properties
+++ b/api/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Ford Motor Company
+# Copyright (c) 2021 Ford Motor Company
 # All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ui/src/ModalFormComponents/EditTagRow.tsx
+++ b/ui/src/ModalFormComponents/EditTagRow.tsx
@@ -53,6 +53,7 @@ function EditTagRow({
 
     const saveTag = (): void => {
         let newTag = tagInputValue as RoleEditRequest;
+        newTag.name = newTag.name.trim();
         if (colors && !(tagInputValue as RoleEditRequest).colorId) {
             newTag = ( {...tagInputValue, colorId: colors[colors.length - 1].id});
         }

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -213,7 +213,6 @@ function PersonForm({
             setIsPersonNameInvalid(false);
 
             let personTagModified = getAddedPersonTag();
-            person.tags = selectedPersonTags;
 
             if (selectedProducts.length === 0) {
                 setIsUnassignedDrawerOpen(true);
@@ -227,8 +226,14 @@ function PersonForm({
                 }
             }
 
+            let personToSend = {...person};
+            personToSend.name = personToSend.name.trim();
+            personToSend.customField1 = personToSend.customField1?.trim();
+            personToSend.notes = personToSend.notes?.trim();
+            personToSend.tags = selectedPersonTags;
+
             if (isEditPersonForm) {
-                const response = await PeopleClient.updatePerson(currentSpace, person, personTagModified);
+                const response = await PeopleClient.updatePerson(currentSpace, personToSend, personTagModified);
                 const updatedPerson: Person = response.data;
                 editPerson(updatedPerson);
                 if (hasAssignmentChanged) {
@@ -241,7 +246,7 @@ function PersonForm({
                 }
 
             } else {
-                const response = await PeopleClient.createPersonForSpace(currentSpace, person, personTagModified);
+                const response = await PeopleClient.createPersonForSpace(currentSpace, personToSend, personTagModified);
                 const newPerson: Person = response.data;
                 addPerson(newPerson);
                 await AssignmentClient.createAssignmentForDate(

--- a/ui/src/Products/ProductForm.tsx
+++ b/ui/src/Products/ProductForm.tsx
@@ -85,7 +85,6 @@ function ProductForm({
 
         setNameWarningMessage('');
 
-        currentProduct.tags = selectedProductTags;
         if (!currentSpace.uuid) {
             console.error('No current space uuid');
             return;
@@ -96,8 +95,14 @@ function ProductForm({
             return;
         }
 
+        let productToSend = {...currentProduct};
+        productToSend.name = productToSend.name.trim();
+        productToSend.url = productToSend.url?.trim();
+        productToSend.notes = productToSend.notes?.trim();
+        productToSend.tags = selectedProductTags;
+
         if (editing) {
-            ProductClient.editProduct(currentSpace, currentProduct)
+            ProductClient.editProduct(currentSpace, productToSend)
                 .then(closeModal)
                 .catch(error => {
                     if (error.response.status === 409) {
@@ -106,7 +111,7 @@ function ProductForm({
                 });
 
         } else {
-            ProductClient.createProduct(currentSpace, currentProduct)
+            ProductClient.createProduct(currentSpace, productToSend)
                 .then(closeModal)
                 .catch(error => {
                     if (error.response.status === 409) {

--- a/ui/src/SpaceDashboard/SpaceForm.tsx
+++ b/ui/src/SpaceDashboard/SpaceForm.tsx
@@ -60,12 +60,15 @@ function SpaceForm({
             setShowWarningMessage(true);
         }
 
+        let spaceToSend = {...formSpace};
+        spaceToSend.name = spaceToSend.name.trim();
+
         if (!!space && formSpace.uuid) {
-            SpaceClient.editSpaceName(formSpace.uuid, formSpace, space.name)
+            SpaceClient.editSpaceName(formSpace.uuid, spaceToSend, space.name)
                 .then(closeModal)
                 .then(fetchUserSpaces);
         } else {
-            SpaceClient.createSpaceForUser(formSpace.name)
+            SpaceClient.createSpaceForUser(spaceToSend.name)
                 .then((response) => setCurrentSpace(response.data.space))
                 .then(closeModal);
         }


### PR DESCRIPTION
## Issue
Resolves 248: Trim spaces from user input strings on front end and back end

## What was done
- [x] Trim spaces from user input strings on front end and back end
- [x] Update copyright year

## How to test
1. Try to enter spaces on things like names, urls, notes, etc. It won't accept them anymore. (Trims them out and then runs with the data.)
