### PR TITLE
Update "Contact Us" link to pplmover@ford.com email

### DIFF
--- a/ui/src/ReusableComponents/Branding.tsx
+++ b/ui/src/ReusableComponents/Branding.tsx
@@ -38,7 +38,7 @@ function Branding(): JSX.Element {
                 FordLabs
             </a>
             <span className="brandingMessage brandingLeftPadSmall">|
-                <a href="mailto:ksawyer8@ford.com,jrozan1@ford.com,dgijsber@ford.com?subject=PeopleMover Web Contact" className="brandingMessage brandingLeftPadSmall">Contact Us</a>
+                <a href="mailto:pplmover@ford.com?subject=PeopleMover Web Contact" className="brandingMessage brandingLeftPadSmall">Contact Us</a>
             </span>
         </div>
     );


### PR DESCRIPTION
## Issue
Resolves #774

## What was done
- Changed the mailto link to now go to pplmover@ford.com (which will then redirect to an ugly Slack channel email)

## How to test
1. Go to peoplemover.ford.com
2. Click the "Contact Us" link
3. See that the "to" box in your default mail client now only contains pplmover@ford.com
