### PR TITLE
H2 local option

### DIFF
--- a/api/Readme.md
+++ b/api/Readme.md
@@ -34,7 +34,7 @@ the `e2e-test` profile replaces it with a simplified auth system for testing.
 ### H2 In-Memory Database
 The simplest way to get the application spun up is by using the in-memory database via Gradle:
 ```
-SPRING_PROFILES_ACTIVE=e2e-test ./gradlew bootRun
+SPRING_PROFILES_ACTIVE=e2e-test,h2 ./gradlew bootRun
 ```
 
 ### Docker MySql Database

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
 
     runtimeOnly 'mysql:mysql-connector-java:8.0.25'
+    runtimeOnly 'com.h2database:h2:1.4.200'
     runtimeOnly 'org.jetbrains.kotlin:kotlin-reflect:1.2.41'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/api/src/main/resources/application-cloud.properties
+++ b/api/src/main/resources/application-cloud.properties
@@ -15,6 +15,4 @@
 # limitations under the License.
 #
 
-spring.h2.console.enabled=false
-spring.flyway.locations=classpath:db/mysql
 spring.flyway.ignore-missing-migrations=true

--- a/api/src/main/resources/application-h2.properties
+++ b/api/src/main/resources/application-h2.properties
@@ -15,7 +15,17 @@
 # limitations under the License.
 #
 
-spring.flyway.locations=classpath:db/mysql
-spring.datasource.url=jdbc:mysql://localhost:3306/PEOPLEMOVER_DB?serverTimezone=America/Detroit
-spring.datasource.username=root
-spring.datasource.password=PASSWORD
+spring.jpa.properties.hibernate.jdbc.time_zone=US/Eastern
+
+# H2
+spring.h2.console.settings.web-allow-others=true
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+# Datasource
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+
+spring.flyway.locations=classpath:db/h2

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -22,6 +22,8 @@ spring.datasource.url=jdbc:mysql://localhost:3306/PEOPLEMOVER_DB?serverTimezone=
 spring.datasource.username=root
 spring.datasource.password=PASSWORD
 
+spring.h2.console.enabled=false
+
 spring.flyway.baseline-on-migrate=true
 
 react.app.auth-enabled=false

