### PR TITLE
Fix unit tests with non-fatal issues (warnings)

### DIFF
--- a/ui/src/Modal/Modal.test.tsx
+++ b/ui/src/Modal/Modal.test.tsx
@@ -25,8 +25,7 @@ describe('Modal', () => {
     beforeEach(() => {
         mockedCloseFunction = jest.fn();
 
-        const ModalForm = (props: { setShouldShowConfirmCloseModal: Function }): JSX.Element => {
-            props.setShouldShowConfirmCloseModal();
+        const ModalForm = (): JSX.Element => {
             return <p>Hello</p>;
         };
 
@@ -34,7 +33,7 @@ describe('Modal', () => {
             <Modal
                 modalMetadata={[{
                     title:'Test Modal',
-                    form:<ModalForm setShouldShowConfirmCloseModal={jest.fn()} />,
+                    form:<ModalForm/>,
                 }]}
                 closeModal={mockedCloseFunction}
             />

--- a/ui/src/SpaceDashboard/TransferOwnershipForm.tsx
+++ b/ui/src/SpaceDashboard/TransferOwnershipForm.tsx
@@ -70,13 +70,12 @@ function TransferOwnershipForm({currentSpace, currentUser, closeModal, fetchUser
 
     const renderOption = (person: UserSpaceMapping): JSX.Element => {
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events
-        return <div key={person.id} className={'transferOwnershipFormRadioControl'}
-            data-testid={'transferOwnershipFormRadioControl-' + person.userId}
-            onClick={(): void => setSelectedUser(person)}>
+        return <label key={person.id} className={'transferOwnershipFormRadioControl'}
+            data-testid={'transferOwnershipFormRadioControl-' + person.userId}>
             <i className={'material-icons'} aria-hidden>account_circle</i>
             <span className={'personRadioUserId'}>{person.userId.toLowerCase()}</span>
             <input type={'radio'} name={'newOwner'} value={person.userId} checked={selectedUser ? selectedUser.id === person.id : false} onChange={() => {setSelectedUser(person)}}/>
-        </div>;
+        </label>;
     };
 
     const notificationModalProps = {content:<span>{'Ownership has been transferred to ' + selectedUser?.userId +

--- a/ui/src/SpaceDashboard/TransferOwnershipForm.tsx
+++ b/ui/src/SpaceDashboard/TransferOwnershipForm.tsx
@@ -18,8 +18,7 @@
 import React, {FormEvent, useEffect, useState} from 'react';
 import SpaceClient from '../Space/SpaceClient';
 import {connect} from 'react-redux';
-import {closeModalAction, fetchUserSpacesAction, setCurrentModalAction} from '../Redux/Actions';
-import {CurrentModalState} from '../Redux/Reducers/currentModalReducer';
+import {closeModalAction, fetchUserSpacesAction} from '../Redux/Actions';
 import FormButton from '../ModalFormComponents/FormButton';
 import {GlobalStateProps} from '../Redux/Reducers';
 import {Space} from '../Space/Space';
@@ -31,7 +30,6 @@ interface TransferOwnershipFormProps {
     currentSpace: Space;
     currentUser: string;
     closeModal(): void;
-    setCurrentModal(modalState: CurrentModalState): void;
     fetchUserSpaces(): void;
 }
 
@@ -39,7 +37,7 @@ interface TransferOwnershipFormOwnProps {
     space?: Space;
 }
 
-function TransferOwnershipForm({currentSpace, currentUser, closeModal, setCurrentModal, fetchUserSpaces}: TransferOwnershipFormProps, {space}: TransferOwnershipFormOwnProps): JSX.Element {
+function TransferOwnershipForm({currentSpace, currentUser, closeModal, fetchUserSpaces}: TransferOwnershipFormProps, {space}: TransferOwnershipFormOwnProps): JSX.Element {
     const [selectedUser, setSelectedUser] = useState<UserSpaceMapping | null>(null);
     const [usersList, setUsersList] = useState<UserSpaceMapping[]>([]);
     const [me, setMe] = useState<UserSpaceMapping>();
@@ -77,7 +75,7 @@ function TransferOwnershipForm({currentSpace, currentUser, closeModal, setCurren
             onClick={(): void => setSelectedUser(person)}>
             <i className={'material-icons'} aria-hidden>account_circle</i>
             <span className={'personRadioUserId'}>{person.userId.toLowerCase()}</span>
-            <input type={'radio'} name={'newOwner'} value={person.userId} checked={selectedUser ? selectedUser.id === person.id : false}/>
+            <input type={'radio'} name={'newOwner'} value={person.userId} checked={selectedUser ? selectedUser.id === person.id : false} onChange={() => {setSelectedUser(person)}}/>
         </div>;
     };
 
@@ -123,7 +121,6 @@ function TransferOwnershipForm({currentSpace, currentUser, closeModal, setCurren
 /* eslint-disable */
 const mapDispatchToProps = (dispatch: any) => ({
     closeModal: () => dispatch(closeModalAction()),
-    setCurrentModal: (modalState: CurrentModalState) => dispatch(setCurrentModalAction(modalState)),
     fetchUserSpaces: () => dispatch(fetchUserSpacesAction()),
 });
 


### PR DESCRIPTION
Remove prop in Modal unit test. Not needed

Add onChange to radio input in TransferOwnership. Needed.

Remove setCurrentModal references from TransferOwnership. Not used.


## What was done
- [x] Code updates to make unit tests run w/o throwing console.error warnings

## How to test
1. Run unit tests. Verify no console.error outputs.