### PR TITLE
216 2 support app tokens

### DIFF
--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthInterceptor.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthInterceptor.kt
@@ -17,7 +17,7 @@ class CustomPermissionEvaluator(
     override fun hasPermission(auth: Authentication, targetDomainObject: Any, permission: Any): Boolean {
 
         if (!auth.isAuthenticated) return false
-        val subject: String = getSubject(auth) ?: return false
+        val subject: String = getUsernameOrAppName(auth) ?: return false
 
         val targetIdString = targetDomainObject.toString()
         val currentSpace: Space? = getCurrentSpace(targetIdString)
@@ -32,11 +32,6 @@ class CustomPermissionEvaluator(
 
     override fun hasPermission(auth: Authentication, targetId: Serializable, targetType: String, permission: Any): Boolean
         = hasPermission(auth, targetId, permission)
-
-    private fun getSubject(auth: Authentication): String? {
-        return if((auth.name != null) && auth.name.isNotEmpty()) auth.name
-        else (auth.credentials as Jwt).claims["appid"]?.toString()
-    }
 
     private fun getCurrentSpace(uuid: String): Space? {
         return spaceRepository.findByUuid(uuid)

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthInterceptor.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthInterceptor.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ford.internalprojects.peoplemover.auth
 
 import com.ford.internalprojects.peoplemover.space.Space

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthService.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ford.internalprojects.peoplemover.auth
 
 import com.ford.internalprojects.peoplemover.auth.exceptions.InvalidTokenException

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/AuthService.kt
@@ -3,8 +3,10 @@ package com.ford.internalprojects.peoplemover.auth
 import com.ford.internalprojects.peoplemover.auth.exceptions.InvalidTokenException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.stereotype.Service
+import java.lang.ClassCastException
 
 @Service
 class AuthService (
@@ -23,5 +25,14 @@ class AuthService (
     fun requestIsAuthorizedFromReportProperties(authentication: Authentication): Boolean {
         val authorizedUsers = users.toLowerCase().split(",")
         return authorizedUsers.contains(authentication.name.toLowerCase())
+    }
+}
+
+fun getUsernameOrAppName(auth: Authentication): String? {
+    return try {
+        if ((auth.name != null) && auth.name.isNotEmpty()) auth.name
+        else (auth.credentials as Jwt).claims["appid"]?.toString()
+    } catch(e: ClassCastException) {
+        null
     }
 }

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/JpaAuditingConfig.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/JpaAuditingConfig.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ford.internalprojects.peoplemover.auth
 
 import org.springframework.context.annotation.Bean

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/OAuthVerifyResponse.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/auth/OAuthVerifyResponse.kt
@@ -1,4 +1,22 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ford.internalprojects.peoplemover.auth
+
 
 data class OAuthVerifyResponse (
     var user_id: String,

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceController.kt
@@ -51,7 +51,7 @@ class SpaceController(
 
     @GetMapping("/user")
     fun getAllSpacesForUser(@RequestHeader(name = "Authorization") accessToken: String): List<Space> {
-        return spaceService.getSpacesForUser(accessToken.replace("Bearer ", ""))
+        return spaceService.getSpacesForUser()
     }
 }
 

--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/space/SpaceService.kt
@@ -20,13 +20,13 @@ package com.ford.internalprojects.peoplemover.space
 import com.ford.internalprojects.peoplemover.auth.PERMISSION_OWNER
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMapping
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
+import com.ford.internalprojects.peoplemover.auth.getUsernameOrAppName
 import com.ford.internalprojects.peoplemover.product.ProductService
 import com.ford.internalprojects.peoplemover.space.exceptions.SpaceIsReadOnlyException
 import com.ford.internalprojects.peoplemover.space.exceptions.SpaceNameInvalidException
 import com.ford.internalprojects.peoplemover.space.exceptions.SpaceNotExistsException
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.stereotype.Service
 import java.sql.Timestamp
 import java.time.LocalDate
@@ -76,17 +76,8 @@ class SpaceService(
         }
     }
 
-    fun getUsernameOrAppName(auth: Authentication): String{
-       return if(auth.name == null){
-            ""
-        }
-        else{
-            auth.name
-        }
-    }
-
     fun getSpacesForUser(): List<Space> {
-        val principal: String = getUsernameOrAppName(SecurityContextHolder.getContext().authentication)
+        val principal: String = getUsernameOrAppName(SecurityContextHolder.getContext().authentication) ?: return emptyList()
         val spaceUuids: List<String> =
                 userSpaceMappingRepository.findAllByUserId(principal).map { mapping -> mapping.spaceUuid }.toList()
         return spaceRepository.findAllByUuidIn(spaceUuids)

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/auth/AuthInterceptorTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/auth/AuthInterceptorTest.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ford.internalprojects.peoplemover.auth
 
 import com.ford.internalprojects.peoplemover.space.Space

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceServiceTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceServiceTest.kt
@@ -1,0 +1,45 @@
+package com.ford.internalprojects.peoplemover.space
+
+import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
+import com.ford.internalprojects.peoplemover.product.ProductService
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit4.SpringRunner
+
+@RunWith(SpringRunner::class)
+@SpringBootTest
+@ActiveProfiles("test")
+class SpaceServiceTest {
+
+   @Autowired
+   lateinit var underTest : SpaceService
+
+    lateinit var userSpaceMappingRepository: UserSpaceMappingRepository
+
+    @Test
+    fun `getSpaceForUser should not blow up if Principal has no name`() {
+        mockkStatic(SecurityContextHolder::class)
+        every { SecurityContextHolder.getContext().authentication.name } returns null
+        try {
+            underTest.getSpacesForUser()
+        } catch(e: Exception) {
+            fail<String>("Should not have caught an exception here")
+        }
+        unmockkStatic(SecurityContextHolder::class)
+    }
+}

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceServiceTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceServiceTest.kt
@@ -60,7 +60,7 @@ class SpaceServiceTest {
     }
 
     @Test
-    fun `getSpacesForUser should handle a token that has no Principal name and no appId name`() {
+    fun `getSpacesForUser should return no spaces given a token that has no Principal name and no appId name`() {
         every { SecurityContextHolder.getContext().authentication.name } returns null
         every { SecurityContextHolder.getContext().authentication.credentials } returns Jwt("token", Instant.now(), Instant.now(), mapOf("h" to "h"), mapOf("noAppId" to "Nothing"))
         assertThat(underTest.getSpacesForUser().size).isEqualTo(0)
@@ -68,7 +68,7 @@ class SpaceServiceTest {
     }
 
     @Test
-    fun `getSpacesForUser should handle a token that has a Principal name`() {
+    fun `getSpacesForUser should use the principal name if a token has a Principal name and an appId`() {
         every { SecurityContextHolder.getContext().authentication.name } returns "Bob"
         every { SecurityContextHolder.getContext().authentication.credentials } returns Jwt("token", Instant.now(), Instant.now(), mapOf("h" to "h"), mapOf("appId" to "Nothing"))
         assertThat(underTest.getSpacesForUser().size).isEqualTo(0)
@@ -76,7 +76,15 @@ class SpaceServiceTest {
     }
 
     @Test
-    fun `getSpacesForUser should handle a token that has no Principal name but does have an appId name`() {
+    fun `getSpacesForUser should use the principal name if a token has a Principal name and no appId`() {
+        every { SecurityContextHolder.getContext().authentication.name } returns "Bob"
+        every { SecurityContextHolder.getContext().authentication.credentials } returns Jwt("token", Instant.now(), Instant.now(), mapOf("h" to "h"), mapOf("dontcare" to "dontcare"))
+        assertThat(underTest.getSpacesForUser().size).isEqualTo(0)
+        Mockito.verify(userSpaceMappingRepository, times(1)).findAllByUserId("Bob")
+    }
+
+    @Test
+    fun `getSpacesForUser should use the appId if a token has an appId name but no principal name`() {
         every { SecurityContextHolder.getContext().authentication.name } returns null
         every { SecurityContextHolder.getContext().authentication.credentials } returns Jwt("token", Instant.now(), Instant.now(), mapOf("h" to "h"), mapOf("appid" to "easyas123"))
         assertThat(underTest.getSpacesForUser().size).isEqualTo(0)
@@ -84,7 +92,7 @@ class SpaceServiceTest {
     }
 
     @Test
-    fun `getSpacesForUser should handle a token that doesn't have jwt credentials`() {
+    fun `getSpacesForUser should return no spaces given a token that doesn't have jwt credentials`() {
         every { SecurityContextHolder.getContext().authentication.name } returns null
         every { SecurityContextHolder.getContext().authentication.credentials } returns null
         assertThat(underTest.getSpacesForUser().size).isEqualTo(0)

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceServiceTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceServiceTest.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2021 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ford.internalprojects.peoplemover.space
 
 import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceServiceTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/space/SpaceServiceTest.kt
@@ -4,16 +4,16 @@ import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
-import org.assertj.core.api.Assertions.fail
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
+import org.mockito.Mockito.times
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.test.context.ActiveProfiles
@@ -34,7 +34,6 @@ class SpaceServiceTest {
     @Before
     fun before() {
         mockkStatic(SecurityContextHolder::class)
-
     }
 
     @After
@@ -44,24 +43,34 @@ class SpaceServiceTest {
     }
 
     @Test
-    fun `getSpacesForUser should not blow up if Principal has no name`() {
+    fun `getSpacesForUser should handle a token that has no Principal name and no appId name`() {
         every { SecurityContextHolder.getContext().authentication.name } returns null
-        try {
-            underTest.getSpacesForUser()
-        } catch (e: Exception) {
-            fail<String>("Should not have caught an exception here")
-        }
+        every { SecurityContextHolder.getContext().authentication.credentials } returns Jwt("token", Instant.now(), Instant.now(), mapOf("h" to "h"), mapOf("noAppId" to "Nothing"))
+        assertThat(underTest.getSpacesForUser().size).isEqualTo(0)
+        Mockito.verifyNoMoreInteractions(userSpaceMappingRepository)
     }
 
     @Test
-    fun `getSpacesForUser should identify a Principal by app id if no Name is available`() {
-        every { SecurityContextHolder.getContext().authentication.credentials } returns Jwt("token", Instant.now(), Instant.now(), mapOf("h" to "h"), mapOf("appid" to "easyas123"))
+    fun `getSpacesForUser should handle a token that has a Principal name`() {
+        every { SecurityContextHolder.getContext().authentication.name } returns "Bob"
+        every { SecurityContextHolder.getContext().authentication.credentials } returns Jwt("token", Instant.now(), Instant.now(), mapOf("h" to "h"), mapOf("appId" to "Nothing"))
+        assertThat(underTest.getSpacesForUser().size).isEqualTo(0)
+        Mockito.verify(userSpaceMappingRepository, times(1)).findAllByUserId("Bob")
+    }
+
+    @Test
+    fun `getSpacesForUser should handle a token that has no Principal name but does have an appId name`() {
         every { SecurityContextHolder.getContext().authentication.name } returns null
-        try {
-            underTest.getSpacesForUser()
-        } catch (e: Exception) {
-            fail<String>("Should not have caught an exception here")
-        }
-        Mockito.verify(userSpaceMappingRepository).findAllByUserId("easyas123")
+        every { SecurityContextHolder.getContext().authentication.credentials } returns Jwt("token", Instant.now(), Instant.now(), mapOf("h" to "h"), mapOf("appid" to "easyas123"))
+        assertThat(underTest.getSpacesForUser().size).isEqualTo(0)
+        Mockito.verify(userSpaceMappingRepository, times(1)).findAllByUserId("easyas123")
+    }
+
+    @Test
+    fun `getSpacesForUser should handle a token that doesn't have jwt credentials`() {
+        every { SecurityContextHolder.getContext().authentication.name } returns null
+        every { SecurityContextHolder.getContext().authentication.credentials } returns null
+        assertThat(underTest.getSpacesForUser().size).isEqualTo(0)
+        Mockito.verifyNoMoreInteractions(userSpaceMappingRepository)
     }
 }


### PR DESCRIPTION
## Issue
Resolves 216

## What was done
- [x] Consolidate token checking code, make more robust. 
- [x] App tokens have same capabilities as user tokens (need to discuss if this is going to be an issue)

## How to test
1. Add an app id to the database (ask egr if unsure)
2. Generate access token for app id (ask egr if unsure)
3. Make a call from Postman using app id access token. Confirm data is returned.
