### PR TITLE
Use "npm ci" instead of "npm install" for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Copy version to meta.json
         run: npm run generate-build-version
         working-directory: ./ui
-      - name: NPM Install
-        run: npm install
+      - name: NPM CI Install
+        run: npm ci
         working-directory: ./ui
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
## Issue
Attempts to fix the CI build due to potential npm versioning issues