--- a/api/src/main/resources/db/h2/V001__baseline.sql
+++ b/api/src/main/resources/db/h2/V001__baseline.sql
@@ -1,0 +1,155 @@
+create table space
+(
+    uuid varchar(36) not null primary key,
+    name varchar(255) not null unique,
+    last_modified_date timestamp,
+    created_by varchar(40),
+    today_view_is_public bit default false,
+    created_date datetime
+);
+
+create table color
+(
+    id    int not null identity primary key,
+    color varchar(255) unique
+);
+
+create table space_locations
+(
+    id       int identity primary key,
+    space_uuid        varchar (36) not null,
+    name     varchar(255),
+
+    FOREIGN KEY (space_uuid) REFERENCES space (uuid) on delete cascade,
+    constraint UQ_Location unique (space_uuid, name)
+);
+
+create table product
+(
+    id                int not null identity primary key,
+    archived          bit not null,
+    dorf              varchar(255),
+    end_date          date,
+    name              varchar(255),
+    notes             varchar(500),
+    start_date        date,
+    space_location_id int,
+    space_uuid        varchar (36) not null,
+    url               varchar(500),
+
+    FOREIGN KEY (space_uuid) REFERENCES space (uuid) on delete cascade,
+    FOREIGN KEY (space_location_id) REFERENCES space_locations (id) ON DELETE SET NULL,
+    constraint UQ_Product unique (space_uuid, name)
+);
+
+create table space_roles
+(
+    id       int not null identity primary key,
+    roles    varchar(255),
+    space_uuid    varchar (36) not null,
+    color_id int,
+
+    FOREIGN KEY (space_uuid) REFERENCES space (uuid) on delete cascade,
+    FOREIGN KEY (color_id) REFERENCES color (id) on delete set null,
+    constraint UQ_Role unique (space_uuid, roles)
+);
+
+create table person
+(
+    id            int           not null identity primary key,
+    name          varchar(255),
+    notes         varchar(255),
+    new_person    bit default 0 not null,
+    space_role_id int,
+    space_uuid    varchar (36) not null,
+    custom_field1  varchar(255),
+    new_person_date date,
+    archive_date  datetime,
+
+    FOREIGN KEY (space_uuid) REFERENCES space (uuid) on delete cascade,
+    FOREIGN KEY (space_role_id) REFERENCES space_roles (id) ON DELETE SET NULL
+);
+CREATE INDEX person_spaceuuid ON person (space_uuid);
+
+create table assignment
+(
+    id                  int not null identity primary key,
+    effective_date      date,
+    placeholder         bit not null,
+    product_id          int,
+    person_id           int,
+    space_uuid          varchar (36) not null,
+
+    FOREIGN KEY (product_id) REFERENCES product (id) on delete cascade,
+    FOREIGN KEY (space_uuid) REFERENCES space (uuid) on delete cascade,
+    FOREIGN KEY (person_id) REFERENCES person (id) on delete cascade,
+    constraint UQ_Assignment unique (product_id, person_id, effective_date)
+);
+
+create table product_tag
+(
+    id           int not null identity primary key,
+    name         varchar(255),
+    space_uuid        varchar (36) not null,
+
+    FOREIGN KEY (space_uuid) REFERENCES space (uuid) on delete cascade,
+    constraint UQ_Product_Tag unique (space_uuid, name)
+);
+
+create table product_tag_mapping
+(
+    id             int not null identity primary key,
+    product_id     int,
+    product_tag_id int,
+
+    FOREIGN KEY (product_id) REFERENCES product (id) on delete cascade,
+    FOREIGN KEY (product_tag_id) REFERENCES product_tag (id) on delete cascade,
+    constraint UQ_Product_Tag_Mapping unique (product_id, product_tag_id)
+);
+
+create table person_tag
+(
+    id           int not null identity primary key,
+    name         varchar(255),
+    space_uuid        varchar (36) not null,
+
+    FOREIGN KEY (space_uuid) REFERENCES space (uuid) on delete cascade,
+    constraint UQ_Person_Tag unique (space_uuid, name)
+);
+
+create table person_tag_mapping
+(
+    id             int not null identity primary key,
+    person_id     int,
+    person_tag_id int,
+
+    FOREIGN KEY (person_id) REFERENCES person (id) on delete cascade,
+    FOREIGN KEY (person_tag_id) REFERENCES person_tag (id) on delete cascade,
+    constraint UQ_Person_Tag_Mapping unique (person_id, person_tag_id)
+);
+
+create table user_space_mapping
+(
+    id          int not null identity primary key,
+    user_id     varchar(255),
+    space_uuid        varchar (36) not null,
+    last_modified_date datetime,
+    last_modified_by varchar(30),
+    created_date datetime,
+    created_by varchar(30),
+    permission varchar(36) NOT NULL default 'editor',
+
+    FOREIGN KEY (space_uuid) REFERENCES space (uuid) on delete cascade,
+    constraint UQ_User_Space_Mapping unique (user_id, space_uuid)
+);
+
+create table custom_field_mapping
+(
+    id int not null identity primary key,
+    reference_name varchar(255),
+    vanity_name varchar(255),
+    space_uuid varchar (36) not null,
+
+    FOREIGN KEY (space_uuid) REFERENCES space (uuid) on delete cascade,
+    constraint UQ_Custom_Field_Mapping unique (space_uuid, reference_name)
+);

--- a/ui/README.md
+++ b/ui/README.md
@@ -39,8 +39,8 @@ This will connect the frontend with to the server at localhost:8080/api.
 The ui application will start at localhost:3000.
 
 Note: If you are running the backend with simplified authentication, your ability to access the frontend will be limited.
-If this is the case, you should be able to navigate to the [home page](http://localhost:3000) and the 
-[test space](http://localhost:3000/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)
+If this is the case, you should be able to navigate to the [home page](https://localhost:3000) and the 
+[test space](https://localhost:3000/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa)
 
 
 ## Set up Analytics

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -12,13 +12,13 @@ cfConfig {
     space = "FordLabs_Experiments_InternalProjects-prod"
     org = "FordLabs_Experiments_InternalProjects_EDC1_Prod"
 
-    ccUser = peoplemoverPcfUsername
-    ccPassword = peoplemoverPcfPassword
+    ccUser = System.getenv("peoplemoverPcfUsername") ?: "ccUser"
+    ccPassword = System.getenv("peoplemoverPcfPassword") ?: "ccPassword"
 
     name = "engineeringEnvUI"
     host = "engineeringEnvUI"
-    ccHost = peoplemoverPcfccHost
-    domain = peoplemoverPcfdomain
+    ccHost = System.getenv("peoplemoverPcfccHost") ?: "ccHost"
+    domain = System.getenv("peoplemoverPcfdomain") ?: "domain"
 }
 
 task pushBranchUI(type: Exec) {


### PR DESCRIPTION
Our readme states that a developer can quickly demonstrate our product using h2. While I agree that having the standard development environment match the mysql environment of the production environment, it may be excessive to require a developer to have a mysql environment setup simply to evaluate the product.

## What was done
- [x] Allow a developer to start PeopleMover using h2 with the 'h2' spring profile

## How to test
1. Start the backend using the spring profile: h2 (in addition to the e2e-local profile)
2. Make sure ui still works the same as if developer was locally using mysql and e2e-local
