### PR TITLE
Disable the person name button in view only mode on the Time On Product page

### DIFF
--- a/ui/src/TimeOnProductPage/TimeOnProduct.scss
+++ b/ui/src/TimeOnProductPage/TimeOnProduct.scss
@@ -55,25 +55,22 @@
       font-weight: bold;
       white-space: nowrap;
       overflow-x: hidden;
+      cursor: default;
+      background: $white;
+      text-align: left;
+      font-family: Helvetica, sans-serif;
+      font-size: 14px;
     }
 
     .timeOnProductCellName {
       cursor: pointer;
       color: $prime-1;
-      background: $white;
-      text-align: left;
-      font-family: Helvetica, sans-serif;
-      font-size: 14px;
       width: 15rem;
     }
 
     .timeOnProductCellNameDisabled {
       cursor: default;
       color: $gray-1;
-      background: $white;
-      text-align: left;
-      font-family: Helvetica, sans-serif;
-      font-size: 14px;
       width: 15rem;
       opacity: 1;
     }
@@ -91,6 +88,7 @@
     font-weight: bold;
 
     .timeOnProductHeaderCell {
+      cursor: default;
       height: 2rem;
       width: 16rem;
       margin: 0rem;

--- a/ui/src/TimeOnProductPage/TimeOnProduct.scss
+++ b/ui/src/TimeOnProductPage/TimeOnProduct.scss
@@ -67,6 +67,17 @@
       width: 15rem;
     }
 
+    .timeOnProductCellNameDisabled {
+      cursor: default;
+      color: $gray-1;
+      background: $white;
+      text-align: left;
+      font-family: Helvetica, sans-serif;
+      font-size: 14px;
+      width: 15rem;
+      opacity: 1;
+    }
+
     .timeOnProductCellDays {
       width: 12rem;
     }

--- a/ui/src/TimeOnProductPage/TimeOnProduct.test.tsx
+++ b/ui/src/TimeOnProductPage/TimeOnProduct.test.tsx
@@ -81,7 +81,8 @@ describe('TimeOnProduct', () => {
         });
 
         it('should make the call to open the Edit Person modal when person name is clicked', async () => {
-            const hank = app.getByText('Hank');
+            const hank = app.getByText(TestUtils.hank.name);
+            expect(hank).toBeEnabled();
             fireEvent.click(hank);
             expect(store.dispatch).toHaveBeenCalledWith(
                 setCurrentModalAction({
@@ -227,6 +228,21 @@ describe('TimeOnProduct', () => {
                 store.dispatch(setViewingDateAction(new Date(2020, 0, 1)));
             });
             await app.findByText(LOADING);
+        });
+    });
+
+    describe('View Only', () => {
+        it('person name button should be disabled', () => {
+            let initialState = {
+                currentSpace: TestUtils.space,
+                viewingDate: new Date(2020, 0, 1),
+                products: [TestUtils.productForHank],
+                isReadOnly: true,
+            };
+            let store = createStore(rootReducer, initialState, applyMiddleware(thunk));
+            let app = renderWithRedux(<TimeOnProduct/>, store);
+            const hank = app.getByText(TestUtils.hank.name);
+            expect(hank).toBeDisabled();
         });
     });
 });

--- a/ui/src/TimeOnProductPage/TimeOnProduct.test.tsx
+++ b/ui/src/TimeOnProductPage/TimeOnProduct.test.tsx
@@ -52,6 +52,7 @@ describe('TimeOnProduct', () => {
                 currentSpace: TestUtils.space,
                 viewingDate: new Date(2020, 0, 1),
                 products: [TestUtils.productForHank],
+                isReadOnly: false,
             };
             store = createStore(rootReducer, initialState);
             store.dispatch = jest.fn();

--- a/ui/src/TimeOnProductPage/TimeOnProduct.tsx
+++ b/ui/src/TimeOnProductPage/TimeOnProduct.tsx
@@ -78,12 +78,13 @@ export interface TimeOnProductProps {
     viewingDate: Date;
     products: Array<Product>;
     currentModal: CurrentModalState;
+    isReadOnly: boolean;
 
     fetchProducts(): Array<Product>;
     setCurrentModal(modalState: CurrentModalState): void;
 }
 
-function TimeOnProduct({currentSpace, viewingDate, products, currentModal, fetchProducts, setCurrentModal}: TimeOnProductProps): JSX.Element {
+function TimeOnProduct({currentSpace, viewingDate, products, currentModal, isReadOnly, fetchProducts, setCurrentModal}: TimeOnProductProps): JSX.Element {
     const [isLoading, setIsLoading] = useState<boolean>(false);
 
     const extractUuidFromUrl = (): string => {
@@ -120,6 +121,12 @@ function TimeOnProduct({currentSpace, viewingDate, products, currentModal, fetch
         }
     };
 
+    const getPersonNameClassName = (): string => {
+        let className = 'timeOnProductCell';
+        className += (isReadOnly ? ' timeOnProductCellNameDisabled' : ' timeOnProductCellName');
+        return className;
+    };
+
     const convertToRow = (timeOnProductItem: TimeOnProductItem): JSX.Element => {
         const unit = (timeOnProductItem.timeOnProduct > 1 ? 'days' : 'day');
         return (
@@ -127,8 +134,9 @@ function TimeOnProduct({currentSpace, viewingDate, products, currentModal, fetch
                 data-testid={timeOnProductItem.assignmentId.toString()}
                 key={timeOnProductItem.assignmentId.toString()}
             >
-                <button className="timeOnProductCell timeOnProductCellName"
+                <button className={getPersonNameClassName()}
                     onClick={(): void => {onNameClick(timeOnProductItem);}}
+                    disabled={isReadOnly}
                 >
                     {timeOnProductItem.personName}
                 </button>
@@ -178,6 +186,7 @@ const mapStateToProps = (state: GlobalStateProps) => ({
     viewingDate: state.viewingDate,
     products: state.products,
     currentModal: state.currentModal,
+    isReadOnly: state.isReadOnly,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({


### PR DESCRIPTION
## Issue / Bug
Resolves 256

## What was done
- [x] Add isReadOnly state to TimeOnProduct
- [x] Use isReadOnly to determine person name button state (enabled/disabled) and style

## How to test
1. Create a space that is editable and that is view only. 
2. Compare the way a person entry in the TimeOnProducts page looks in both spaces
3. in the view only space, the person button should be disabled, no way to open the Edit Person Modal
4. in the editable space, the person button should be enabled and the Edit Person Modal can be opened
