### PR TITLE
Write unit tests for hooks & move mocking clients towards jest manual mocks

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -36,6 +36,7 @@
         "@babel/types": "^7.8.7",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^12.1.5",
+        "@testing-library/react-hooks": "^8.0.0",
         "@types/jest": "^26.0.24",
         "@types/jest-axe": "^3.5.1",
         "@types/json2csv": "^4.5.1",
@@ -4219,6 +4220,36 @@
       "peerDependencies": {
         "react": "<18.0.0",
         "react-dom": "<18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz",
+      "integrity": "sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-test-renderer": "^16.9.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tootallnate/once": {
@@ -20767,6 +20798,22 @@
         "react": "17.0.2"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -21024,6 +21071,21 @@
         "@testing-library/dom": ">=7"
       }
     },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-switch": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-6.0.0.tgz",
@@ -21035,6 +21097,31 @@
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0",
         "react-dom": "^15.3.0 || ^16.0.0 || ^17.0.0"
       }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.2",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/react-text-mask": {
       "version": "5.4.3",
@@ -28382,6 +28469,16 @@
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0",
         "@types/react-dom": "<18.0.0"
+      }
+    },
+    "@testing-library/react-hooks": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.0.tgz",
+      "integrity": "sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
       }
     },
     "@tootallnate/once": {
@@ -40733,6 +40830,15 @@
         "scheduler": "^0.20.2"
       }
     },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -40921,12 +41027,48 @@
         "@testing-library/dom": ">=7"
       }
     },
+    "react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "react-switch": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-6.0.0.tgz",
       "integrity": "sha512-QV3/6eRK5/5epdQzIqvDAHRoGLbCv/wDpHUi6yBMXY1Xco5XGuIZxvB49PHoV1v/SpEgOCJLD/Zo43iic+aEIw==",
       "requires": {
         "prop-types": "^15.7.2"
+      }
+    },
+    "react-test-renderer": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.2",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
       }
     },
     "react-text-mask": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -65,6 +65,7 @@
     "@babel/types": "^7.8.7",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
+    "@testing-library/react-hooks": "^8.0.0",
     "@types/jest": "^26.0.24",
     "@types/jest-axe": "^3.5.1",
     "@types/json2csv": "^4.5.1",

--- a/ui/src/AccountDropdown/AccountDropdown.test.tsx
+++ b/ui/src/AccountDropdown/AccountDropdown.test.tsx
@@ -17,6 +17,7 @@
 
 import {fireEvent, screen, waitFor} from '@testing-library/react';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import React from 'react';
 import {MemoryRouter} from 'react-router-dom';
 import Cookies from 'universal-cookie';
@@ -53,7 +54,7 @@ describe('Account Dropdown', () => {
 
     describe('Dropdown Options', () => {
         const mockStore = configureStore([]);
-        const expectedCurrentSpace = TestUtils.space;
+        const expectedCurrentSpace = TestData.space;
         const expectedViewingDate = new Date(2020, 4, 14);
         const store = mockStore({
             currentSpace: expectedCurrentSpace,
@@ -128,7 +129,7 @@ describe('Account Dropdown', () => {
                     </RecoilRoot>
                 </MemoryRouter>,
                 undefined,
-                {currentSpace: TestUtils.space}
+                {currentSpace: TestData.space}
             );
         });
         it('should not display Download Report and Share Access when it is in Read Only mode', async () => {

--- a/ui/src/AccountDropdown/InviteEditorsFormSection.test.tsx
+++ b/ui/src/AccountDropdown/InviteEditorsFormSection.test.tsx
@@ -16,6 +16,7 @@
  */
 
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import React from 'react';
 import InviteEditorsFormSection from './InviteEditorsFormSection';
 import {fireEvent, screen, waitFor, within} from '@testing-library/react';
@@ -231,7 +232,7 @@ describe('Invite Editors Form', function() {
             fireEvent.click(permissionButton);
             fireEvent.click(await screen.findByText(/yes/i));
             expect(Axios.put).toHaveBeenCalledWith(
-                `/api/spaces/${TestUtils.space.uuid}/users/user_id_2`,
+                `/api/spaces/${TestData.space.uuid}/users/user_id_2`,
                 null,
                 {headers: {Authorization: 'Bearer 123456'}},
             );
@@ -287,7 +288,7 @@ describe('Invite Editors Form', function() {
             const confirmDeleteButton = await screen.findByTestId('confirmDeleteButton');
             fireEvent.click(confirmDeleteButton);
 
-            await waitFor(() => expect(SpaceClient.removeUser).toHaveBeenCalledWith(TestUtils.space, TestUtils.spaceMappingsArray[1]));
+            await waitFor(() => expect(SpaceClient.removeUser).toHaveBeenCalledWith(TestData.space, TestData.spaceMappingsArray[1]));
             expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
             expect(RedirectClient.redirect).toHaveBeenCalledWith('/user/dashboard');
         });
@@ -306,7 +307,7 @@ describe('Invite Editors Form', function() {
             const confirmDeleteButton = await screen.findByText('Yes');
             fireEvent.click(confirmDeleteButton);
 
-            await waitFor(async () => expect(SpaceClient.removeUser).toHaveBeenCalledWith(TestUtils.space, TestUtils.spaceMappingsArray[1]));
+            await waitFor(async () => expect(SpaceClient.removeUser).toHaveBeenCalledWith(TestData.space, TestData.spaceMappingsArray[1]));
             expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
         });
 
@@ -328,7 +329,7 @@ function renderComponent(currentUser = 'User_id'): void {
             <InviteEditorsFormSection collapsed={false}/>,
         </RecoilRoot>,
         undefined,
-        {currentSpace: TestUtils.space}
+        {currentSpace: TestData.space}
     );
 }
 
@@ -337,7 +338,7 @@ function renderComponentWithSpaceFromProps(): void {
         id: 2,
         uuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         name: 'local testSpace',
-        lastModifiedDate: TestUtils.originDateString,
+        lastModifiedDate: TestData.originDateString,
         todayViewIsPublic: true,
     };
 
@@ -348,13 +349,13 @@ function renderComponentWithSpaceFromProps(): void {
             <InviteEditorsFormSection collapsed={false} space={space}/>,
         </RecoilRoot>,
         undefined,
-        {currentSpace: TestUtils.space}
+        {currentSpace: TestData.space}
     );
 }
 
 function validateApiCall(userIds: string[]): void {
     expect(Axios.post).toHaveBeenCalledWith(
-        `/api/spaces/${TestUtils.space.uuid}/users`,
+        `/api/spaces/${TestData.space.uuid}/users`,
         {userIds: userIds},
         {
             headers: {

--- a/ui/src/AccountDropdown/ViewOnlyAccessFormSection.test.tsx
+++ b/ui/src/AccountDropdown/ViewOnlyAccessFormSection.test.tsx
@@ -15,7 +15,8 @@
  *  limitations under the License.
  */
 
-import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import React from 'react';
 import {fireEvent, screen, waitFor} from '@testing-library/react';
 import rootReducer from '../Redux/Reducers';
@@ -37,7 +38,7 @@ Object.assign(navigator, {
 });
 
 describe('View Only Access Form Section', () => {
-    const testSpace = TestUtils.space;
+    const testSpace = TestData.space;
     const testSpaceWithViewOnlyOn = {...testSpace, todayViewIsPublic: true};
     const testSpaceWithViewOnlyOff = {...testSpace, todayViewIsPublic: false};
     const expectedUrl = 'https://some-url';
@@ -83,7 +84,7 @@ describe('View Only Access Form Section', () => {
         });
 
         expect(navigator.clipboard.writeText).toBeCalledWith(expectedUrl);
-        expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'readOnlyLinkCopied', '']);
+        expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'readOnlyLinkCopied', '']);
     });
 
     it('should should change text on copy', async () => {

--- a/ui/src/Assignments/Assignment.test.ts
+++ b/ui/src/Assignments/Assignment.test.ts
@@ -16,15 +16,15 @@
  */
 
 import {Assignment, calculateDuration} from './Assignment';
-import TestUtils from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 
 describe('Assignment', () => {
     describe('calculateDuration', () => {
         const assignment: Assignment = {
             id: 1,
-            person: TestUtils.hank,
-            productId: TestUtils.productForHank.id,
-            spaceUuid: TestUtils.hank.spaceUuid,
+            person: TestData.hank,
+            productId: TestData.productForHank.id,
+            spaceUuid: TestData.hank.spaceUuid,
             placeholder: false,
             startDate: undefined,
             endDate: undefined,

--- a/ui/src/Assignments/AssignmentCard.test.tsx
+++ b/ui/src/Assignments/AssignmentCard.test.tsx
@@ -36,6 +36,7 @@ import ProductClient from '../Products/ProductClient';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 
 jest.mock('axios');
+jest.mock('../Products/ProductClient');
 
 describe('Assignment Card', () => {
     let assignmentToRender: Assignment;

--- a/ui/src/Assignments/AssignmentCard.test.tsx
+++ b/ui/src/Assignments/AssignmentCard.test.tsx
@@ -19,6 +19,7 @@ import {fireEvent, screen, waitFor} from '@testing-library/react';
 import React from 'react';
 import AssignmentCard from './AssignmentCard';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {Assignment} from './Assignment';
 import {Color, RoleTag} from '../Roles/RoleTag.interface';
 import rootReducer from '../Redux/Reducers';
@@ -48,9 +49,9 @@ describe('Assignment Card', () => {
                 spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
                 id: 445,
                 name: 'Billiam Handy',
-                spaceRole: TestUtils.softwareEngineer,
+                spaceRole: TestData.softwareEngineer,
                 notes: 'This is a note',
-                tags: TestUtils.personTags,
+                tags: TestData.personTags,
             },
             placeholder: false,
             productId: 1,
@@ -62,7 +63,7 @@ describe('Assignment Card', () => {
 
         jest.useFakeTimers();
 
-        store = createStore(rootReducer, {currentSpace: TestUtils.space}, applyMiddleware(thunk));
+        store = createStore(rootReducer, {currentSpace: TestData.space}, applyMiddleware(thunk));
     });
 
     afterEach(() => {
@@ -94,7 +95,7 @@ describe('Assignment Card', () => {
             .toHaveBeenCalledWith(assignmentToRender.spaceUuid, assignmentToRender.person.id, expect.any(Date))
         )
         await waitFor(() => expect(AssignmentClient.createAssignmentForDate)
-            .toHaveBeenCalledWith(moment(new Date()).format('YYYY-MM-DD'), [{"placeholder": true, "productId": 1}], TestUtils.space, assignmentToRender.person, false)
+            .toHaveBeenCalledWith(moment(new Date()).format('YYYY-MM-DD'), [{"placeholder": true, "productId": 1}], TestData.space, assignmentToRender.person, false)
         )
         await waitFor(() => expect(ProductClient.getProductsForDate).toHaveBeenCalledWith('uuid', expect.any(Date)))
     });
@@ -114,14 +115,14 @@ describe('Assignment Card', () => {
             assignmentToRender.spaceUuid, assignmentToRender.person.id, expect.any(Date)
         ))
         await waitFor(() => expect(AssignmentClient.createAssignmentForDate).toHaveBeenCalledWith(
-            moment(new Date()).format('YYYY-MM-DD'), [{"placeholder": false, "productId": 1}], TestUtils.space, assignmentToRender.person, false
+            moment(new Date()).format('YYYY-MM-DD'), [{"placeholder": false, "productId": 1}], TestData.space, assignmentToRender.person, false
         ))
         await waitFor(() => expect(ProductClient.getProductsForDate).toHaveBeenCalledWith('uuid', expect.any(Date)));
     });
 
     describe('Read-Only Functionality', function() {
         beforeEach(function() {
-            store = createStore(rootReducer, {currentSpace: TestUtils.space});
+            store = createStore(rootReducer, {currentSpace: TestData.space});
         });
 
         it('should not display edit Menu if in read only mode', function() {
@@ -185,13 +186,13 @@ describe('Assignment Card', () => {
 
     describe('Role color', () => {
         beforeEach(() => {
-            store = createStore(rootReducer, {currentSpace: TestUtils.space});
+            store = createStore(rootReducer, {currentSpace: TestData.space});
         });
 
         it('should render software engineer color correctly', () => {
             renderAssignmentCard(assignmentToRender);
             const assignmentCardEditContainer: HTMLElement = screen.getByTestId('editPersonIconContainer__billiam_handy');
-            const person1Role: RoleTag = (TestUtils.people[0].spaceRole as RoleTag);
+            const person1Role: RoleTag = (TestData.people[0].spaceRole as RoleTag);
             const person1RoleColor: Color = (person1Role.color as Color);
             expect(assignmentCardEditContainer).toHaveStyle(`background-color: ${person1RoleColor.color}`);
         });
@@ -232,7 +233,7 @@ describe('Assignment Card', () => {
 
     describe('Edit Menu', () => {
         beforeEach(() => {
-            store = createStore(rootReducer, {currentSpace: TestUtils.space}, applyMiddleware(thunk));
+            store = createStore(rootReducer, {currentSpace: TestData.space}, applyMiddleware(thunk));
         });
 
         it('should initialize with the Edit Menu closed', () => {
@@ -287,13 +288,13 @@ describe('Assignment Card', () => {
             expectEditMenuContents(true);
             fireEvent.click(screen.getByText('Archive Person'));
             fireEvent.click(await screen.findByText('Archive'));
-            await waitFor(() =>expect(PeopleClient.archivePerson).toHaveBeenCalledWith(TestUtils.space, assignmentToRender.person, new Date(2020, 0, 1)));
+            await waitFor(() =>expect(PeopleClient.archivePerson).toHaveBeenCalledWith(TestData.space, assignmentToRender.person, new Date(2020, 0, 1)));
         });
     });
 
     describe('New Person Badge', () => {
         beforeEach(() => {
-            store = createStore(rootReducer, {currentSpace: TestUtils.space}, applyMiddleware(thunk));
+            store = createStore(rootReducer, {currentSpace: TestData.space}, applyMiddleware(thunk));
         });
 
         it('should show the new badge if the assignment says the person is new and there is a newPersonDate', () => {
@@ -325,7 +326,7 @@ describe('Assignment Card', () => {
 
     describe('Hoverable Notes', () => {
         beforeEach(() => {
-            store = createStore(rootReducer, {currentSpace: TestUtils.space}, applyMiddleware(thunk));
+            store = createStore(rootReducer, {currentSpace: TestData.space}, applyMiddleware(thunk));
         });
 
         it('should display hover notes icon if person has valid notes', () => {
@@ -368,7 +369,7 @@ describe('Assignment Card', () => {
         });
 
         it('should hide hover box for assignment when an assignment is being dragged', () => {
-            store = createStore(rootReducer, {currentSpace: TestUtils.space});
+            store = createStore(rootReducer, {currentSpace: TestData.space});
             renderAssignmentCard(assignmentToRender, false, ({set}) => {
                 set(IsDraggingState, true);
             });
@@ -385,7 +386,7 @@ describe('Assignment Card', () => {
 
     describe('Hoverable Person tag', () => {
         beforeEach(() => {
-            store = createStore(rootReducer, {currentSpace: TestUtils.space}, applyMiddleware(thunk));
+            store = createStore(rootReducer, {currentSpace: TestData.space}, applyMiddleware(thunk));
         });
 
         it('should display person tag Icon if person has valid notes', () => {
@@ -394,7 +395,7 @@ describe('Assignment Card', () => {
         });
 
         it('should not display person tag Icon if person has valid person tags, but user is readOnly', () => {
-            store = createStore(rootReducer, {currentSpace: TestUtils.space});
+            store = createStore(rootReducer, {currentSpace: TestData.space});
             renderAssignmentCard(assignmentToRender, false, ({set}) => {
                 set(IsReadOnlyState, true);
             });

--- a/ui/src/Assignments/AssignmentCardList.test.tsx
+++ b/ui/src/Assignments/AssignmentCardList.test.tsx
@@ -16,7 +16,8 @@
  */
 import React from 'react';
 import {screen} from '@testing-library/react';
-import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import AssignmentCardList from './AssignmentCardList';
 import moment from 'moment';
 import {AllGroupedTagFilterOptions} from '../SortingAndFiltering/FilterLibraries';
@@ -30,8 +31,8 @@ const product: Product = {
     spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
     startDate: '2011-01-01',
     endDate: '2022-02-02',
-    spaceLocation: TestUtils.southfield,
-    assignments: TestUtils.assignmentsFilterTest,
+    spaceLocation: TestData.southfield,
+    assignments: TestData.assignmentsFilterTest,
     archived: false,
     tags: [],
     notes: '',
@@ -88,7 +89,7 @@ const setupComponent = (allGroupedTagFilterOptions: Array<AllGroupedTagFilterOpt
         undefined,
         {
             allGroupedTagFilterOptions: allGroupedTagFilterOptions,
-            currentSpace: TestUtils.space,
+            currentSpace: TestData.space,
         }
     );
 }

--- a/ui/src/Assignments/AssignmentClient.test.tsx
+++ b/ui/src/Assignments/AssignmentClient.test.tsx
@@ -18,7 +18,7 @@
 import Axios from 'axios';
 import AssignmentClient from './AssignmentClient';
 import {CreateAssignmentsRequest, ProductPlaceholderPair} from './CreateAssignmentRequest';
-import TestUtils from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import moment from 'moment';
 import Cookies from 'universal-cookie';
 import {MatomoWindow} from '../CommonTypes/MatomoWindow';
@@ -77,17 +77,17 @@ describe('Assignment client', () => {
 
         };
 
-        const expectedUrl = `/api/spaces/${TestUtils.space.uuid}/person/${TestUtils.person1.id}/assignment/create`;
+        const expectedUrl = `/api/spaces/${TestData.space.uuid}/person/${TestData.person1.id}/assignment/create`;
 
         await AssignmentClient.createAssignmentForDate(
             moment(date).format('YYYY-MM-DD'),
             [productPlaceholderPair],
-            TestUtils.space,
-            TestUtils.person1
+            TestData.space,
+            TestData.person1
         );
 
         expect(Axios.post).toHaveBeenCalledWith(expectedUrl, expectedCreateAssignmentRequest, expectedConfig);
-        expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'assignPerson', TestUtils.person1.name]);
+        expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'assignPerson', TestData.person1.name]);
     });
 
     it('should send matomo error event if assign person fails', async () => {
@@ -97,12 +97,12 @@ describe('Assignment client', () => {
             await AssignmentClient.createAssignmentForDate(
                 moment(new Date()).format('YYYY-MM-DD'),
                 [],
-                TestUtils.space,
-                TestUtils.person1
+                TestData.space,
+                TestData.person1
             );
         } catch (err) {
             expect(window._paq).toContainEqual(
-                ['trackEvent', TestUtils.space.name, 'assignPersonError', TestUtils.person1.name, 417]
+                ['trackEvent', TestData.space.name, 'assignPersonError', TestData.person1.name, 417]
             );
         }
     });
@@ -111,12 +111,12 @@ describe('Assignment client', () => {
         await AssignmentClient.createAssignmentForDate(
             moment(new Date()).format('YYYY-MM-DD'),
             [],
-            TestUtils.space,
-            TestUtils.person1,
+            TestData.space,
+            TestData.person1,
             false
         );
         expect(window._paq).not.toContainEqual(
-            ['trackEvent', TestUtils.space.name, 'assignPerson', TestUtils.person1.name]
+            ['trackEvent', TestData.space.name, 'assignPerson', TestData.person1.name]
         );
     });
 
@@ -127,13 +127,13 @@ describe('Assignment client', () => {
             await AssignmentClient.createAssignmentForDate(
                 moment(new Date()).format('YYYY-MM-DD'),
                 [],
-                TestUtils.space,
-                TestUtils.person1,
+                TestData.space,
+                TestData.person1,
                 false
             );
         } catch (err) {
             expect(window._paq).not.toContainEqual(
-                ['trackEvent', TestUtils.space.name, 'assignPersonError', TestUtils.person1.name, 417]
+                ['trackEvent', TestData.space.name, 'assignPersonError', TestData.person1.name, 417]
             );
         }
 
@@ -149,15 +149,15 @@ describe('Assignment client', () => {
     });
 
     it('should delete assignment given person for a specific date', async () => {
-        const expectedUrl = `/api/spaces/${TestUtils.person1.spaceUuid}/person/${TestUtils.person1.id}/assignment/delete/${TestUtils.originDateString}`;
+        const expectedUrl = `/api/spaces/${TestData.person1.spaceUuid}/person/${TestData.person1.id}/assignment/delete/${TestData.originDateString}`;
         const expectedConfig = {
             headers: {
                 'Content-Type': 'application/json',
                 'Authorization': 'Bearer 123456',
             },
-            data: TestUtils.person1,
+            data: TestData.person1,
         };
-        await AssignmentClient.deleteAssignmentForDate(new Date(2019, 0, 1), TestUtils.person1);
+        await AssignmentClient.deleteAssignmentForDate(new Date(2019, 0, 1), TestData.person1);
 
         expect(Axios.delete).toHaveBeenCalledWith(expectedUrl, expectedConfig);
     });
@@ -169,18 +169,18 @@ describe('Assignment client', () => {
                 'Authorization': 'Bearer 123456',
             },
         };
-        await AssignmentClient.getAssignmentsV2ForSpaceAndPerson(TestUtils.hank.spaceUuid, TestUtils.hank.id);
-        expect(Axios.get).toHaveBeenCalledWith('/api/v2/spaces/' + TestUtils.hank.spaceUuid + '/person/' + TestUtils.hank.id + '/assignments', expectedConfig);
+        await AssignmentClient.getAssignmentsV2ForSpaceAndPerson(TestData.hank.spaceUuid, TestData.hank.id);
+        expect(Axios.get).toHaveBeenCalledWith('/api/v2/spaces/' + TestData.hank.spaceUuid + '/person/' + TestData.hank.id + '/assignments', expectedConfig);
     });
 
     it('should return what it gets from the assignment history summary API', async () => {
-        const assignment = TestUtils.assignmentForHank;
+        const assignment = TestData.assignmentForHank;
         Axios.get = jest.fn().mockResolvedValue({
             data: [assignment],
         });
 
-        const actual = await AssignmentClient.getAssignmentsV2ForSpaceAndPerson(TestUtils.hank.spaceUuid, TestUtils.hank.id);
-        expect(actual.data).toEqual([TestUtils.assignmentForHank]);
+        const actual = await AssignmentClient.getAssignmentsV2ForSpaceAndPerson(TestData.hank.spaceUuid, TestData.hank.id);
+        expect(actual.data).toEqual([TestData.assignmentForHank]);
     });
 
     it('should get reassignments given assignment', async () => {

--- a/ui/src/Assignments/AssignmentForm.test.tsx
+++ b/ui/src/Assignments/AssignmentForm.test.tsx
@@ -21,6 +21,7 @@ import AssignmentForm from '../Assignments/AssignmentForm';
 import AssignmentClient from '../Assignments/AssignmentClient';
 import rootReducer, {GlobalStateProps} from '../Redux/Reducers';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {createStore, Store} from 'redux';
 import selectEvent from 'react-select-event';
 import moment from 'moment';
@@ -38,7 +39,7 @@ describe('AssignmentForm', () => {
 
     describe('in create mode', () => {
         it('should not show the unassigned or archived products in the product list', async () => {
-            const products = [TestUtils.productWithAssignments, TestUtils.archivedProduct, TestUtils.unassignedProduct];
+            const products = [TestData.productWithAssignments, TestData.archivedProduct, TestData.unassignedProduct];
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ProductsState, products);
@@ -67,11 +68,11 @@ describe('AssignmentForm', () => {
             expect(AssignmentClient.createAssignmentForDate).toBeCalledWith(
                 moment(viewingDate).format('YYYY-MM-DD'),
                 [{
-                    productId: TestUtils.assignmentForPerson1.productId,
-                    placeholder: TestUtils.assignmentForPerson1.placeholder,
+                    productId: TestData.assignmentForPerson1.productId,
+                    placeholder: TestData.assignmentForPerson1.placeholder,
                 }],
-                TestUtils.space,
-                TestUtils.person1
+                TestData.space,
+                TestData.person1
             );
         });
 
@@ -85,11 +86,11 @@ describe('AssignmentForm', () => {
             expect(AssignmentClient.createAssignmentForDate).toBeCalledWith(
                 moment(viewingDate).format('YYYY-MM-DD'),
                 [{
-                    productId: TestUtils.assignmentForPerson1.productId,
-                    placeholder: TestUtils.assignmentForPerson1.placeholder,
+                    productId: TestData.assignmentForPerson1.productId,
+                    placeholder: TestData.assignmentForPerson1.placeholder,
                 }],
-                TestUtils.space,
-                TestUtils.person1
+                TestData.space,
+                TestData.person1
             );
         });
 
@@ -106,11 +107,11 @@ describe('AssignmentForm', () => {
             expect(AssignmentClient.createAssignmentForDate).toBeCalledWith(
                 moment(viewingDate).format('YYYY-MM-DD'),
                 [{
-                    productId: TestUtils.assignmentForPerson1.productId,
+                    productId: TestData.assignmentForPerson1.productId,
                     placeholder: true,
                 }],
-                TestUtils.space,
-                TestUtils.person1
+                TestData.space,
+                TestData.person1
             );
         });
 
@@ -147,7 +148,7 @@ describe('AssignmentForm', () => {
         });
 
         it('populates the person name field of the Create Person modal on open', async () => {
-            const state = { people: TestUtils.people };
+            const state = { people: TestData.people };
             const store = createStore(rootReducer, state);
             store.dispatch = jest.fn();
 
@@ -161,7 +162,7 @@ describe('AssignmentForm', () => {
             expect(store.dispatch).toBeCalledWith(setCurrentModalAction({
                 modal: AvailableModals.CREATE_PERSON,
                 item: {
-                    initiallySelectedProduct: TestUtils.productWithAssignments,
+                    initiallySelectedProduct: TestData.productWithAssignments,
                     initialPersonName: 'XYZ ABC 123',
                 },
             }));
@@ -171,14 +172,14 @@ describe('AssignmentForm', () => {
 
 const renderComponent = (store: Store|undefined = undefined): { viewingDate: Date; initialState: Partial<GlobalStateProps>; } => {
     const products = [
-        TestUtils.productWithAssignments,
-        TestUtils.archivedProduct,
-        TestUtils.unassignedProduct,
+        TestData.productWithAssignments,
+        TestData.archivedProduct,
+        TestData.unassignedProduct,
     ];
     const viewingDate = new Date(2020, 5, 5);
     const initialState = {
-        currentSpace: TestUtils.space,
-        people: TestUtils.people,
+        currentSpace: TestData.space,
+        people: TestData.people,
     };
     renderWithRedux(
         <RecoilRoot initializeState={({set}) => {

--- a/ui/src/Assignments/AssignmentSelector.test.tsx
+++ b/ui/src/Assignments/AssignmentSelector.test.tsx
@@ -20,6 +20,7 @@ import AssignmentForm from './AssignmentForm';
 import {fireEvent, screen} from '@testing-library/react';
 import AssignmentClient from './AssignmentClient';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import selectEvent from 'react-select-event';
 import moment from 'moment';
 import {RecoilRoot} from 'recoil';
@@ -35,9 +36,9 @@ describe('the assignment form', () => {
     it('renders the assignment form labels', () => {
         renderWithRedux(
             <RecoilRoot initializeState={(({set}) => {
-                set(ProductsState, [TestUtils.unassignedProduct])
+                set(ProductsState, [TestData.unassignedProduct])
             })}>
-                <AssignmentForm initiallySelectedProduct={TestUtils.unassignedProduct} />,
+                <AssignmentForm initiallySelectedProduct={TestData.unassignedProduct} />,
             </RecoilRoot>
         );
         expect(screen.getByLabelText('Name')).toBeDefined();
@@ -46,9 +47,9 @@ describe('the assignment form', () => {
     });
 
     it('accepts changes to the assignment forms product list and can submit multiple assignments', async () => {
-        const products = [TestUtils.unassignedProduct, TestUtils.productWithAssignments, TestUtils.productWithoutAssignments, TestUtils.productForHank];
+        const products = [TestData.unassignedProduct, TestData.productWithAssignments, TestData.productWithoutAssignments, TestData.productForHank];
         const viewingDate = new Date(2020, 5, 5);
-        const initialState = {people: TestUtils.people, currentSpace: TestUtils.space};
+        const initialState = {people: TestData.people, currentSpace: TestData.space};
         renderWithRedux(
             <RecoilRoot initializeState={(({set}) => {
                 set(ViewingDateState, viewingDate)
@@ -75,20 +76,20 @@ describe('the assignment form', () => {
             moment(viewingDate).format('YYYY-MM-DD'),
             [
                 {
-                    productId: TestUtils.productWithoutAssignments.id,
+                    productId: TestData.productWithoutAssignments.id,
                     placeholder: false,
                 },
                 {
-                    productId: TestUtils.productWithAssignments.id,
+                    productId: TestData.productWithAssignments.id,
                     placeholder: false,
                 },
                 {
-                    productId: TestUtils.productForHank.id,
-                    placeholder: TestUtils.assignmentForHank.placeholder,
+                    productId: TestData.productForHank.id,
+                    placeholder: TestData.assignmentForHank.placeholder,
                 },
             ],
-            TestUtils.space,
-            TestUtils.hank
+            TestData.space,
+            TestData.hank
         );
     });
 });

--- a/ui/src/Assignments/History/AssignmentHistory.test.tsx
+++ b/ui/src/Assignments/History/AssignmentHistory.test.tsx
@@ -26,6 +26,8 @@ import {fireEvent} from '@testing-library/dom';
 import {Assignment} from '../Assignment';
 import TestUtils from '../../Utils/TestUtils';
 
+jest.mock('../../Products/ProductClient');
+
 describe('Assignment History', () => {
 
     const daysBetweenStartAndToday = (assignment: Assignment): number  => {

--- a/ui/src/Assignments/PersonAndRoleInfo.test.tsx
+++ b/ui/src/Assignments/PersonAndRoleInfo.test.tsx
@@ -16,7 +16,8 @@
  */
 
 import React from 'react';
-import TestUtils, {renderWithRecoil} from '../Utils/TestUtils';
+import {renderWithRecoil} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import PersonAndRoleInfo from './PersonAndRoleInfo';
 import {fireEvent, screen} from '@testing-library/react';
 import {IsReadOnlyState} from '../State/IsReadOnlyState';
@@ -25,7 +26,7 @@ describe('Tooltip behavior on hover', () => {
     it('should show the notes of the person being hovered over', async () => {
         renderWithRecoil(
             <PersonAndRoleInfo
-                person={TestUtils.hank}
+                person={TestData.hank}
                 isUnassignedProduct={false}
                 duration={parseInt('dontcare', 1)}
             />
@@ -42,7 +43,7 @@ describe('Tooltip behavior on hover', () => {
     it('should not show the notes of the person being hovered over if they have none', async () => {
         renderWithRecoil(
             <PersonAndRoleInfo
-                person={TestUtils.person2}
+                person={TestData.person2}
                 isUnassignedProduct={false}
                 duration={parseInt('dontcare', 1)}
             />
@@ -57,7 +58,7 @@ describe('Tooltip behavior on hover', () => {
     it('should show the time on product of the person being hovered over', async () => {
         renderWithRecoil(
             <PersonAndRoleInfo
-                person={TestUtils.hank}
+                person={TestData.hank}
                 isUnassignedProduct={false}
                 duration={367}
             />
@@ -74,7 +75,7 @@ describe('Tooltip behavior on hover', () => {
     it('should show the person tags of the person being hovered over', async () => {
         renderWithRecoil(
             <PersonAndRoleInfo
-                person={TestUtils.person2}
+                person={TestData.person2}
                 isUnassignedProduct={false}
                 duration={parseInt('dontcare', 1)}
             />
@@ -92,7 +93,7 @@ describe('Tooltip behavior on hover', () => {
     it('should not show the person tags of the person being hovered over if they have none', async () => {
         renderWithRecoil(
             <PersonAndRoleInfo
-                person={TestUtils.unassignedPerson}
+                person={TestData.unassignedPerson}
                 isUnassignedProduct={false}
                 duration={parseInt('dontcare', 1)}
             />
@@ -106,7 +107,7 @@ describe('Tooltip behavior on hover', () => {
     it('should not show the hover if the space is read only', async () => {
         renderWithRecoil(
             <PersonAndRoleInfo
-                person={TestUtils.hank}
+                person={TestData.hank}
                 duration={0}
                 isUnassignedProduct={false}
             />,
@@ -124,7 +125,7 @@ describe('Tooltip behavior on hover', () => {
     it('should not show the hover if it is part of the Unassigned product', async () => {
         renderWithRecoil(
             <PersonAndRoleInfo
-                person={TestUtils.hank}
+                person={TestData.hank}
                 duration={0}
                 isUnassignedProduct={true}
             />

--- a/ui/src/Assignments/Unassigned.test.tsx
+++ b/ui/src/Assignments/Unassigned.test.tsx
@@ -18,6 +18,7 @@
 import {fireEvent, screen, waitFor} from '@testing-library/react';
 import React from 'react';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {Product} from '../Products/Product';
 import UnassignedDrawer from './UnassignedDrawer';
 import {act} from 'react-dom/test-utils';
@@ -75,14 +76,14 @@ describe('Unassigned Products', () => {
                         { label: 'Role Tags:', options: []},
                         { label: 'Person Tags:', options: []},
                     ],
-                    currentSpace: TestUtils.space,
+                    currentSpace: TestData.space,
                 }
             );
         }
 
         it('hides the number of unassigned people when there are less than 1', async () => {
             const emptyUnassignedProduct: Product = {
-                ...TestUtils.unassignedProduct,
+                ...TestData.unassignedProduct,
                 assignments: [],
                 spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
             };
@@ -92,15 +93,15 @@ describe('Unassigned Products', () => {
         });
 
         it('does not show archived people as unassigned', async () => {
-            renderWithUnassignedProduct( [TestUtils.unassignedProduct])
+            renderWithUnassignedProduct( [TestData.unassignedProduct])
 
-            await waitFor(() => expect(screen.queryByText(TestUtils.archivedPerson.name)).toBeNull());
+            await waitFor(() => expect(screen.queryByText(TestData.archivedPerson.name)).toBeNull());
         });
 
         it('should show an archived person as unassigned if their archive date has not passed', async () => {
-            const product = {...TestUtils.unassignedProduct, assignments:[TestUtils.assignmentForHank]};
+            const product = {...TestData.unassignedProduct, assignments:[TestData.assignmentForHank]};
             renderWithUnassignedProduct( [product])
-            screen.getByText(TestUtils.hank.name);
+            screen.getByText(TestData.hank.name);
         });
     });
 
@@ -128,7 +129,7 @@ describe('Unassigned Products', () => {
     });
 
     describe('Edit menus', () => {
-        const initialState = {people: TestUtils.people, productTags: [TestUtils.productTag1]};
+        const initialState = {people: TestData.people, productTags: [TestData.productTag1]};
 
         beforeEach(async () => {
             jest.clearAllMocks();
@@ -145,7 +146,7 @@ describe('Unassigned Products', () => {
             fireEvent.click(editUnassignment);
 
             const unassignedPersonName: HTMLInputElement = await screen.findByLabelText('Name') as HTMLInputElement;
-            expect(unassignedPersonName.value).toEqual(TestUtils.unassignedPerson.name);
+            expect(unassignedPersonName.value).toEqual(TestData.unassignedPerson.name);
         });
 
         // @todo should be a cypress test
@@ -157,7 +158,7 @@ describe('Unassigned Products', () => {
             fireEvent.click(editUnassignment);
 
             const unassignedPersonName = await screen.findByLabelText('Name');
-            expect(unassignedPersonName).toHaveValue(TestUtils.unassignedPerson.name);
+            expect(unassignedPersonName).toHaveValue(TestData.unassignedPerson.name);
 
             const closeForm = await screen.findByTestId('modalCloseButton');
             fireEvent.click(closeForm);
@@ -171,7 +172,7 @@ describe('Unassigned Products', () => {
             fireEvent.click(editPerson1);
 
             const person1Name = await screen.findByLabelText('Name');
-            expect(person1Name).toHaveValue(TestUtils.assignmentForPerson1.person.name);
+            expect(person1Name).toHaveValue(TestData.assignmentForPerson1.person.name);
         });
     });
 });

--- a/ui/src/Assignments/Unassigned.test.tsx
+++ b/ui/src/Assignments/Unassigned.test.tsx
@@ -27,6 +27,7 @@ import {IsUnassignedDrawerOpenState} from '../State/IsUnassignedDrawerOpenState'
 import {ProductsState} from '../State/ProductsState';
 
 jest.mock('../Products/ProductClient');
+jest.mock('../Space/SpaceClient');
 
 describe('Unassigned Products', () => {
     const submitFormButtonText = 'Add';

--- a/ui/src/Assignments/Unassigned.test.tsx
+++ b/ui/src/Assignments/Unassigned.test.tsx
@@ -26,6 +26,8 @@ import {RecoilRoot} from 'recoil';
 import {IsUnassignedDrawerOpenState} from '../State/IsUnassignedDrawerOpenState';
 import {ProductsState} from '../State/ProductsState';
 
+jest.mock('../Products/ProductClient');
+
 describe('Unassigned Products', () => {
     const submitFormButtonText = 'Add';
 

--- a/ui/src/Calendar/Calendar.test.tsx
+++ b/ui/src/Calendar/Calendar.test.tsx
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import TestUtils, {mockCreateRange, renderWithRedux} from '../Utils/TestUtils';
+import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import React from 'react';
 import {fireEvent, queryByText, screen, waitFor} from '@testing-library/react';
 import Calendar from './Calendar';
@@ -30,7 +31,7 @@ describe('Calendar', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         TestUtils.mockClientCalls();
-        resetCreateRange = mockCreateRange();
+        resetCreateRange = TestUtils.mockCreateRange();
     });
 
     afterEach(() => {
@@ -80,7 +81,7 @@ describe('Calendar', () => {
 function setupCalenderComponent(isReadOnly = false) {
     const mockStore = configureStore([]);
     const reduxStore = mockStore({
-        currentSpace: TestUtils.space,
+        currentSpace: TestData.space,
     });
 
     renderWithRedux(

--- a/ui/src/Header/Header.test.tsx
+++ b/ui/src/Header/Header.test.tsx
@@ -20,6 +20,7 @@ import {fireEvent, screen, waitFor} from '@testing-library/react';
 import {axe, toHaveNoViolations} from 'jest-axe';
 import Header from './Header';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {RunConfig} from '../index';
 import {MemoryRouter} from 'react-router-dom';
 import flagsmith from 'flagsmith';
@@ -29,7 +30,7 @@ const debounceTimeToWait = 100;
 expect.extend(toHaveNoViolations);
 
 describe('Header', () => {
-    const initialState = {currentSpace: TestUtils.space };
+    const initialState = {currentSpace: TestData.space };
     let location: (string | Location) & Location;
 
     beforeEach(() => {

--- a/ui/src/Hooks/useFetchProducts.test.tsx
+++ b/ui/src/Hooks/useFetchProducts.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {ReactNode} from 'react';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {act, renderHook} from '@testing-library/react-hooks';
+import {RecoilRoot} from 'recoil';
+import useFetchProducts from './useFetchProducts';
+import ProductClient from '../Products/ProductClient';
+import {ViewingDateState} from '../State/ViewingDateState';
+import TestData from '../Utils/TestData';
+
+jest.mock('../Products/ProductClient');
+
+const teamUUID = 'team-uuid';
+const viewingDate = new Date();
+
+describe('useFetchProducts Hook', () => {
+    it('should fetch all products and store them in recoil', async () => {
+        const { result } = renderHook(() => useFetchProducts(), { wrapper });
+
+        expect(ProductClient.getProductsForDate).not.toHaveBeenCalled()
+        expect(result.current.products).toEqual([]);
+
+        await act(async () => {
+            result.current.fetchProducts()
+        });
+        expect(ProductClient.getProductsForDate).toHaveBeenCalledWith(teamUUID, viewingDate);
+        expect(result.current.products).toEqual(TestData.products);
+    });
+});
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[`/${teamUUID}`]}>
+        <RecoilRoot initializeState={({set}) => {
+            set(ViewingDateState, viewingDate)
+        }}>
+            <Routes>
+                <Route path="/:teamUUID" element={children} />
+            </Routes>
+        </RecoilRoot>
+    </MemoryRouter>
+);

--- a/ui/src/Hooks/useFetchUserSpaces.test.tsx
+++ b/ui/src/Hooks/useFetchUserSpaces.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {ReactNode} from 'react';
+import {act, renderHook} from '@testing-library/react-hooks';
+import TestData from '../Utils/TestData';
+import SpaceClient from '../Space/SpaceClient';
+import useFetchUserSpaces from './useFetchUserSpaces';
+import {RecoilRoot} from 'recoil';
+
+jest.mock('../Space/SpaceClient');
+
+describe('useFetchUserSpaces Hook', () => {
+    it('should fetch all spaces and store them in recoil', async () => {
+        const { result } = renderHook(() => useFetchUserSpaces(), { wrapper });
+
+        expect(SpaceClient.getSpacesForUser).not.toHaveBeenCalled()
+        expect(result.current.userSpaces).toEqual([]);
+
+        await act(async () => {
+            await result.current.fetchUserSpaces()
+        });
+        expect(SpaceClient.getSpacesForUser).toHaveBeenCalledWith();
+        expect(result.current.userSpaces).toEqual([TestData.space]);
+    });
+});
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+    <RecoilRoot>
+        {children}
+    </RecoilRoot>
+);

--- a/ui/src/Locations/LocationClient.test.tsx
+++ b/ui/src/Locations/LocationClient.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Ford Motor Company
+ * Copyright (c) 2022 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import Axios, {AxiosResponse} from 'axios';
+import Axios from 'axios';
 import LocationClient from './LocationClient';
-import TestUtils from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import Cookies from 'universal-cookie';
 
 describe('Location Client', function() {
@@ -35,10 +35,10 @@ describe('Location Client', function() {
     beforeEach(() => {
         cookies.set('accessToken', '123456');
 
-        Axios.post = jest.fn().mockReturnValue(Promise.resolve({data: 'Created Location'} as AxiosResponse));
-        Axios.put = jest.fn().mockReturnValue(Promise.resolve({data: 'Updated Location'} as AxiosResponse));
-        Axios.delete = jest.fn().mockReturnValue(Promise.resolve({data: 'Deleted Location'} as AxiosResponse));
-        Axios.get = jest.fn().mockReturnValue(Promise.resolve({data: 'Get Locations'} as AxiosResponse));
+        Axios.post = jest.fn().mockResolvedValue({data: 'Created Location'});
+        Axios.put = jest.fn().mockResolvedValue({data: 'Updated Location'});
+        Axios.delete = jest.fn().mockResolvedValue({data: 'Deleted Location'});
+        Axios.get = jest.fn().mockResolvedValue({data: 'Get Locations'});
     });
 
     afterEach(function() {
@@ -56,8 +56,8 @@ describe('Location Client', function() {
     });
 
     it('should create a location and return that location', function(done) {
-        const expectedLocationAddRequest = { name: TestUtils.annarbor.name };
-        LocationClient.add(expectedLocationAddRequest, TestUtils.space)
+        const expectedLocationAddRequest = { name: TestData.annarbor.name };
+        LocationClient.add(expectedLocationAddRequest, TestData.space)
             .then((response) => {
                 expect(Axios.post).toHaveBeenCalledWith(baseLocationsUrl, expectedLocationAddRequest, expectedConfig);
                 expect(response.data).toBe('Created Location');
@@ -67,20 +67,20 @@ describe('Location Client', function() {
 
     it('should update a location and return that location', function(done) {
         const expectedLocationEditRequest = {
-            id: TestUtils.annarbor.id,
-            name: TestUtils.annarbor.name,
+            id: TestData.annarbor.id,
+            name: TestData.annarbor.name,
         };
-        LocationClient.edit(expectedLocationEditRequest, TestUtils.space)
+        LocationClient.edit(expectedLocationEditRequest, TestData.space)
             .then((response) => {
-                expect(Axios.put).toHaveBeenCalledWith(baseLocationsUrl + `/${TestUtils.annarbor.id}`, expectedLocationEditRequest, expectedConfig);
+                expect(Axios.put).toHaveBeenCalledWith(baseLocationsUrl + `/${TestData.annarbor.id}`, expectedLocationEditRequest, expectedConfig);
                 expect(response.data).toBe('Updated Location');
                 done();
             });
     });
 
     it('should delete a location', function(done) {
-        const expectedUrl = `${baseLocationsUrl}/${TestUtils.annarbor.id}`;
-        LocationClient.delete(TestUtils.annarbor.id, TestUtils.space)
+        const expectedUrl = `${baseLocationsUrl}/${TestData.annarbor.id}`;
+        LocationClient.delete(TestData.annarbor.id, TestData.space)
             .then((response) => {
                 expect(Axios.delete).toHaveBeenCalledWith(expectedUrl, expectedConfig);
                 expect(response.data).toBe('Deleted Location');

--- a/ui/src/ModalFormComponents/SelectWithNoCreateOption.test.tsx
+++ b/ui/src/ModalFormComponents/SelectWithNoCreateOption.test.tsx
@@ -19,14 +19,14 @@ import {render, screen} from '@testing-library/react';
 import SelectWithNoCreateOption from './SelectWithNoCreateOption';
 import React from 'react';
 import {Product} from '../Products/Product';
-import TestUtils from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {noop} from '@babel/types';
 import selectEvent from 'react-select-event';
 
 describe('SelectWithNoCreateOption (Multi-select)', () => {
     const initiallySelectedProducts: Product[] = [
-        TestUtils.products[0],
-        TestUtils.products[1],
+        TestData.products[0],
+        TestData.products[1],
     ];
 
     it('should render initial select options', () => {
@@ -38,14 +38,14 @@ describe('SelectWithNoCreateOption (Multi-select)', () => {
                     placeholder: 'Select a product',
                 }}
                 values={initiallySelectedProducts.map(x => {return {value:x.name, label:x.name};})}
-                options={TestUtils.products.map(x => {return {value:x.name, label:x.name};})}
+                options={TestData.products.map(x => {return {value:x.name, label:x.name};})}
                 onChange={noop}
             />
         );
         expect(screen.getByText(initiallySelectedProducts[0].name)).toBeInTheDocument();
         expect(screen.getByText(initiallySelectedProducts[1].name)).toBeInTheDocument();
-        expect(screen.queryByText(TestUtils.products[2].name)).not.toBeInTheDocument();
-        expect(screen.queryByText(TestUtils.products[3].name)).not.toBeInTheDocument();
+        expect(screen.queryByText(TestData.products[2].name)).not.toBeInTheDocument();
+        expect(screen.queryByText(TestData.products[3].name)).not.toBeInTheDocument();
     });
 
     it('should call the onChange callback when user selects new option', async () => {
@@ -59,13 +59,13 @@ describe('SelectWithNoCreateOption (Multi-select)', () => {
                     placeholder: 'Select a product',
                 }}
                 values={initiallySelectedProducts.map(x => ({value: x.name, label: x.name}))}
-                options={TestUtils.products.map(x => ({value: x.name, label: x.name}))}
+                options={TestData.products.map(x => ({value: x.name, label: x.name}))}
                 onChange={mockOnChange}
             />
         );
 
         const SelectElement = screen.getByLabelText('Title');
-        await selectEvent.select(SelectElement, [TestUtils.productForHank.name]);
+        await selectEvent.select(SelectElement, [TestData.productForHank.name]);
         expect(mockOnChange).toHaveBeenCalled();
     });
 
@@ -78,7 +78,7 @@ describe('SelectWithNoCreateOption (Multi-select)', () => {
                     placeholder: 'Select a product',
                 }}
                 values={[]}
-                options={TestUtils.products.map(x => {return {value:x.name, label:x.name};})}
+                options={TestData.products.map(x => {return {value:x.name, label:x.name};})}
                 onChange={noop}
             />
         );
@@ -95,7 +95,7 @@ describe('SelectWithNoCreateOption (Multi-select)', () => {
                     placeholder: 'Select a product',
                 }}
                 values={initiallySelectedProducts.map(x => {return {value:x.name, label:x.name};})}
-                options={TestUtils.products.map(x => {return {value:x.name, label:x.name};})}
+                options={TestData.products.map(x => {return {value:x.name, label:x.name};})}
                 onChange={noop}
             />
         );

--- a/ui/src/People/ArchivedPersonDrawer.test.tsx
+++ b/ui/src/People/ArchivedPersonDrawer.test.tsx
@@ -24,6 +24,8 @@ import configureStore from 'redux-mock-store';
 import {RecoilRoot} from 'recoil';
 import {ViewingDateState} from '../State/ViewingDateState';
 
+jest.mock('../Products/ProductClient');
+
 describe('Archived People', () => {
     const mayFourteen2020: Date = new Date(2020, 4, 14);
     const mayFourteen1999: Date = new Date(1999, 4, 14);

--- a/ui/src/People/ArchivedPersonDrawer.test.tsx
+++ b/ui/src/People/ArchivedPersonDrawer.test.tsx
@@ -18,6 +18,7 @@
 import {fireEvent, screen} from '@testing-library/react';
 import React from 'react';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import ArchivedPersonDrawer from './ArchivedPersonDrawer';
 import configureStore from 'redux-mock-store';
 import {RecoilRoot} from 'recoil';
@@ -35,8 +36,8 @@ describe('Archived People', () => {
 
             const mockStore = configureStore([]);
             const store = mockStore({
-                currentSpace: TestUtils.space,
-                people: [...TestUtils.people, TestUtils.unassignedBigBossSE],
+                currentSpace: TestData.space,
+                people: [...TestData.people, TestData.unassignedBigBossSE],
             });
 
             ({unmount} = renderWithRedux(
@@ -56,9 +57,9 @@ describe('Archived People', () => {
         it('shows the names of two archived people but not one unarchived person', async () => {
             const drawerCaret = await screen.findByTestId('archivedPersonDrawerCaret');
             fireEvent.click(drawerCaret);
-            expect(await screen.findByText(TestUtils.archivedPerson.name)).toBeInTheDocument();
-            expect(await screen.findByText(TestUtils.unassignedBigBossSE.name)).toBeInTheDocument();
-            expect(screen.queryByText(TestUtils.person1.name)).not.toBeInTheDocument();
+            expect(await screen.findByText(TestData.archivedPerson.name)).toBeInTheDocument();
+            expect(await screen.findByText(TestData.unassignedBigBossSE.name)).toBeInTheDocument();
+            expect(screen.queryByText(TestData.person1.name)).not.toBeInTheDocument();
             expect(screen.getAllByTestId(/archivedPersonCard__*/)).toHaveLength(2);
             expect((await screen.findByTestId('archivedPersonDrawerCountBadge')).innerHTML).toEqual('2');
         });
@@ -66,15 +67,15 @@ describe('Archived People', () => {
         it('should not show people who have not passed their archived date', async () => {
             const drawerCaret = await screen.findByTestId('archivedPersonDrawerCaret');
             fireEvent.click(drawerCaret);
-            expect(screen.queryByText(TestUtils.hank.name)).not.toBeInTheDocument();
+            expect(screen.queryByText(TestData.hank.name)).not.toBeInTheDocument();
         });
 
         it('can be closed and opened again', async () => {
             const drawerCaret = await screen.findByTestId('archivedPersonDrawerCaret');
             fireEvent.click(drawerCaret);
-            expect(await screen.findByText(TestUtils.archivedPerson.name)).toBeInTheDocument();
+            expect(await screen.findByText(TestData.archivedPerson.name)).toBeInTheDocument();
             fireEvent.click(drawerCaret);
-            expect(await screen.queryByText(TestUtils.archivedPerson.name)).not.toBeInTheDocument();
+            expect(await screen.queryByText(TestData.archivedPerson.name)).not.toBeInTheDocument();
         });
 
         it('should not show an archived person if the viewing date is before their archive date', async () => {
@@ -83,8 +84,8 @@ describe('Archived People', () => {
 
             const mockStore = configureStore([]);
             const store = mockStore({
-                currentSpace: TestUtils.space,
-                people: [...TestUtils.people, TestUtils.unassignedBigBossSE],
+                currentSpace: TestData.space,
+                people: [...TestData.people, TestData.unassignedBigBossSE],
             });
 
             unmount();
@@ -100,9 +101,9 @@ describe('Archived People', () => {
 
             const drawerCaret = await screen.findByTestId('archivedPersonDrawerCaret');
             fireEvent.click(drawerCaret);
-            expect(await screen.queryByText(TestUtils.archivedPerson.name)).not.toBeInTheDocument();
-            expect(await screen.findByText(TestUtils.unassignedBigBossSE.name)).toBeInTheDocument();
-            expect(screen.queryByText(TestUtils.person1.name)).not.toBeInTheDocument();
+            expect(await screen.queryByText(TestData.archivedPerson.name)).not.toBeInTheDocument();
+            expect(await screen.findByText(TestData.unassignedBigBossSE.name)).toBeInTheDocument();
+            expect(screen.queryByText(TestData.person1.name)).not.toBeInTheDocument();
             expect(screen.getAllByTestId(/archivedPersonCard__*/)).toHaveLength(1);
         });
     });

--- a/ui/src/People/ArchivedPersonDrawer.test.tsx
+++ b/ui/src/People/ArchivedPersonDrawer.test.tsx
@@ -25,6 +25,7 @@ import {RecoilRoot} from 'recoil';
 import {ViewingDateState} from '../State/ViewingDateState';
 
 jest.mock('../Products/ProductClient');
+jest.mock('../Space/SpaceClient');
 
 describe('Archived People', () => {
     const mayFourteen2020: Date = new Date(2020, 4, 14);

--- a/ui/src/People/People.test.tsx
+++ b/ui/src/People/People.test.tsx
@@ -28,7 +28,6 @@ import selectEvent from 'react-select-event';
 import {emptyPerson, Person} from './Person';
 import moment from 'moment';
 import {MatomoWindow} from '../CommonTypes/MatomoWindow';
-import ProductClient from '../Products/ProductClient';
 import {ViewingDateState} from '../State/ViewingDateState';
 import {RecoilRoot} from 'recoil';
 import {ProductsState} from '../State/ProductsState';
@@ -44,8 +43,6 @@ describe('People actions', () => {
     const submitFormButtonText = 'Add';
 
     beforeEach(() => {
-        ProductClient.getProductsForDate = jest.fn().mockResolvedValue({ data: [] })
-
         jest.clearAllMocks();
         TestUtils.mockClientCalls();
     });
@@ -59,9 +56,6 @@ describe('People actions', () => {
         const viewingDate = new Date(2020, 5, 5)
 
         beforeEach(async () => {
-            jest.clearAllMocks();
-            TestUtils.mockClientCalls();
-
             await TestUtils.renderPeopleMoverComponent(undefined, personFormInitialState, ({set}) => {
                 set(ViewingDateState, viewingDate)
             });

--- a/ui/src/People/People.test.tsx
+++ b/ui/src/People/People.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Ford Motor Company
+ * Copyright (c) 2022 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@ import AssignmentClient from '../Assignments/AssignmentClient';
 import PeopleClient from '../People/PeopleClient';
 import PersonForm from '../People/PersonForm';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {PreloadedState} from 'redux';
 import {GlobalStateProps} from '../Redux/Reducers';
 import selectEvent from 'react-select-event';
@@ -37,7 +38,7 @@ declare let window: MatomoWindow;
 jest.mock('../Products/ProductClient');
 
 describe('People actions', () => {
-    const initialState: PreloadedState<Partial<GlobalStateProps>> = {currentSpace: TestUtils.space};
+    const initialState: PreloadedState<Partial<GlobalStateProps>> = {currentSpace: TestData.space};
     const addPersonButtonText = 'Add Person';
     const addPersonModalTitle = 'Add New Person';
     const submitFormButtonText = 'Add';
@@ -51,9 +52,9 @@ describe('People actions', () => {
 
     describe('Person Form', () => {
         const personFormInitialState: PreloadedState<Partial<GlobalStateProps>> = {
-            people: TestUtils.people,
-            currentSpace: TestUtils.space,
-            allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions,
+            people: TestData.people,
+            currentSpace: TestData.space,
+            allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions,
         };
         const viewingDate = new Date(2020, 5, 5)
 
@@ -97,8 +98,8 @@ describe('People actions', () => {
 
             await waitFor(() => expect(AssignmentClient.getAssignmentsUsingPersonIdAndDate)
                 .toBeCalledWith(
-                    TestUtils.space.uuid,
-                    TestUtils.person1.id,
+                    TestData.space.uuid,
+                    TestData.person1.id,
                     new Date(2020, 5, 5)
                 )
             );
@@ -155,7 +156,7 @@ describe('People actions', () => {
                     name: 'Low Achiever',
                 }],
             };
-            expect(PeopleClient.createPersonForSpace).toHaveBeenCalledWith(TestUtils.space, expectedPerson, ['Low Achiever']);
+            expect(PeopleClient.createPersonForSpace).toHaveBeenCalledWith(TestData.space, expectedPerson, ['Low Achiever']);
         });
 
         it('should not create person with empty value and display proper error message', async () => {
@@ -210,11 +211,11 @@ describe('People actions', () => {
                         name: 'Product Manager',
                         id: 2,
                         spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-                        color: TestUtils.color2,
+                        color: TestData.color2,
                     },
                 };
                 const spy = jest.spyOn(PeopleClient, 'createPersonForSpace');
-                expect(spy.mock.calls[0]).toEqual([TestUtils.space, expectedPerson, []]);
+                expect(spy.mock.calls[0]).toEqual([TestData.space, expectedPerson, []]);
             });
         });
 
@@ -247,7 +248,7 @@ describe('People actions', () => {
                     },
                 };
                 const spy = jest.spyOn(PeopleClient, 'createPersonForSpace');
-                expect(spy.mock.calls[0]).toEqual([TestUtils.space, expectedPerson, []]);
+                expect(spy.mock.calls[0]).toEqual([TestData.space, expectedPerson, []]);
             });
         });
 
@@ -287,7 +288,7 @@ describe('People actions', () => {
                 name: 'Software Engineer',
                 id: 1,
                 spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-                color: TestUtils.color1,
+                color: TestData.color1,
             },
             newPerson: true,
             newPersonDate: viewingDate,
@@ -295,13 +296,13 @@ describe('People actions', () => {
 
         const checkForCreatedPerson = async (): Promise<void> => {
             expect(PeopleClient.createPersonForSpace).toBeCalledTimes(1);
-            expect(PeopleClient.createPersonForSpace).toBeCalledWith(TestUtils.space, expectedPerson, []);
+            expect(PeopleClient.createPersonForSpace).toBeCalledWith(TestData.space, expectedPerson, []);
 
             expect(AssignmentClient.createAssignmentForDate).toBeCalledTimes(1);
             expect(AssignmentClient.createAssignmentForDate).toBeCalledWith(
                 moment(viewingDate).format('YYYY-MM-DD'),
                 [],
-                TestUtils.space,
+                TestData.space,
                 expectedPerson
             );
         };
@@ -335,7 +336,7 @@ describe('People actions', () => {
                 <PersonForm
                     isEditPersonForm={false}
                     initialPersonName="BRADLEY"
-                    initiallySelectedProduct={TestUtils.productWithAssignments}
+                    initiallySelectedProduct={TestData.productWithAssignments}
                 />
             </RecoilRoot>,
             undefined,
@@ -345,7 +346,7 @@ describe('People actions', () => {
     });
 
     it('should not show the unassigned product or archived products in product list', async () => {
-        const products = [TestUtils.productWithAssignments, TestUtils.archivedProduct, TestUtils.unassignedProduct];
+        const products = [TestData.productWithAssignments, TestData.archivedProduct, TestData.unassignedProduct];
         renderWithRedux(
             <RecoilRoot  initializeState={({set}) => {
                 set(ProductsState, products)
@@ -374,7 +375,7 @@ describe('People actions', () => {
     });
 
     it('should remove the unassigned product when a product is selected from dropdown', async () => {
-        const products = [TestUtils.productWithAssignments, TestUtils.unassignedProduct];
+        const products = [TestData.productWithAssignments, TestData.unassignedProduct];
         renderWithRedux(
             <RecoilRoot initializeState={({set}) => {
                 set(ProductsState, products)
@@ -399,8 +400,8 @@ describe('People actions', () => {
 
         beforeEach(async () => {
             await TestUtils.renderPeopleMoverComponent(undefined,{
-                currentSpace: TestUtils.space,
-                allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions,
+                currentSpace: TestData.space,
+                allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions,
             }, ({set}) => {
                 set(ViewingDateState, new Date(2019, 0, 1))
             })
@@ -431,13 +432,13 @@ describe('People actions', () => {
 
             await waitFor(() => {
                 expect(AssignmentClient.createAssignmentForDate).toBeCalledWith(
-                    TestUtils.originDateString,
+                    TestData.originDateString,
                     [],
-                    TestUtils.space,
-                    TestUtils.person1,
+                    TestData.space,
+                    TestData.person1,
                     false
                 );
-                expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'cancelAssignment', TestUtils.person1.name]);
+                expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'cancelAssignment', TestData.person1.name]);
             });
         });
     });

--- a/ui/src/People/People.test.tsx
+++ b/ui/src/People/People.test.tsx
@@ -35,6 +35,7 @@ import {ProductsState} from '../State/ProductsState';
 declare let window: MatomoWindow;
 
 jest.mock('../Products/ProductClient');
+jest.mock('../Space/SpaceClient');
 
 describe('People actions', () => {
     const initialState: PreloadedState<Partial<GlobalStateProps>> = {currentSpace: TestData.space};

--- a/ui/src/People/PeopleClient.test.tsx
+++ b/ui/src/People/PeopleClient.test.tsx
@@ -17,7 +17,7 @@
 
 import Axios from 'axios';
 import PeopleClient from './PeopleClient';
-import TestUtils from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import Cookies from 'universal-cookie';
 import {Person} from './Person';
 import {MatomoWindow} from '../CommonTypes/MatomoWindow';
@@ -27,7 +27,7 @@ jest.mock('axios');
 declare let window: MatomoWindow;
 
 describe('People Client', function() {
-    const uuid = TestUtils.space.uuid || '';
+    const uuid = TestData.space.uuid || '';
     const basePeopleUrl = `/api/spaces/${uuid}/people`;
     const cookies = new Cookies();
 
@@ -69,8 +69,8 @@ describe('People Client', function() {
     });
 
     it('should create a person and return that person', function(done) {
-        const newPerson = TestUtils.person1;
-        PeopleClient.createPersonForSpace(TestUtils.space, newPerson, [])
+        const newPerson = TestData.person1;
+        PeopleClient.createPersonForSpace(TestData.space, newPerson, [])
             .then((response) => {
                 expect(Axios.post).toHaveBeenCalledWith(basePeopleUrl, newPerson, expectedConfig);
                 expect(response.data).toBe('Created Person');
@@ -79,9 +79,9 @@ describe('People Client', function() {
     });
 
     it('should edit a person and return that person', function(done) {
-        const updatedPerson = TestUtils.person1;
+        const updatedPerson = TestData.person1;
         const expectedUrl = basePeopleUrl + `/${updatedPerson.id}`;
-        PeopleClient.updatePerson(TestUtils.space, updatedPerson, [])
+        PeopleClient.updatePerson(TestData.space, updatedPerson, [])
             .then((response) => {
                 expect(Axios.put).toHaveBeenCalledWith(expectedUrl, updatedPerson, expectedConfig);
                 expect(response.data).toBe('Updated Person');
@@ -90,18 +90,18 @@ describe('People Client', function() {
     });
 
     it('should archive a person on today', function(done) {
-        const archivedPerson = TestUtils.person1;
+        const archivedPerson = TestData.person1;
         const archiveDate = new Date(2020, 0, 2);
         const expectedUrl = basePeopleUrl + `/${archivedPerson.id}/archive`;
-        PeopleClient.archivePerson(TestUtils.space, archivedPerson, archiveDate).then((response) => {
+        PeopleClient.archivePerson(TestData.space, archivedPerson, archiveDate).then(() => {
             expect(Axios.post).toHaveBeenCalledWith(expectedUrl, {archiveDate: archiveDate}, expectedConfig);
             done();
         });
     });
 
     it('should delete a person', function(done) {
-        const expectedUrl = basePeopleUrl + `/${TestUtils.person1.id}`;
-        PeopleClient.removePerson(uuid, TestUtils.person1.id)
+        const expectedUrl = basePeopleUrl + `/${TestData.person1.id}`;
+        PeopleClient.removePerson(uuid, TestData.person1.id)
             .then((response) => {
                 expect(Axios.delete).toHaveBeenCalledWith(expectedUrl, expectedConfig);
                 expect(response.data).toBe('Deleted Person');
@@ -116,7 +116,7 @@ describe('People Client', function() {
             spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
             id: -1,
             name: expectedName,
-            spaceRole: TestUtils.softwareEngineer,
+            spaceRole: TestData.softwareEngineer,
             newPerson: false,
             tags: [],
         };
@@ -135,9 +135,9 @@ describe('People Client', function() {
         });
 
         it('should send an event to matomo when a person is created', async () => {
-            await PeopleClient.createPersonForSpace(TestUtils.space, person, ['bob']);
-            expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'addPerson', expectedName]);
-            expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'assignPersonTagToANewPerson', 'bob']);
+            await PeopleClient.createPersonForSpace(TestData.space, person, ['bob']);
+            expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'addPerson', expectedName]);
+            expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'assignPersonTagToANewPerson', 'bob']);
         });
     });
 });

--- a/ui/src/People/PersonCard.test.tsx
+++ b/ui/src/People/PersonCard.test.tsx
@@ -17,7 +17,8 @@
 
 import {fireEvent, screen} from '@testing-library/react';
 import React from 'react';
-import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {Store} from 'redux';
 import PersonCard from './PersonCard';
 import {Person} from './Person';
@@ -34,9 +35,9 @@ describe('Person Card', () => {
         spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
         id: 1,
         name: 'Billiam Handy',
-        spaceRole: TestUtils.softwareEngineer,
+        spaceRole: TestData.softwareEngineer,
         notes: 'This is a note',
-        tags: TestUtils.personTags,
+        tags: TestData.personTags,
         archiveDate: new Date(2000, 0, 1),
     }
     let store: Store;
@@ -46,7 +47,7 @@ describe('Person Card', () => {
     beforeEach(() => {
         jest.clearAllMocks();
 
-        initialState = {currentSpace: TestUtils.space}
+        initialState = {currentSpace: TestData.space}
     });
 
     it('should render the assigned persons name', () => {
@@ -89,7 +90,7 @@ describe('Person Card', () => {
 
     describe('Read-Only Functionality', function() {
         beforeEach(() => {
-            initialState = {currentSpace: TestUtils.space};
+            initialState = {currentSpace: TestData.space};
         });
 
         it('should not display Edit Person Modal if in read only mode', function() {

--- a/ui/src/People/PersonForm.test.tsx
+++ b/ui/src/People/PersonForm.test.tsx
@@ -16,6 +16,7 @@
  */
 
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import PersonForm from './PersonForm';
 import configureStore from 'redux-mock-store';
 import React from 'react';
@@ -39,9 +40,9 @@ describe('Person Form', () => {
 
     const mockStore = configureStore([]);
     const store = mockStore({
-        currentSpace: TestUtils.space,
-        allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions,
-        roles: TestUtils.roles,
+        currentSpace: TestData.space,
+        allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions,
+        roles: TestData.roles,
     });
 
     beforeEach(() => {
@@ -54,7 +55,7 @@ describe('Person Form', () => {
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
-                    set(ProductsState, TestUtils.products)
+                    set(ProductsState, TestData.products)
                 }}>
                     <PersonForm isEditPersonForm={false}/>
                 </RecoilRoot>,
@@ -68,7 +69,7 @@ describe('Person Form', () => {
             const personTagsLabel = await screen.findByLabelText('Person Tags');
             await selectEvent.create(personTagsLabel, 'Low Achiever');
             const expectedPersonTagAddRequest: TagRequest = {name: 'Low Achiever'};
-            await expect(PersonTagClient.add).toHaveBeenCalledWith(expectedPersonTagAddRequest, TestUtils.space);
+            await expect(PersonTagClient.add).toHaveBeenCalledWith(expectedPersonTagAddRequest, TestData.space);
             const form = await screen.findByTestId('personForm');
             expect(form).toHaveFormValues({personTags: '1337_Low Achiever'});
         });
@@ -84,7 +85,7 @@ describe('Person Form', () => {
                 newPerson: true,
                 newPersonDate: mayFourteen,
             };
-            await waitFor(() => expect(PeopleClient.createPersonForSpace).toHaveBeenCalledWith(TestUtils.space, expectedPerson, []));
+            await waitFor(() => expect(PeopleClient.createPersonForSpace).toHaveBeenCalledWith(TestData.space, expectedPerson, []));
         });
     });
 
@@ -93,16 +94,16 @@ describe('Person Form', () => {
 
         beforeEach(async () => {
             AssignmentClient.getAssignmentsV2ForSpaceAndPerson = jest.fn().mockResolvedValue({
-                data: [{...TestUtils.assignmentForHank, endDate: null},
-                    TestUtils.assignmentVacationForHank,
-                    TestUtils.previousAssignmentForHank],
+                data: [{...TestData.assignmentForHank, endDate: null},
+                    TestData.assignmentVacationForHank,
+                    TestData.previousAssignmentForHank],
             });
 
             ({unmount} = renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
                     set(ProductsState, [
-                        ...TestUtils.products,
+                        ...TestData.products,
                         {
                             id: 500,
                             name: 'Already Closed Product',
@@ -117,9 +118,9 @@ describe('Person Form', () => {
                 }}>
                     <PersonForm
                         isEditPersonForm={true}
-                        initiallySelectedProduct={TestUtils.productForHank}
-                        initialPersonName={TestUtils.hank.name}
-                        personEdited={TestUtils.hank}
+                        initiallySelectedProduct={TestData.productForHank}
+                        initialPersonName={TestData.hank.name}
+                        personEdited={TestData.hank}
                     />
                 </RecoilRoot>,
                 store
@@ -139,28 +140,28 @@ describe('Person Form', () => {
         it('should only display active assignable projects in the assignment dropdown', async () => {
             const assignmentDropDown = await screen.getByLabelText('Assign to');
             await selectEvent.openMenu(assignmentDropDown);
-            expect(screen.queryByText(TestUtils.unassignedProduct.name)).not.toBeInTheDocument();
-            await screen.findByText(TestUtils.productWithAssignments.name);
-            await screen.findByText(TestUtils.productForHank.name);
-            await screen.findByText(TestUtils.productWithoutAssignments.name);
-            expect(screen.queryByText(TestUtils.archivedProduct.name)).not.toBeInTheDocument();
-            await screen.findByText(TestUtils.productWithoutLocation.name);
+            expect(screen.queryByText(TestData.unassignedProduct.name)).not.toBeInTheDocument();
+            await screen.findByText(TestData.productWithAssignments.name);
+            await screen.findByText(TestData.productForHank.name);
+            await screen.findByText(TestData.productWithoutAssignments.name);
+            expect(screen.queryByText(TestData.archivedProduct.name)).not.toBeInTheDocument();
+            await screen.findByText(TestData.productWithoutLocation.name);
             expect(screen.queryByText('Already Closed Product')).not.toBeInTheDocument();
         });
 
         it('should show unassigned in the AssignTo field for an unassigned person', async () => {
             AssignmentClient.getAssignmentsUsingPersonIdAndDate = jest.fn().mockResolvedValue({
-                data: [TestUtils.assignmentForUnassigned],
+                data: [TestData.assignmentForUnassigned],
             });
             unmount();
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
-                    set(ProductsState, TestUtils.products);
+                    set(ProductsState, TestData.products);
                 }}>
                     <PersonForm
                         isEditPersonForm={true}
-                        personEdited={TestUtils.unassignedPerson}
+                        personEdited={TestData.unassignedPerson}
                     />
                 </RecoilRoot>,
                 store
@@ -170,17 +171,17 @@ describe('Person Form', () => {
 
         it('should show Archived in the AssignTo field for an archived person', async () => {
             AssignmentClient.getAssignmentsUsingPersonIdAndDate = jest.fn().mockResolvedValue({
-                data: [TestUtils.assignmentForArchived],
+                data: [TestData.assignmentForArchived],
             });
             unmount();
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
-                    set(ProductsState, TestUtils.products);
+                    set(ProductsState, TestData.products);
                 }}>
                     <PersonForm
                         isEditPersonForm={true}
-                        personEdited={TestUtils.archivedPerson}
+                        personEdited={TestData.archivedPerson}
                     />
                 </RecoilRoot>,
                 store
@@ -194,12 +195,12 @@ describe('Person Form', () => {
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
-                    set(ProductsState, TestUtils.products);
+                    set(ProductsState, TestData.products);
                 }}>
                     <PersonForm
                         isEditPersonForm={true}
-                        initiallySelectedProduct={TestUtils.productForHank}
-                        personEdited={TestUtils.hank}
+                        initiallySelectedProduct={TestData.productForHank}
+                        personEdited={TestData.hank}
                     />
                 </RecoilRoot>,
                 store
@@ -213,18 +214,18 @@ describe('Person Form', () => {
         });
 
         it('should call createAssignmentForDate when assignment has been deliberately changed to unassigned', async () => {
-            PeopleClient.updatePerson = jest.fn().mockResolvedValue({data: TestUtils.hank});
+            PeopleClient.updatePerson = jest.fn().mockResolvedValue({data: TestData.hank});
 
             const personForm =  renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
-                    set(ProductsState, TestUtils.products);
+                    set(ProductsState, TestData.products);
                 }}>
                     <PersonForm
                         isEditPersonForm={true}
-                        initiallySelectedProduct={TestUtils.productForHank}
-                        initialPersonName={TestUtils.hank.name}
-                        personEdited={TestUtils.hank}
+                        initiallySelectedProduct={TestData.productForHank}
+                        initialPersonName={TestData.hank.name}
+                        personEdited={TestData.hank}
                     />
                 </RecoilRoot>,
                 store
@@ -245,13 +246,13 @@ describe('Person Form', () => {
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
-                    set(ProductsState, TestUtils.products);
+                    set(ProductsState, TestData.products);
                 }}>
                     <PersonForm
                         isEditPersonForm={true}
-                        initiallySelectedProduct={TestUtils.productForHank}
-                        initialPersonName={TestUtils.hank.name}
-                        personEdited={TestUtils.hank}
+                        initiallySelectedProduct={TestData.productForHank}
+                        initialPersonName={TestData.hank.name}
+                        personEdited={TestData.hank}
                     />
                 </RecoilRoot>,
                 store
@@ -261,42 +262,42 @@ describe('Person Form', () => {
             fireEvent.click(await screen.findByTestId('personFormIsNewCheckbox'));
             fireEvent.click(await screen.findByText('Save'));
 
-            const expectedPerson: Person =  {...TestUtils.hank, newPerson: true, newPersonDate: mayFourteen};
-            await waitFor(() => expect(PeopleClient.updatePerson).toHaveBeenCalledWith(TestUtils.space, expectedPerson, []));
+            const expectedPerson: Person =  {...TestData.hank, newPerson: true, newPersonDate: mayFourteen};
+            await waitFor(() => expect(PeopleClient.updatePerson).toHaveBeenCalledWith(TestData.space, expectedPerson, []));
         });
 
         it('should send a regular assignment request on an unarchived person', async () => {
-            const updatedPerson = {...TestUtils.archivedPerson, archiveDate: null};
+            const updatedPerson = {...TestData.archivedPerson, archiveDate: null};
             PeopleClient.updatePerson = jest.fn().mockResolvedValue({ data: updatedPerson });
             AssignmentClient.createAssignmentForDate = jest.fn().mockResolvedValue({
-                data: [ {...TestUtils.assignmentForUnassigned, productId: TestUtils.productWithoutAssignments.id} ]
+                data: [ {...TestData.assignmentForUnassigned, productId: TestData.productWithoutAssignments.id} ]
             })
-            AssignmentClient.getAssignmentsUsingPersonIdAndDate = jest.fn().mockResolvedValue({ data: [TestUtils.assignmentForArchived] });
+            AssignmentClient.getAssignmentsUsingPersonIdAndDate = jest.fn().mockResolvedValue({ data: [TestData.assignmentForArchived] });
 
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
-                    set(ProductsState, [TestUtils.unassignedProduct, TestUtils.productWithoutAssignments]);
+                    set(ProductsState, [TestData.unassignedProduct, TestData.productWithoutAssignments]);
                 }}>
                     <PersonForm
                         isEditPersonForm={true}
-                        personEdited={TestUtils.archivedPerson}
+                        personEdited={TestData.archivedPerson}
                     />
                 </RecoilRoot>,
                 store
             );
 
             await selectEvent.openMenu(await screen.findByLabelText('Assign to'));
-            await screen.findByText(TestUtils.productWithoutAssignments.name);
-            await selectEvent.select(await screen.findByLabelText('Assign to'), TestUtils.productWithoutAssignments.name);
+            await screen.findByText(TestData.productWithoutAssignments.name);
+            await selectEvent.select(await screen.findByLabelText('Assign to'), TestData.productWithoutAssignments.name);
 
             fireEvent.click(await screen.findByText('Save'));
 
             await waitFor( async () => expect(AssignmentClient.createAssignmentForDate).toHaveBeenCalledTimes(1));
             await waitFor( async () => expect(AssignmentClient.createAssignmentForDate).toHaveBeenCalledWith(
                 moment(mayFourteen).format('YYYY-MM-DD'),
-                [{'placeholder': false, 'productId': TestUtils.productWithoutAssignments.id}],
-                TestUtils.space,
+                [{'placeholder': false, 'productId': TestData.productWithoutAssignments.id}],
+                TestData.space,
                 updatedPerson
             ));
         });
@@ -314,12 +315,12 @@ describe('Person Form', () => {
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
-                    set(ProductsState, TestUtils.products);
+                    set(ProductsState, TestData.products);
                 }}>
                     <PersonForm
                         isEditPersonForm={true}
-                        initiallySelectedProduct={TestUtils.productForHank}
-                        personEdited={TestUtils.hank}
+                        initiallySelectedProduct={TestData.productForHank}
+                        personEdited={TestData.hank}
                     />
                 </RecoilRoot>,
                 store
@@ -328,20 +329,20 @@ describe('Person Form', () => {
             fireEvent.click(await screen.findByTestId('personFormIsNewCheckbox'));
             fireEvent.click(await screen.findByText('Save'));
 
-            await waitFor(() => expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'newPersonChecked', TestUtils.hank.name]));
+            await waitFor(() => expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'newPersonChecked', TestData.hank.name]));
         });
 
         it('newPerson box goes from checked to unchecked, call matomo event for newPersonUnchecked action',  async () => {
-            const newHank: Person = {...TestUtils.hank, newPerson: true, newPersonDate: new Date(2019, 4, 14)};
+            const newHank: Person = {...TestData.hank, newPerson: true, newPersonDate: new Date(2019, 4, 14)};
 
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
-                    set(ProductsState, TestUtils.products);
+                    set(ProductsState, TestData.products);
                 }}>
                     <PersonForm
                         isEditPersonForm={true}
-                        initiallySelectedProduct={TestUtils.productForHank}
+                        initiallySelectedProduct={TestData.productForHank}
                         personEdited={newHank}
                     />
                 </RecoilRoot>,
@@ -351,20 +352,20 @@ describe('Person Form', () => {
             fireEvent.click(await screen.findByTestId('personFormIsNewCheckbox'));
             fireEvent.click(await screen.findByText('Save'));
 
-            await waitFor(() => expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'newPersonUnchecked', newHank.name + ', 366 day(s)']));
+            await waitFor(() => expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'newPersonUnchecked', newHank.name + ', 366 day(s)']));
         });
 
         it('newPerson box goes from checked to unchecked to checked, DO NOT call any matomo event',  async () => {
-            const newHank: Person = {...TestUtils.hank, name: 'XXXX', newPerson: true, newPersonDate: new Date(2019, 4, 14)};
+            const newHank: Person = {...TestData.hank, name: 'XXXX', newPerson: true, newPersonDate: new Date(2019, 4, 14)};
 
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
-                    set(ProductsState, TestUtils.products);
+                    set(ProductsState, TestData.products);
                 }}>
                     <PersonForm
                         isEditPersonForm={true}
-                        initiallySelectedProduct={TestUtils.productForHank}
+                        initiallySelectedProduct={TestData.productForHank}
                         personEdited={newHank}
                     />
                 </RecoilRoot>,
@@ -382,12 +383,12 @@ describe('Person Form', () => {
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, mayFourteen);
-                    set(ProductsState, TestUtils.products);
+                    set(ProductsState, TestData.products);
                 }}>
                     <PersonForm
                         isEditPersonForm={true}
-                        initiallySelectedProduct={TestUtils.productForHank}
-                        personEdited={TestUtils.hank}
+                        initiallySelectedProduct={TestData.productForHank}
+                        personEdited={TestData.hank}
                     />
                 </RecoilRoot>,
                 store

--- a/ui/src/PeopleMover/ArchivedProduct.test.tsx
+++ b/ui/src/PeopleMover/ArchivedProduct.test.tsx
@@ -22,6 +22,7 @@ import TestData from '../Utils/TestData';
 import {fireEvent, screen} from '@testing-library/react';
 
 jest.mock('../Space/SpaceClient');
+jest.mock('../Products/ProductClient');
 
 describe('Archive Products', () => {
     describe('integration tests', () => {

--- a/ui/src/PeopleMover/ArchivedProduct.test.tsx
+++ b/ui/src/PeopleMover/ArchivedProduct.test.tsx
@@ -18,6 +18,7 @@
 import React from 'react';
 import ArchivedProduct from '../Products/ArchivedProduct';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {fireEvent, screen} from '@testing-library/react';
 
 jest.mock('../Space/SpaceClient');
@@ -66,17 +67,17 @@ describe('Archive Products', () => {
     
     describe('component that summarizes a product in the graveyard', () => {
         it('should render the number of people on the product', () => {
-            renderWithRedux(<ArchivedProduct product={TestUtils.productWithAssignments}/>);
+            renderWithRedux(<ArchivedProduct product={TestData.productWithAssignments}/>);
             expect(screen.getByText('1')).toBeInTheDocument();
         });
     
         it('should render the product name', () => {
-            renderWithRedux(<ArchivedProduct product={TestUtils.productWithAssignments}/>);
+            renderWithRedux(<ArchivedProduct product={TestData.productWithAssignments}/>);
             expect(screen.getByText('Product 1')).toBeInTheDocument();
         });
     
         it('should render the product type', () => {
-            renderWithRedux(<ArchivedProduct product={TestUtils.productWithAssignments}/>);
+            renderWithRedux(<ArchivedProduct product={TestData.productWithAssignments}/>);
             expect(screen.getByText('Southfield')).toBeInTheDocument();
         });
     });

--- a/ui/src/PeopleMover/LocalStorageFilters.test.tsx
+++ b/ui/src/PeopleMover/LocalStorageFilters.test.tsx
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-import TestUtils from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {findByText, fireEvent} from '@testing-library/dom';
 import {act, screen} from '@testing-library/react';
 import {LocalStorageFilters} from '../SortingAndFiltering/FilterLibraries';
 import LocationClient from '../Locations/LocationClient';
+import TestUtils from '../Utils/TestUtils';
 
 describe('Filter products', () => {
     class MockLocalStorage {
@@ -32,10 +33,10 @@ describe('Filter products', () => {
     }
 
     const filters: LocalStorageFilters = {
-        locationTagsFilters: [TestUtils.annarbor.name],
-        productTagsFilters: [TestUtils.productTag1.name],
-        roleTagsFilters: [TestUtils.roles[0].name],
-        personTagsFilters: [TestUtils.personTag1.name],
+        locationTagsFilters: [TestData.annarbor.name],
+        productTagsFilters: [TestData.productTag1.name],
+        roleTagsFilters: [TestData.roles[0].name],
+        personTagsFilters: [TestData.personTag1.name],
     };
 
     beforeEach(() => {
@@ -57,7 +58,7 @@ describe('Filter products', () => {
     });
 
     it('should show unedited location tags in the filter as checked from local storage', async () => {
-        filters.locationTagsFilters.push(TestUtils.detroit.name);
+        filters.locationTagsFilters.push(TestData.detroit.name);
         localStorage.setItem('filters', JSON.stringify(filters));
 
         await TestUtils.renderPeopleMoverComponent();
@@ -74,7 +75,7 @@ describe('Filter products', () => {
         LocationClient.get = jest.fn().mockResolvedValue({
             data: [
                 {id: 1, name: 'Saline', spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'},
-                TestUtils.detroit, TestUtils.dearborn, TestUtils.southfield,
+                TestData.detroit, TestData.dearborn, TestData.southfield,
             ],
         })
 
@@ -91,8 +92,8 @@ describe('Filter products', () => {
         expect(instancesOfSaline.length).toEqual(2);
 
         const tagFiltersAfterUpdate = JSON.parse(localStorage.getItem('filters') || '');
-        expect(tagFiltersAfterUpdate.locationTagsFilters).toContain(TestUtils.detroit.name);
+        expect(tagFiltersAfterUpdate.locationTagsFilters).toContain(TestData.detroit.name);
         expect(tagFiltersAfterUpdate.locationTagsFilters).toContain(updatedLocation);
-        expect(tagFiltersAfterUpdate.locationTagsFilters).not.toContain(TestUtils.annarbor.name);
+        expect(tagFiltersAfterUpdate.locationTagsFilters).not.toContain(TestData.annarbor.name);
     });
 });

--- a/ui/src/PeopleMover/LocalStorageFilters.test.tsx
+++ b/ui/src/PeopleMover/LocalStorageFilters.test.tsx
@@ -22,6 +22,8 @@ import {LocalStorageFilters} from '../SortingAndFiltering/FilterLibraries';
 import LocationClient from '../Locations/LocationClient';
 import TestUtils from '../Utils/TestUtils';
 
+jest.mock('../Products/ProductClient');
+
 describe('Filter products', () => {
     class MockLocalStorage {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ui/src/PeopleMover/LocalStorageFilters.test.tsx
+++ b/ui/src/PeopleMover/LocalStorageFilters.test.tsx
@@ -23,6 +23,7 @@ import LocationClient from '../Locations/LocationClient';
 import TestUtils from '../Utils/TestUtils';
 
 jest.mock('../Products/ProductClient');
+jest.mock('../Space/SpaceClient');
 
 describe('Filter products', () => {
     class MockLocalStorage {

--- a/ui/src/PeopleMover/PeopleMover.test.tsx
+++ b/ui/src/PeopleMover/PeopleMover.test.tsx
@@ -16,6 +16,7 @@
  */
 
 import TestUtils from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {screen, waitFor} from '@testing-library/react';
 import SpaceClient from '../Space/SpaceClient';
 import rootReducer from '../Redux/Reducers';
@@ -52,14 +53,14 @@ describe('PeopleMover', () => {
     describe('Read Only Mode', function() {
         beforeEach(async () => {
             const initialState = {
-                currentSpace: TestUtils.space,
-                allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions,
+                currentSpace: TestData.space,
+                allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions,
             };
             store = createStore(rootReducer, initialState, applyMiddleware(thunk));
 
             await TestUtils.renderPeopleMoverComponent(store, initialState, ({set}) => {
                 set(IsReadOnlyState, true);
-                set(ProductsState, TestUtils.products);
+                set(ProductsState, TestData.products);
             });
         });
 
@@ -78,7 +79,7 @@ describe('PeopleMover', () => {
         it('should trigger a matomo read-only visit event each time the current space changes', () => {
             const nextSpace = {...createEmptySpace(), name: 'newSpace'};
 
-            expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'viewOnlyVisit', '']);
+            expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'viewOnlyVisit', '']);
             expect(window._paq).not.toContainEqual(['trackEvent', nextSpace.name, 'viewOnlyVisit', '']);
             expect(getEventCount('viewOnlyVisit')).toEqual(1);
 
@@ -188,9 +189,9 @@ describe('PeopleMover', () => {
         });
 
         it('should display products', async () => {
-            await screen.findAllByText(TestUtils.productWithAssignments.name);
-            await screen.findAllByText(TestUtils.productWithoutAssignments.name);
-            await screen.findAllByText(TestUtils.productForHank.name);
+            await screen.findAllByText(TestData.productWithAssignments.name);
+            await screen.findAllByText(TestData.productWithoutAssignments.name);
+            await screen.findAllByText(TestData.productForHank.name);
         });
 
         it('should sort products by name by default',  async () => {
@@ -198,10 +199,10 @@ describe('PeopleMover', () => {
             const actualProductNames = productNameElements.map((element) => element.innerHTML);
             expect(actualProductNames).toEqual(
                 [
-                    TestUtils.productWithoutLocation.name,
-                    TestUtils.productForHank.name,
-                    TestUtils.productWithAssignments.name,
-                    TestUtils.productWithoutAssignments.name,
+                    TestData.productWithoutLocation.name,
+                    TestData.productForHank.name,
+                    TestData.productWithAssignments.name,
+                    TestData.productWithoutAssignments.name,
                 ]
             );
         });

--- a/ui/src/PeopleMover/PeopleMover.test.tsx
+++ b/ui/src/PeopleMover/PeopleMover.test.tsx
@@ -32,6 +32,7 @@ import {ProductsState} from '../State/ProductsState';
 declare let window: MatomoWindow;
 
 jest.mock('../Space/SpaceClient');
+jest.mock('../Products/ProductClient');
 
 const mockedUsedNavigate = jest.fn();
 

--- a/ui/src/Products/Product.test.tsx
+++ b/ui/src/Products/Product.test.tsx
@@ -36,6 +36,7 @@ import {RecoilRoot} from 'recoil';
 import {IsReadOnlyState} from '../State/IsReadOnlyState';
 
 jest.mock('./ProductClient');
+jest.mock('../Space/SpaceClient');
 
 describe('Products', () => {
     const addProductButtonText = 'Add Product';

--- a/ui/src/Products/Product.test.tsx
+++ b/ui/src/Products/Product.test.tsx
@@ -20,6 +20,7 @@ import {act, fireEvent, screen, waitFor} from '@testing-library/react';
 import AssignmentClient from '../Assignments/AssignmentClient';
 import ProductClient from './ProductClient';
 import TestUtils, {createDataTestId, renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {applyMiddleware, createStore} from 'redux';
 import rootReducer from '../Redux/Reducers';
 import ProductTagClient from '../Tags/ProductTag/ProductTagClient';
@@ -67,7 +68,7 @@ describe('Products', () => {
         });
 
         it('should not make an update assignment call when dragging assignment card to same product', async () => {
-            renderProductCard({ product: TestUtils.productWithAssignments });
+            renderProductCard({ product: TestData.productWithAssignments });
 
             AssignmentClient.createAssignmentForDate = jest.fn().mockResolvedValue({});
 
@@ -420,7 +421,7 @@ describe('Products', () => {
             fireEvent.click(editProductOption);
 
             const notesFieldText = await screen.findByTestId('notesFieldText');
-            const expectedNotes = TestUtils.productWithAssignments.notes || '';
+            const expectedNotes = TestData.productWithAssignments.notes || '';
             expect(notesFieldText.innerHTML).toContain(expectedNotes.length.toString());
         });
 
@@ -470,7 +471,7 @@ describe('Products', () => {
             const deleteButton = await screen.findByText('Delete');
             fireEvent.click(deleteButton);
             expect(ProductClient.deleteProduct).toBeCalledTimes(1);
-            expect(ProductClient.deleteProduct).toBeCalledWith(TestUtils.space, TestUtils.productWithoutAssignments);
+            expect(ProductClient.deleteProduct).toBeCalledWith(TestData.space, TestData.productWithoutAssignments);
         });
 
         it('should not show archive button option in delete modal if product is already archived', async () => {
@@ -506,9 +507,9 @@ describe('Products', () => {
                 fireEvent.click(archiveButton);
 
                 expect(ProductClient.editProduct).toBeCalledTimes(1);
-                const cloneWithEndDateSet = JSON.parse(JSON.stringify(TestUtils.productWithoutAssignments));
+                const cloneWithEndDateSet = JSON.parse(JSON.stringify(TestData.productWithoutAssignments));
                 cloneWithEndDateSet.endDate = moment(viewingDate).subtract(1, 'day').format('YYYY-MM-DD');
-                expect(ProductClient.editProduct).toBeCalledWith(TestUtils.space, cloneWithEndDateSet);
+                expect(ProductClient.editProduct).toBeCalledWith(TestData.space, cloneWithEndDateSet);
             });
         });
     });
@@ -537,12 +538,12 @@ describe('Products', () => {
         it('should put product in archived products when clicking archive product', async () => {
             function updateGetAllProductsResponse(): void {
                 const updatedProduct = {
-                    ...TestUtils.productWithAssignments,
+                    ...TestData.productWithAssignments,
                     archived: true,
                 };
                 const updatedProducts = [
                     updatedProduct,
-                    TestUtils.unassignedProduct,
+                    TestData.unassignedProduct,
                 ];
                 ProductClient.getProductsForDate = jest.fn().mockResolvedValue({ data: updatedProducts });
             }
@@ -568,7 +569,7 @@ describe('Products', () => {
 
     describe('Read only view', () => {
         beforeEach(() => {
-            renderProductCard({ product: TestUtils.productWithAssignments, isReadOnly: true})
+            renderProductCard({ product: TestData.productWithAssignments, isReadOnly: true})
         });
 
         it('should not show edit product icon', async () => {
@@ -582,11 +583,11 @@ describe('Products', () => {
 });
 
 function renderProductCard(params?: { product?: Product, isReadOnly?: boolean }) {
-    const { product = TestUtils.productWithoutAssignments, isReadOnly = false } = params || {}
+    const { product = TestData.productWithoutAssignments, isReadOnly = false } = params || {}
 
     const initialState = {
-        currentSpace: TestUtils.space,
-        allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions,
+        currentSpace: TestData.space,
+        allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions,
         currentModal: {modal: null},
     };
 

--- a/ui/src/Products/Product.test.tsx
+++ b/ui/src/Products/Product.test.tsx
@@ -35,6 +35,8 @@ import {ViewingDateState} from '../State/ViewingDateState';
 import {RecoilRoot} from 'recoil';
 import {IsReadOnlyState} from '../State/IsReadOnlyState';
 
+jest.mock('./ProductClient');
+
 describe('Products', () => {
     const addProductButtonText = 'Add Product';
     const addProductModalTitle = 'Add New Product';

--- a/ui/src/Products/ProductCard.test.tsx
+++ b/ui/src/Products/ProductCard.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Ford Motor Company
+ * Copyright (c) 2022 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 
 import React from 'react';
 import TestUtils, {createDataTestId, renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {emptyProduct, Product} from './Product';
 import ProductCard, {PRODUCT_URL_CLICKED} from './ProductCard';
 import {MatomoWindow} from '../CommonTypes/MatomoWindow';
@@ -45,14 +46,14 @@ describe('ProductCard', () => {
     ];
     const mayFourteenth2020 = new Date(2020, 4, 14);
     let store: Store;
-    const products = [TestUtils.unassignedProduct,
-        TestUtils.productWithoutAssignments,
-        TestUtils.archivedProduct,
-        TestUtils.productWithoutLocation,
-        TestUtils.productWithAssignments,
-        {...TestUtils.productForHank, assignments: [
-            TestUtils.assignmentForHank,
-            {...TestUtils.assignmentForPerson1, productId: TestUtils.productForHank.id},
+    const products = [TestData.unassignedProduct,
+        TestData.productWithoutAssignments,
+        TestData.archivedProduct,
+        TestData.productWithoutLocation,
+        TestData.productWithAssignments,
+        {...TestData.productForHank, assignments: [
+            TestData.assignmentForHank,
+            {...TestData.assignmentForPerson1, productId: TestData.productForHank.id},
         ]},
     ];
 
@@ -62,7 +63,7 @@ describe('ProductCard', () => {
 
         store = createStore(rootReducer, 
             {
-                currentSpace: TestUtils.space,
+                currentSpace: TestData.space,
                 allGroupedTagFilterOptions: allGroupedTagFilterOptions,
             },
             applyMiddleware(thunk));
@@ -91,13 +92,13 @@ describe('ProductCard', () => {
 
         expect(window.open).toHaveBeenCalledTimes(1);
         expect(window.open).toHaveBeenCalledWith('any old url');
-        expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, PRODUCT_URL_CLICKED, 'testProduct']);
+        expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, PRODUCT_URL_CLICKED, 'testProduct']);
     });
 
     it('archiving a product sets the appropriate fields in the product and moves all people to unassigned', async () => {
         const may13String = moment(mayFourteenth2020).subtract(1, 'day').format('YYYY-MM-DD');
         const may14String = moment(mayFourteenth2020).format('YYYY-MM-DD');
-        const testProduct = {...TestUtils.productWithAssignments, assignments: [TestUtils.assignmentForPerson1, TestUtils.assignmentForPerson2, TestUtils.assignmentForPerson3]};
+        const testProduct = {...TestData.productWithAssignments, assignments: [TestData.assignmentForPerson1, TestData.assignmentForPerson2, TestData.assignmentForPerson3]};
 
         ProductClient.editProduct = jest.fn().mockResolvedValue({data: {...testProduct, endDate: may13String}});
 
@@ -105,24 +106,24 @@ describe('ProductCard', () => {
 
         renderProductCard(testProduct);
 
-        fireEvent.click(await screen.findByTestId(createDataTestId('editProductIcon', TestUtils.productWithAssignments.name)));
+        fireEvent.click(await screen.findByTestId(createDataTestId('editProductIcon', TestData.productWithAssignments.name)));
         fireEvent.click(await screen.findByText('Archive Product'));
         fireEvent.click(screen.getByText('Archive'));
 
         await waitFor(() => expect(AssignmentClient.createAssignmentForDate).toHaveBeenCalledTimes(3));
-        expect(AssignmentClient.createAssignmentForDate).toHaveBeenCalledWith(may14String, [{productId: TestUtils.productForHank.id, placeholder: false}], TestUtils.space, TestUtils.person1);
-        expect(AssignmentClient.createAssignmentForDate).toHaveBeenCalledWith(may14String, [], TestUtils.space, TestUtils.person2);
-        expect(AssignmentClient.createAssignmentForDate).toHaveBeenCalledWith(may14String, [], TestUtils.space, TestUtils.person3);
+        expect(AssignmentClient.createAssignmentForDate).toHaveBeenCalledWith(may14String, [{productId: TestData.productForHank.id, placeholder: false}], TestData.space, TestData.person1);
+        expect(AssignmentClient.createAssignmentForDate).toHaveBeenCalledWith(may14String, [], TestData.space, TestData.person2);
+        expect(AssignmentClient.createAssignmentForDate).toHaveBeenCalledWith(may14String, [], TestData.space, TestData.person3);
         expect(ProductClient.editProduct).toHaveBeenCalledTimes(1);
-        expect(ProductClient.editProduct).toHaveBeenCalledWith(TestUtils.space, {...testProduct, endDate: may13String}, true);
+        expect(ProductClient.editProduct).toHaveBeenCalledWith(TestData.space, {...testProduct, endDate: may13String}, true);
         expect(store.dispatch).toHaveBeenCalledTimes(1);
     });
 
     it('should show a confirmation modal when Archive Person is clicked, and be able to close it', async () => {
-        renderProductCard(TestUtils.productWithAssignments);
+        renderProductCard(TestData.productWithAssignments);
         expectEditMenuContents(false);
 
-        const editProductSelector = createDataTestId('editProductIcon', TestUtils.productWithAssignments.name)
+        const editProductSelector = createDataTestId('editProductIcon', TestData.productWithAssignments.name)
         fireEvent.click(screen.getByTestId(editProductSelector));
         expectEditMenuContents(true);
 

--- a/ui/src/Products/ProductClient.test.tsx
+++ b/ui/src/Products/ProductClient.test.tsx
@@ -18,7 +18,7 @@
 import ProductClient from './ProductClient';
 import {Product} from './Product';
 import {MatomoWindow} from '../CommonTypes/MatomoWindow';
-import TestUtils from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import Cookies from 'universal-cookie';
 import Axios from 'axios';
 
@@ -26,7 +26,7 @@ jest.mock('axios');
 declare let window: MatomoWindow;
 
 describe('Product Client', function() {
-    const baseProductsUrl = `/api/spaces/${TestUtils.space.uuid}/products`;
+    const baseProductsUrl = `/api/spaces/${TestData.space.uuid}/products`;
     const expectedConfig = {
         headers: {
             'Content-Type': 'application/json',
@@ -57,27 +57,27 @@ describe('Product Client', function() {
 
     it('should create a product and return that product', function(done) {
         const expectedUrl = baseProductsUrl;
-        ProductClient.createProduct(TestUtils.space, TestUtils.productWithAssignments)
+        ProductClient.createProduct(TestData.space, TestData.productWithAssignments)
             .then((response) => {
-                expect(Axios.post).toHaveBeenCalledWith(expectedUrl, TestUtils.productWithAssignments, expectedConfig);
+                expect(Axios.post).toHaveBeenCalledWith(expectedUrl, TestData.productWithAssignments, expectedConfig);
                 expect(response.data).toBe('Created Product');
                 done();
             });
     });
 
     it('should update a product and return that product', function(done) {
-        const expectedUrl = `${baseProductsUrl}/${TestUtils.productWithAssignments.id}`;
-        ProductClient.editProduct(TestUtils.space, TestUtils.productWithAssignments)
+        const expectedUrl = `${baseProductsUrl}/${TestData.productWithAssignments.id}`;
+        ProductClient.editProduct(TestData.space, TestData.productWithAssignments)
             .then((response) => {
-                expect(Axios.put).toHaveBeenCalledWith(expectedUrl, TestUtils.productWithAssignments, expectedConfig);
+                expect(Axios.put).toHaveBeenCalledWith(expectedUrl, TestData.productWithAssignments, expectedConfig);
                 expect(response.data).toBe('Updated Product');
                 done();
             });
     });
 
     it('should delete a product', function(done) {
-        const expectedUrl = `${baseProductsUrl}/${TestUtils.productWithAssignments.id}`;
-        ProductClient.deleteProduct(TestUtils.space, TestUtils.productWithAssignments)
+        const expectedUrl = `${baseProductsUrl}/${TestData.productWithAssignments.id}`;
+        ProductClient.deleteProduct(TestData.space, TestData.productWithAssignments)
             .then((response) => {
                 expect(Axios.delete).toHaveBeenCalledWith(expectedUrl, expectedConfig);
                 expect(response.data).toBe('Deleted Product');
@@ -88,7 +88,7 @@ describe('Product Client', function() {
     it('should return the products given a date', function(done) {
         const date = '2019-01-10';
         const expectedUrl = baseProductsUrl + `?requestedDate=${date}`;
-        const spaceUuid = TestUtils?.space?.uuid || '';
+        const spaceUuid = TestData?.space?.uuid || '';
         ProductClient.getProductsForDate(spaceUuid, new Date(2019, 0, 10))
             .then((response) => {
                 expect(Axios.get).toHaveBeenCalledWith(expectedUrl, expectedConfig);
@@ -121,18 +121,18 @@ describe('Product Client', function() {
             const expectedResponse = { post: true };
             Axios.post = jest.fn().mockResolvedValue(expectedResponse);
 
-            const axiosResponse = await ProductClient.createProduct(TestUtils.space, product);
+            const axiosResponse = await ProductClient.createProduct(TestData.space, product);
             expect(axiosResponse).toBe(expectedResponse);
 
-            expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'createProduct', expectedName]);
+            expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'createProduct', expectedName]);
         });
 
         it('should push createError on create with failure code', (done) => {
             const expectedResponse = { code: 417 };
             Axios.post = jest.fn().mockRejectedValue(expectedResponse);
 
-            ProductClient.createProduct(TestUtils.space, product).catch(() => {
-                expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'createProductError', expectedName, expectedResponse.code]);
+            ProductClient.createProduct(TestData.space, product).catch(() => {
+                expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'createProductError', expectedName, expectedResponse.code]);
                 done()
             });
         });
@@ -141,20 +141,20 @@ describe('Product Client', function() {
             const expectedResponse = { delete: true };
             Axios.delete = jest.fn().mockResolvedValue(expectedResponse);
 
-            const axiosResponse = await ProductClient.deleteProduct(TestUtils.space, product);
+            const axiosResponse = await ProductClient.deleteProduct(TestData.space, product);
             expect(axiosResponse).toBe(expectedResponse);
 
-            expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'deleteProduct', expectedName]);
+            expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'deleteProduct', expectedName]);
         });
 
         it('should push edit product action on edit', async () => {
             const expectedResponse = { put: true };
             Axios.put = jest.fn().mockResolvedValue(expectedResponse);
 
-            const axiosResponse = await ProductClient.editProduct(TestUtils.space, product);
+            const axiosResponse = await ProductClient.editProduct(TestData.space, product);
             expect(axiosResponse).toBe(expectedResponse);
 
-            expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'editProduct', expectedName]);
+            expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'editProduct', expectedName]);
         });
     });
 });

--- a/ui/src/Products/ProductClient.ts
+++ b/ui/src/Products/ProductClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Ford Motor Company
+ * Copyright (c) 2022 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ui/src/Products/ProductForm.test.tsx
+++ b/ui/src/Products/ProductForm.test.tsx
@@ -18,7 +18,8 @@ import ProductForm from '../Products/ProductForm';
 import React from 'react';
 import configureStore from 'redux-mock-store';
 import {fireEvent, screen, waitFor} from '@testing-library/react';
-import TestUtils, {mockCreateRange, renderWithRedux} from '../Utils/TestUtils';
+import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {Space} from '../Space/Space';
 import {AvailableActions} from '../Redux/Actions';
 import LocationClient from '../Locations/LocationClient';
@@ -37,17 +38,17 @@ import {ProductsState} from '../State/ProductsState';
 describe('ProductForm', function() {
     const mockStore = configureStore([]);
     const store = mockStore({
-        currentSpace: TestUtils.space,
+        currentSpace: TestData.space,
     });
 
     let resetCreateRange: () => void;
 
     beforeEach(() => {
         store.dispatch = jest.fn();
-        resetCreateRange = mockCreateRange();
+        resetCreateRange = TestUtils.mockCreateRange();
 
-        LocationClient.get = jest.fn().mockResolvedValue({data: TestUtils.locations});
-        ProductTagClient.get = jest.fn().mockResolvedValue({data: TestUtils.productTags});
+        LocationClient.get = jest.fn().mockResolvedValue({data: TestData.locations});
+        ProductTagClient.get = jest.fn().mockResolvedValue({data: TestData.productTags});
         ProductClient.createProduct = jest.fn().mockResolvedValue({data: {}});
     });
 
@@ -93,19 +94,19 @@ describe('ProductForm', function() {
         fireEvent.click(screen.getByText('Add'));
 
         await waitFor(() => expect(ProductClient.createProduct).toHaveBeenCalledWith(
-            TestUtils.space,
+            TestData.space,
             {
                 id: -1,
                 spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
                 name: 'Some Name',
                 startDate: '2020-05-14',
                 endDate: '',
-                spaceLocation: TestUtils.annarbor,
+                spaceLocation: TestData.annarbor,
                 archived: false,
                 dorf: '',
                 notes: '',
                 url: '',
-                tags: [TestUtils.productTag2],
+                tags: [TestData.productTag2],
                 assignments: [],
             } as Product));
 
@@ -123,7 +124,7 @@ describe('ProductForm', function() {
             } as Space,
         });
 
-        const archivedProduct = {...TestUtils.productWithoutLocation, endDate: '2020-02-02'};
+        const archivedProduct = {...TestData.productWithoutLocation, endDate: '2020-02-02'};
         renderWithRedux(
             <RecoilRoot initializeState={({set}) => {
                 set(ViewingDateState, new Date(2022, 3, 14))
@@ -148,7 +149,7 @@ describe('ProductForm', function() {
             }}>
                 <ProductForm
                     editing={true}
-                    product={TestUtils.productWithoutLocation}
+                    product={TestData.productWithoutLocation}
                 />
             </RecoilRoot>,
             store
@@ -164,7 +165,7 @@ describe('ProductForm', function() {
             <RecoilRoot initializeState={({set}) => {
                 set(ViewingDateState, new Date(2020, 4, 14))
             }}>
-                <ProductForm editing={true} product={TestUtils.archivedProduct} />
+                <ProductForm editing={true} product={TestData.archivedProduct} />
             </RecoilRoot>,
             store
         );
@@ -178,9 +179,9 @@ describe('ProductForm', function() {
     describe('tag dropdowns', () => {
         let history: History;
         const initialState: PreloadedState<Partial<GlobalStateProps>> = {
-            currentSpace: TestUtils.space,
-            productTags: TestUtils.productTags,
-            allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions,
+            currentSpace: TestData.space,
+            productTags: TestData.productTags,
+            allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions,
         };
 
         beforeEach(() => {
@@ -194,7 +195,7 @@ describe('ProductForm', function() {
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, moment().toDate())
-                    set(ProductsState, TestUtils.products)
+                    set(ProductsState, TestData.products)
                 }}>
                     <ProductForm editing={false} />
                 </RecoilRoot>,

--- a/ui/src/Products/ProductList.test.tsx
+++ b/ui/src/Products/ProductList.test.tsx
@@ -18,6 +18,7 @@
 import React from 'react';
 import {screen} from '@testing-library/react';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import ProductClient from './ProductClient';
 import ProductList from './ProductList';
 import {Product} from './Product';
@@ -32,7 +33,7 @@ describe('Product List', () => {
         jest.clearAllMocks();
         TestUtils.mockClientCalls();
 
-        ProductClient.getProductsForDate = jest.fn().mockResolvedValue({ data: TestUtils.products });
+        ProductClient.getProductsForDate = jest.fn().mockResolvedValue({ data: TestData.products });
     });
 
     describe('Product list test filtering', () => {
@@ -43,25 +44,25 @@ describe('Product List', () => {
                 spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
                 startDate: '2011-01-01',
                 endDate: undefined,
-                spaceLocation: TestUtils.annarbor,
+                spaceLocation: TestData.annarbor,
                 assignments: [],
                 archived: false,
-                tags: [TestUtils.productTag2],
+                tags: [TestData.productTag2],
                 notes: '',
             };
-            const products: Array<Product> = Object.assign([], TestUtils.products);
+            const products: Array<Product> = Object.assign([], TestData.products);
             products.push(productWithAnnArborLocation);
 
             const initialState = {
-                productTags: TestUtils.productTags,
-                allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions,
-                currentSpace: TestUtils.space,
+                productTags: TestData.productTags,
+                allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions,
+                currentSpace: TestData.space,
             };
             renderProductList(initialState, ({set}) => {
                 set(ProductsState, products)
             });
 
-            await screen.findByText(TestUtils.productForHank.name);
+            await screen.findByText(TestData.productForHank.name);
             await screen.findByText(productWithAnnArborLocation.name);
             expect(screen.getByTestId('productListSortedContainer').children.length).toEqual(3);
         });
@@ -73,26 +74,26 @@ describe('Product List', () => {
                 spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
                 startDate: '2011-01-01',
                 endDate: undefined,
-                spaceLocation: TestUtils.annarbor,
+                spaceLocation: TestData.annarbor,
                 assignments: [],
                 archived: false,
-                tags: [TestUtils.productTag2],
+                tags: [TestData.productTag2],
                 notes: '',
             };
-            const products: Array<Product> = Object.assign([], TestUtils.products);
+            const products: Array<Product> = Object.assign([], TestData.products);
             products.push(productWithAnnArborLocation);
 
             const initialState = {
-                productTags: TestUtils.productTags,
-                allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions,
-                currentSpace: TestUtils.space,
+                productTags: TestData.productTags,
+                allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions,
+                currentSpace: TestData.space,
             };
             renderProductList(initialState, ({set}) => {
                 set(IsReadOnlyState, true)
                 set(ProductsState, products)
             });
 
-            await screen.findByText(TestUtils.productForHank.name);
+            await screen.findByText(TestData.productForHank.name);
             await screen.findByText(productWithAnnArborLocation.name);
             expect(screen.getByTestId('productListSortedContainer').children.length).toEqual(2);
             expect(screen.queryByTestId('newProductButton')).not.toBeInTheDocument();
@@ -123,15 +124,15 @@ describe('Product List', () => {
             ];
 
             const initialState = {
-                productTags: TestUtils.productTags,
+                productTags: TestData.productTags,
                 allGroupedTagFilterOptions: allGroupedTagFilterOptions,
-                currentSpace: TestUtils.space,
+                currentSpace: TestData.space,
             };
             renderProductList(initialState, ({set}) => {
-                set(ProductsState, TestUtils.products)
+                set(ProductsState, TestData.products)
             });
 
-            await screen.findByText(TestUtils.productWithAssignments.name);
+            await screen.findByText(TestData.productWithAssignments.name);
             expect(screen.getByTestId('productListSortedContainer').children.length).toEqual(2);
         });
 
@@ -160,16 +161,16 @@ describe('Product List', () => {
             ];
 
             const initialState = {
-                productTags: TestUtils.productTags,
+                productTags: TestData.productTags,
                 allGroupedTagFilterOptions: allGroupedTagFilterOptions,
-                currentSpace: TestUtils.space,
+                currentSpace: TestData.space,
             };
             renderProductList(initialState, ({set}) => {
                 set(IsReadOnlyState, true)
-                set(ProductsState, TestUtils.products)
+                set(ProductsState, TestData.products)
             });
 
-            await screen.findByText(TestUtils.productWithAssignments.name);
+            await screen.findByText(TestData.productWithAssignments.name);
             expect(screen.getByTestId('productListSortedContainer').children.length).toEqual(1);
             expect(screen.queryByTestId('newProductButton')).not.toBeInTheDocument();
         });
@@ -199,15 +200,15 @@ describe('Product List', () => {
             ];
 
             const initialState = {
-                productTags: TestUtils.productTags,
+                productTags: TestData.productTags,
                 allGroupedTagFilterOptions: allGroupedTagFilterOptions,
-                currentSpace: TestUtils.space,
+                currentSpace: TestData.space,
             };
             renderProductList(initialState, ({set}) => {
-                set(ProductsState, TestUtils.products)
+                set(ProductsState, TestData.products)
             });
 
-            await screen.findByText(TestUtils.productWithoutAssignments.name);
+            await screen.findByText(TestData.productWithoutAssignments.name);
             expect(screen.getByTestId('productListSortedContainer').children.length).toEqual(2);
         });
     });

--- a/ui/src/Products/__mocks__/ProductClient.ts
+++ b/ui/src/Products/__mocks__/ProductClient.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import TestData from '../../Utils/TestData';
+
+const ProductClient = {
+    getProductsForDate: jest.fn().mockResolvedValue({ data: TestData.products }),
+    createProduct: jest.fn().mockResolvedValue({ data: {} }),
+    deleteProduct: jest.fn().mockResolvedValue({ data: {} }),
+    editProduct: jest.fn().mockResolvedValue({ data: {} }),
+}
+
+export default ProductClient;

--- a/ui/src/ReassignedDrawer/ReassignedDrawer.test.tsx
+++ b/ui/src/ReassignedDrawer/ReassignedDrawer.test.tsx
@@ -18,6 +18,7 @@
 import {fireEvent, screen, waitFor} from '@testing-library/react';
 import React from 'react';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import ReassignedDrawer from './ReassignedDrawer';
 import AssignmentClient from '../Assignments/AssignmentClient';
 import PeopleClient from '../People/PeopleClient';
@@ -40,15 +41,15 @@ describe('ReassignedDrawer', () => {
             TestUtils.mockClientCalls();
             AssignmentClient.getReassignments = jest.fn().mockResolvedValue( {
                 data: [{
-                    person: TestUtils.archivedPerson,
+                    person: TestData.archivedPerson,
                     originProductName: fromProductName,
                     destinationProductName: 'unassigned',
                 }],
             });
 
             store = createStore(rootReducer, {
-                currentSpace: TestUtils.space,
-                people: TestUtils.people,
+                currentSpace: TestData.space,
+                people: TestData.people,
             }, applyMiddleware(thunk));
 
             await waitFor(async () => {
@@ -68,8 +69,8 @@ describe('ReassignedDrawer', () => {
         });
 
         it('should show that they have been archived', async () => {
-            expect(await screen.findByText(TestUtils.archivedPerson.name)).toBeInTheDocument();
-            expect(await screen.findByText(TestUtils.archivedPerson.spaceRole!.name)).toBeInTheDocument();
+            expect(await screen.findByText(TestData.archivedPerson.name)).toBeInTheDocument();
+            expect(await screen.findByText(TestData.archivedPerson.spaceRole!.name)).toBeInTheDocument();
             expect(await screen.findByText(/Product 1/)).toBeInTheDocument();
             expect(await screen.queryByText(/unassigned/)).not.toBeInTheDocument();
             expect(await screen.findByText(/archived/)).toBeInTheDocument();
@@ -77,19 +78,19 @@ describe('ReassignedDrawer', () => {
 
         it('should unarchive an archived person that gets reverted', async () => {
             AssignmentClient.deleteAssignmentForDate = jest.fn().mockResolvedValue({ data: []});
-            PeopleClient.updatePerson = jest.fn().mockResolvedValue({data: {...TestUtils.archivedPerson, archiveDate: null}});
+            PeopleClient.updatePerson = jest.fn().mockResolvedValue({data: {...TestData.archivedPerson, archiveDate: null}});
             const revertButton = await screen.findByText('Revert');
             await waitFor(() => {
                 fireEvent.click(revertButton);
             });
             expect(AssignmentClient.deleteAssignmentForDate).toHaveBeenCalledTimes(1);
-            expect(AssignmentClient.deleteAssignmentForDate).toHaveBeenCalledWith(mayFourteen2020, TestUtils.archivedPerson);
+            expect(AssignmentClient.deleteAssignmentForDate).toHaveBeenCalledWith(mayFourteen2020, TestData.archivedPerson);
             expect(PeopleClient.updatePerson).toHaveBeenCalledTimes(1);
-            expect(PeopleClient.updatePerson).toHaveBeenCalledWith(TestUtils.space, {...TestUtils.archivedPerson, archiveDate: undefined}, []);
+            expect(PeopleClient.updatePerson).toHaveBeenCalledWith(TestData.space, {...TestData.archivedPerson, archiveDate: undefined}, []);
             expect(ProductClient.getProductsForDate).toHaveBeenCalledTimes(1);
-            expect(ProductClient.getProductsForDate).toHaveBeenCalledWith(TestUtils.space.uuid, mayFourteen2020);
+            expect(ProductClient.getProductsForDate).toHaveBeenCalledWith(TestData.space.uuid, mayFourteen2020);
             expect(PeopleClient.getAllPeopleInSpace).toHaveBeenCalledTimes(1);
-            expect(PeopleClient.getAllPeopleInSpace).toHaveBeenCalledWith(TestUtils.space.uuid);
+            expect(PeopleClient.getAllPeopleInSpace).toHaveBeenCalledWith(TestData.space.uuid);
         });
     });
 });

--- a/ui/src/ReassignedDrawer/ReassignedDrawer.test.tsx
+++ b/ui/src/ReassignedDrawer/ReassignedDrawer.test.tsx
@@ -30,6 +30,8 @@ import {RecoilRoot} from 'recoil';
 import {ViewingDateState} from '../State/ViewingDateState';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 
+jest.mock('../Products/ProductClient');
+
 describe('ReassignedDrawer', () => {
     let store: Store;
     const mayFourteen2020: Date = new Date(2020, 4, 14);

--- a/ui/src/Redux/Actions/Actions.test.tsx
+++ b/ui/src/Redux/Actions/Actions.test.tsx
@@ -25,7 +25,7 @@ import {
     setupSpaceAction,
 } from './index';
 import configureStore, {MockStoreCreator, MockStoreEnhanced} from 'redux-mock-store';
-import TestUtils from '../../Utils/TestUtils';
+import TestData from '../../Utils/TestData';
 import thunk from 'redux-thunk';
 import * as filterConstants from '../../SortingAndFiltering/FilterLibraries';
 import RoleClient from '../../Roles/RoleClient';
@@ -35,7 +35,6 @@ import PersonTagClient from '../../Tags/PersonTag/PersonTagClient';
 import ProductTagClient from '../../Tags/ProductTag/ProductTagClient';
 import PeopleClient from '../../People/PeopleClient';
 
-
 describe('Actions', () => {
     let mockStore: MockStoreCreator<unknown, {}>;
     let store: MockStoreEnhanced<unknown, {}>;
@@ -43,7 +42,7 @@ describe('Actions', () => {
     beforeEach(() => {
         mockStore = configureStore([thunk]);
         store = mockStore({
-            currentSpace: TestUtils.space,
+            currentSpace: TestData.space,
         });
     });
 
@@ -53,16 +52,16 @@ describe('Actions', () => {
 
     describe('setupSpaceAction', () => {
         it('should update the current space and filters', () => {
-            const mock = jest.spyOn(filterConstants, 'getFilterOptionsForSpace');  // spy on otherFn
-            mock.mockReturnValueOnce(Promise.resolve(TestUtils.allGroupedTagFilterOptions));  // mock the return value
+            const mock = jest.spyOn(filterConstants, 'getFilterOptionsForSpace');
+            mock.mockResolvedValueOnce(TestData.allGroupedTagFilterOptions);
 
             const expectedActions = [
-                {type: AvailableActions.SET_CURRENT_SPACE, space: TestUtils.space },
-                {type: AvailableActions.SET_ALL_FILTER_OPTIONS, allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions},
+                {type: AvailableActions.SET_CURRENT_SPACE, space: TestData.space },
+                {type: AvailableActions.SET_ALL_FILTER_OPTIONS, allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions},
             ];
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            return store.dispatch<any>(setupSpaceAction(TestUtils.space)).then(() => {
+            return store.dispatch<any>(setupSpaceAction(TestData.space)).then(() => {
                 expect(store.getActions()).toEqual(expectedActions);
             });
         });
@@ -71,16 +70,16 @@ describe('Actions', () => {
     describe('fetchProductTagsAction', () => {
         it('should invoke ProductTagClient.get and fire the setProductTag Action', () => {
             const mock = jest.spyOn(ProductTagClient, 'get');
-            mock.mockReturnValueOnce(Promise.resolve({data: TestUtils.productTags} as AxiosResponse));
+            mock.mockReturnValueOnce(Promise.resolve({data: TestData.productTags} as AxiosResponse));
 
             const expectedActions = [
-                {type: AvailableActions.SET_PRODUCT_TAGS, productTags: TestUtils.productTags},
+                {type: AvailableActions.SET_PRODUCT_TAGS, productTags: TestData.productTags},
             ];
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return store.dispatch<any>(fetchProductTagsAction()).then(() => {
                 expect(mock).toHaveBeenCalledTimes(1);
-                expect(mock).toHaveBeenCalledWith(TestUtils.space.uuid);
+                expect(mock).toHaveBeenCalledWith(TestData.space.uuid);
                 expect(store.getActions()).toEqual(expectedActions);
             });
         });
@@ -89,16 +88,16 @@ describe('Actions', () => {
     describe('fetchPersonTagsAction', () => {
         it('should invoke PersonTagClient.get and fire the setPersonTags Action', () => {
             const mock = jest.spyOn(PersonTagClient, 'get');
-            mock.mockReturnValueOnce(Promise.resolve({data: TestUtils.personTags} as AxiosResponse));
+            mock.mockReturnValueOnce(Promise.resolve({data: TestData.personTags} as AxiosResponse));
 
             const expectedActions = [
-                {type: AvailableActions.SET_PERSON_TAGS, personTags: TestUtils.personTags},
+                {type: AvailableActions.SET_PERSON_TAGS, personTags: TestData.personTags},
             ];
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return store.dispatch<any>(fetchPersonTagsAction()).then(() => {
                 expect(mock).toHaveBeenCalledTimes(1);
-                expect(mock).toHaveBeenCalledWith(TestUtils.space.uuid);
+                expect(mock).toHaveBeenCalledWith(TestData.space.uuid);
                 expect(store.getActions()).toEqual(expectedActions);
             });
         });
@@ -107,16 +106,16 @@ describe('Actions', () => {
     describe('fetchLocationsAction', () => {
         it('should invoke LocationClient.get and fire the setLocations Action', () => {
             const mock = jest.spyOn(LocationClient, 'get');
-            mock.mockReturnValueOnce(Promise.resolve({data: TestUtils.locations} as AxiosResponse));
+            mock.mockReturnValueOnce(Promise.resolve({data: TestData.locations} as AxiosResponse));
 
             const expectedActions = [
-                {type: AvailableActions.SET_LOCATIONS, locations: TestUtils.locations},
+                {type: AvailableActions.SET_LOCATIONS, locations: TestData.locations},
             ];
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return store.dispatch<any>(fetchLocationsAction()).then(() => {
                 expect(mock).toHaveBeenCalledTimes(1);
-                expect(mock).toHaveBeenCalledWith(TestUtils.space.uuid);
+                expect(mock).toHaveBeenCalledWith(TestData.space.uuid);
                 expect(store.getActions()).toEqual(expectedActions);
             });
         });
@@ -125,16 +124,16 @@ describe('Actions', () => {
     describe('fetchRolesAction', () => {
         it('should invoke RoleClient.get and fire the setRoles Action', () => {
             const mock = jest.spyOn(RoleClient, 'get');
-            mock.mockReturnValueOnce(Promise.resolve({data: TestUtils.roles} as AxiosResponse));
+            mock.mockReturnValueOnce(Promise.resolve({data: TestData.roles} as AxiosResponse));
 
             const expectedActions = [
-                {type: AvailableActions.SET_ROLES, roles: TestUtils.roles},
+                {type: AvailableActions.SET_ROLES, roles: TestData.roles},
             ];
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return store.dispatch<any>(fetchRolesAction()).then(() => {
                 expect(mock).toHaveBeenCalledTimes(1);
-                expect(mock).toHaveBeenCalledWith(TestUtils.space.uuid);
+                expect(mock).toHaveBeenCalledWith(TestData.space.uuid);
                 expect(store.getActions()).toEqual(expectedActions);
             });
         });
@@ -143,16 +142,16 @@ describe('Actions', () => {
     describe('fetchPeopleAction', () => {
         it('should invoke PeopleClient.getforspace and fire the setPeople action', () => {
             const mock = jest.spyOn(PeopleClient, 'getAllPeopleInSpace');
-            mock.mockReturnValueOnce(Promise.resolve({data: TestUtils.people} as AxiosResponse));
+            mock.mockReturnValueOnce(Promise.resolve({data: TestData.people} as AxiosResponse));
 
             const expectedActions = [
-                {type: AvailableActions.SET_PEOPLE, people: TestUtils.people},
+                {type: AvailableActions.SET_PEOPLE, people: TestData.people},
             ];
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return store.dispatch<any>(fetchPeopleAction()).then(() => {
                 expect(mock).toHaveBeenCalledTimes(1);
-                expect(mock).toHaveBeenCalledWith(TestUtils.space.uuid);
+                expect(mock).toHaveBeenCalledWith(TestData.space.uuid);
                 expect(store.getActions()).toEqual(expectedActions);
             });
         });

--- a/ui/src/ReusableComponents/Counter.test.tsx
+++ b/ui/src/ReusableComponents/Counter.test.tsx
@@ -16,7 +16,8 @@
  */
 
 import React from 'react';
-import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import Counter from './Counter';
 import {RenderResult} from '@testing-library/react';
 import {AllGroupedTagFilterOptions} from '../SortingAndFiltering/FilterLibraries';
@@ -52,7 +53,7 @@ describe('counter', () => {
 
     it('should display the number of products and people when no filter are applied and ignore archived products', async () => {
         const expectedString = 'Results - Products: 4, People: 3 (Unassigned: 1)';
-        app = renderWithRedux(<Counter products={TestUtils.products} allGroupedTagFilterOptions={noFilter} viewingDate={viewingDate}/>);
+        app = renderWithRedux(<Counter products={TestData.products} allGroupedTagFilterOptions={noFilter} viewingDate={viewingDate}/>);
         const counter = await app.findByTestId('counter');
         expect(counter).toContainHTML(expectedString);
     });
@@ -70,7 +71,7 @@ describe('counter', () => {
             tags: [],
         };
 
-        app = renderWithRedux(<Counter products={[finishedProduct, TestUtils.unassignedProduct]} allGroupedTagFilterOptions={noFilter} viewingDate={viewingDate}/>);
+        app = renderWithRedux(<Counter products={[finishedProduct, TestData.unassignedProduct]} allGroupedTagFilterOptions={noFilter} viewingDate={viewingDate}/>);
         const counter = await app.findByTestId('counter');
         expect(counter).toContainHTML(expectedString);
     });
@@ -105,14 +106,14 @@ describe('counter', () => {
             },
         ];
 
-        app = renderWithRedux(<Counter products={TestUtils.products} allGroupedTagFilterOptions={allGroupedTagFilterOptions} viewingDate={viewingDate}/>);
+        app = renderWithRedux(<Counter products={TestData.products} allGroupedTagFilterOptions={allGroupedTagFilterOptions} viewingDate={viewingDate}/>);
         const counter = await app.findByTestId('counter');
         expect(counter).toContainHTML(expectedString);
     });
 
     it('should display the number of products and people when location filters are applied', async () => {
         const expectedString = 'Results - Products: 1, People: 2 (Unassigned: 1)';
-        app = renderWithRedux(<Counter products={TestUtils.products} allGroupedTagFilterOptions={TestUtils.allGroupedTagFilterOptions} viewingDate={viewingDate}/>);
+        app = renderWithRedux(<Counter products={TestData.products} allGroupedTagFilterOptions={TestData.allGroupedTagFilterOptions} viewingDate={viewingDate}/>);
         const counter = await app.findByTestId('counter');
         expect(counter).toContainHTML(expectedString);
     });
@@ -162,7 +163,7 @@ describe('counter', () => {
             },
         ];
         
-        app = renderWithRedux(<Counter products={TestUtils.products} allGroupedTagFilterOptions={allGroupedTagFilterOptions} viewingDate={viewingDate}/>);
+        app = renderWithRedux(<Counter products={TestData.products} allGroupedTagFilterOptions={allGroupedTagFilterOptions} viewingDate={viewingDate}/>);
         const counter = await app.findByTestId('counter');
         expect(counter).toContainHTML(expectedString);
     });
@@ -191,7 +192,7 @@ describe('counter', () => {
             },
         ];
 
-        app = renderWithRedux(<Counter products={[TestUtils.unassignedProductForBigBossSE, TestUtils.productWithTags]} allGroupedTagFilterOptions={allGroupedTagFilterOptions} viewingDate={viewingDate}/>);
+        app = renderWithRedux(<Counter products={[TestData.unassignedProductForBigBossSE, TestData.productWithTags]} allGroupedTagFilterOptions={allGroupedTagFilterOptions} viewingDate={viewingDate}/>);
         const counter = await app.findByTestId('counter');
         expect(counter).toContainHTML(expectedString);
     });
@@ -226,14 +227,14 @@ describe('counter', () => {
             spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
             startDate: '2011-01-01',
             endDate: '2022-02-02',
-            spaceLocation: TestUtils.southfield,
-            assignments: TestUtils.assignmentsFilterTest,
+            spaceLocation: TestData.southfield,
+            assignments: TestData.assignmentsFilterTest,
             archived: false,
-            tags: [TestUtils.productTag2],
+            tags: [TestData.productTag2],
             notes: 'note',
         };
 
-        app = renderWithRedux(<Counter products={[TestUtils.unassignedProductForBigBossSE, TestUtils.productWithTags, productWithPersonAlreadyAssignedInProduct1]} allGroupedTagFilterOptions={allGroupedTagFilterOptions} viewingDate={viewingDate}/>);
+        app = renderWithRedux(<Counter products={[TestData.unassignedProductForBigBossSE, TestData.productWithTags, productWithPersonAlreadyAssignedInProduct1]} allGroupedTagFilterOptions={allGroupedTagFilterOptions} viewingDate={viewingDate}/>);
         const counter = await app.findByTestId('counter');
         expect(counter).toContainHTML(expectedString);
     });

--- a/ui/src/ReusableComponents/EditMenu.test.tsx
+++ b/ui/src/ReusableComponents/EditMenu.test.tsx
@@ -18,32 +18,33 @@
 import {fireEvent, render} from '@testing-library/react';
 import React from 'react';
 import EditMenu, {EditMenuOption} from './EditMenu';
-import TestUtils from '../Utils/TestUtils';
 
 describe('The edit menu', () => {
-
     describe('for a person card', () => {
+        const editPersonCallback = jest.fn();
+        const markAsPlaceholderCallback = jest.fn();
+        const cancelAssignmentCallback = jest.fn();
         const menuOptionList: EditMenuOption[] = [
             {
-                callback: TestUtils.dummyCallback,
+                callback: editPersonCallback,
                 text: 'Edit Person',
                 icon: 'account_circle',
             },
             {
-                callback: TestUtils.dummyCallback,
+                callback: markAsPlaceholderCallback,
                 text: 'Mark as Placeholder',
                 icon: 'create',
 
             },
             {
-                callback: TestUtils.dummyCallback,
+                callback: cancelAssignmentCallback,
                 text: 'Cancel Assignment',
                 icon: 'delete',
             },
         ];
 
         it('should render the right static content', async () => {
-            const underTest = render(<EditMenu menuOptionList={menuOptionList} onClosed={TestUtils.dummyCallback}/>);
+            const underTest = render(<EditMenu menuOptionList={menuOptionList} onClosed={jest.fn()}/>);
 
             await underTest.findByText('Edit Person');
             const firstIcon = await underTest.findByTestId('editMenuOption__edit_person');
@@ -59,18 +60,10 @@ describe('The edit menu', () => {
         });
 
         it('should call the right callback when menu option is clicked', () => {
-            let testPassed = false;
-
-            function makeTestPass(): void {
-                testPassed = true;
-            }
-
-            menuOptionList[0].callback = makeTestPass;
-
-            const underTest = render(<EditMenu menuOptionList={menuOptionList} onClosed={TestUtils.dummyCallback}/>);
-            expect(testPassed).toBeFalsy();
+            const underTest = render(<EditMenu menuOptionList={menuOptionList} onClosed={jest.fn()}/>);
+            expect(menuOptionList[0].callback).not.toHaveBeenCalled();
             fireEvent.click(underTest.getByText('Edit Person'));
-            expect(testPassed).toBeTruthy();
+            expect(menuOptionList[0].callback).toHaveBeenCalled();
         });
     });
 
@@ -78,17 +71,17 @@ describe('The edit menu', () => {
         it('should render the right static content', async () => {
             const menuOptionList: EditMenuOption[] = [
                 {
-                    callback: TestUtils.dummyCallback,
+                    callback: jest.fn(),
                     text: 'Edit product',
                     icon: 'create',
                 },
                 {
-                    callback: TestUtils.dummyCallback,
+                    callback: jest.fn(),
                     text: 'Archive product',
                     icon: 'inbox',
                 },
             ];
-            const underTest = render(<EditMenu menuOptionList={menuOptionList} onClosed={TestUtils.dummyCallback}/>);
+            const underTest = render(<EditMenu menuOptionList={menuOptionList} onClosed={jest.fn()}/>);
             await underTest.findByText('Edit product');
             const firstIcon = await underTest.findByTestId('editMenuOption__edit_product');
             expect(firstIcon.innerHTML).toContain(menuOptionList[0].icon);

--- a/ui/src/Roles/RoleClient.test.tsx
+++ b/ui/src/Roles/RoleClient.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Ford Motor Company
+ * Copyright (c) 2022 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import Axios, {AxiosResponse} from 'axios';
+import Axios from 'axios';
 import RoleClient from './RoleClient';
-import TestUtils from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import Cookies from 'universal-cookie';
 import {MatomoWindow} from '../CommonTypes/MatomoWindow';
 
@@ -38,20 +38,11 @@ describe('Role Client', function() {
 
     beforeEach(() => {
         cookies.set('accessToken', '123456');
-        /* eslint-disable @typescript-eslint/no-explicit-any */
-        Axios.post = jest.fn(x => Promise.resolve({
-            data: 'Created Role',
-        } as AxiosResponse)) as any;
-        Axios.put = jest.fn(x => Promise.resolve({
-            data: 'Updated Role',
-        } as AxiosResponse)) as any;
-        Axios.delete = jest.fn(x => Promise.resolve({
-            data: 'Deleted Role',
-        } as AxiosResponse)) as any;
-        Axios.get = jest.fn(x => Promise.resolve({
-            data: 'Get Roles',
-        } as AxiosResponse)) as any;
-        /* eslint-enable */
+
+        Axios.post = jest.fn().mockResolvedValue({ data: 'Created Role' });
+        Axios.put = jest.fn().mockResolvedValue({ data: 'Updated Role' });
+        Axios.delete = jest.fn().mockResolvedValue({ data: 'Deleted Role' });
+        Axios.get = jest.fn().mockResolvedValue({ data: 'Get Roles' });
     });
 
     afterEach(function() {
@@ -70,10 +61,10 @@ describe('Role Client', function() {
     });
 
     it('should create a role and send matomo event and return that role', function(done) {
-        const expectedRoleAddRequest = { name: TestUtils.softwareEngineer.name };
-        RoleClient.add(expectedRoleAddRequest, TestUtils.space)
+        const expectedRoleAddRequest = { name: TestData.softwareEngineer.name };
+        RoleClient.add(expectedRoleAddRequest, TestData.space)
             .then((response) => {
-                expect(window._paq).toContainEqual(['trackEvent', TestUtils.space.name, 'addRole', TestUtils.softwareEngineer.name]);
+                expect(window._paq).toContainEqual(['trackEvent', TestData.space.name, 'addRole', TestData.softwareEngineer.name]);
                 expect(Axios.post).toHaveBeenCalledWith(
                     baseRolesUrl, expectedRoleAddRequest, expectedConfig
                 );
@@ -84,13 +75,13 @@ describe('Role Client', function() {
 
     it('should edit a role and event and return that role', function(done) {
         const expectedRoleEditRequest = {
-            id: TestUtils.softwareEngineer.id,
-            name: TestUtils.softwareEngineer.name,
+            id: TestData.softwareEngineer.id,
+            name: TestData.softwareEngineer.name,
         };
-        RoleClient.edit(expectedRoleEditRequest, TestUtils.space)
+        RoleClient.edit(expectedRoleEditRequest, TestData.space)
             .then((response) => {
                 expect(Axios.put).toHaveBeenCalledWith(
-                    `${baseRolesUrl}/${TestUtils.softwareEngineer.id}`, expectedRoleEditRequest, expectedConfig
+                    `${baseRolesUrl}/${TestData.softwareEngineer.id}`, expectedRoleEditRequest, expectedConfig
                 );
                 expect(response.data).toBe('Updated Role');
                 done();
@@ -98,8 +89,8 @@ describe('Role Client', function() {
     });
 
     it('should delete a role', function(done) {
-        const expectedUrl = `${baseRolesUrl}/${TestUtils.softwareEngineer.id}`;
-        RoleClient.delete(TestUtils.softwareEngineer.id, TestUtils.space)
+        const expectedUrl = `${baseRolesUrl}/${TestData.softwareEngineer.id}`;
+        RoleClient.delete(TestData.softwareEngineer.id, TestData.space)
             .then((response) => {
                 expect(Axios.delete).toHaveBeenCalledWith(expectedUrl, expectedConfig);
                 expect(response.data).toBe('Deleted Role');

--- a/ui/src/Roles/RoleModal.test.tsx
+++ b/ui/src/Roles/RoleModal.test.tsx
@@ -17,6 +17,7 @@
 
 import React from 'react';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {findByTestId, findByText, fireEvent, screen, waitFor} from '@testing-library/react';
 import RoleClient from './RoleClient';
 import {RoleAddRequest} from './RoleAddRequest.interface';
@@ -25,7 +26,7 @@ import * as Actions from '../Redux/Actions';
 import ColorClient from '../Roles/ColorClient';
 
 describe('My Roles Form', () => {
-    const initialState = {currentSpace: TestUtils.space, allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions, roles: TestUtils.roles};
+    const initialState = {currentSpace: TestData.space, allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions, roles: TestData.roles};
 
     beforeEach(async () => {
         jest.clearAllMocks();
@@ -48,9 +49,9 @@ describe('My Roles Form', () => {
     });
 
     it('should show existing roles with color-circle', async () => {
-        expect(await screen.findByTestId(`myRolesCircle__${TestUtils.roles[0].name}`)).toHaveStyle(`background-color: ${TestUtils.color3.color}`);
-        expect(await screen.findByTestId(`myRolesCircle__${TestUtils.roles[1].name}`)).toHaveStyle(`background-color: ${TestUtils.color2.color}`);
-        expect(await screen.findByTestId(`myRolesCircle__${TestUtils.roles[2].name}`)).toHaveStyle(`background-color: ${TestUtils.color1.color}`);
+        expect(await screen.findByTestId(`myRolesCircle__${TestData.roles[0].name}`)).toHaveStyle(`background-color: ${TestData.color3.color}`);
+        expect(await screen.findByTestId(`myRolesCircle__${TestData.roles[1].name}`)).toHaveStyle(`background-color: ${TestData.color2.color}`);
+        expect(await screen.findByTestId(`myRolesCircle__${TestData.roles[2].name}`)).toHaveStyle(`background-color: ${TestData.color1.color}`);
     });
 
     describe('adding roles', () => {
@@ -110,7 +111,7 @@ describe('My Roles Form', () => {
 
             const expectedRoleAddRequest: RoleAddRequest = {
                 name: expectedNewRoleName,
-                colorId: TestUtils.whiteColor.id,
+                colorId: TestData.whiteColor.id,
             };
             expect(RoleClient.add).toHaveBeenCalledTimes(1);
             expect(RoleClient.add).toHaveBeenCalledWith(expectedRoleAddRequest, initialState.currentSpace);
@@ -224,7 +225,7 @@ describe('My Roles Form', () => {
             const confirmDeleteButton = await screen.findByTestId('confirmDeleteButton');
             fireEvent.click(confirmDeleteButton);
 
-            expect(RoleClient.delete).toHaveBeenCalledWith(TestUtils.productManager.id, initialState.currentSpace);
+            expect(RoleClient.delete).toHaveBeenCalledWith(TestData.productManager.id, initialState.currentSpace);
             await waitFor(() => {
                 expect(screen.queryByText(deleteWarning)).not.toBeInTheDocument();
             });

--- a/ui/src/Space/__mocks__/SpaceClient.ts
+++ b/ui/src/Space/__mocks__/SpaceClient.ts
@@ -15,28 +15,16 @@
  * limitations under the License.
  */
 
-import {UserSpaceMapping} from '../UserSpaceMapping';
-import {Space} from '../Space';
-
-const space: Space = {
-    id: 1,
-    uuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
-    name: 'testSpace',
-    lastModifiedDate:  '2019-01-01',
-    todayViewIsPublic: true,
-}
-
-const spaceMappingsArray: UserSpaceMapping[] = [
-    {id: '1', spaceUuid: space.uuid!, userId: 'user_id', permission: 'owner'},
-    {id: '2', spaceUuid: space.uuid!, userId: 'user_id_2', permission: 'editor'},
-];
+import TestData from '../../Utils/TestData';
 
 const SpaceClient = {
-    getSpacesForUser: jest.fn().mockResolvedValue([]),
-    getUsersForSpace:  jest.fn().mockResolvedValue(spaceMappingsArray),
+    getSpacesForUser: jest.fn().mockResolvedValue([TestData.space]),
+    getUsersForSpace:  jest.fn().mockResolvedValue(TestData.spaceMappingsArray),
     changeOwner: jest.fn().mockResolvedValue({}),
-    removeUser: jest.fn().mockResolvedValue({}),
-    deleteSpaceByUuid: jest.fn().mockResolvedValue({})
+    removeUser: jest.fn().mockResolvedValue({data: {}}),
+    deleteSpaceByUuid: jest.fn().mockResolvedValue({}),
+    getSpaceFromUuid: jest.fn().mockResolvedValue({data: TestData.space}),
+    inviteUsersToSpace: jest.fn().mockResolvedValue({})
 }
 
 export default SpaceClient;

--- a/ui/src/SpaceDashboard/DeleteSpaceForm.test.tsx
+++ b/ui/src/SpaceDashboard/DeleteSpaceForm.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Ford Motor Company
+ * Copyright (c) 2022 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import * as React from 'react';
 import {act, waitFor} from '@testing-library/react';
 import DeleteSpaceForm from './DeleteSpaceForm';
@@ -32,11 +33,11 @@ describe('Delete Space Form', () => {
 
     describe('Space has no editors', () => {
         beforeEach(() => {
-            store = createStore(rootReducer, {currentSpace: TestUtils.space}, applyMiddleware(thunk));
+            store = createStore(rootReducer, {currentSpace: TestData.space}, applyMiddleware(thunk));
             store.dispatch = jest.fn();
             renderWithRedux(
                 <RecoilRoot>
-                    <DeleteSpaceForm space={TestUtils.space} spaceHasEditors={false}/>
+                    <DeleteSpaceForm space={TestData.space} spaceHasEditors={false}/>
                 </RecoilRoot>,
                 store
             );
@@ -49,12 +50,12 @@ describe('Delete Space Form', () => {
 
     describe('Space has editors', () => {
         beforeEach(() => {
-            store = createStore(rootReducer, {currentSpace: TestUtils.space}, applyMiddleware(thunk));
+            store = createStore(rootReducer, {currentSpace: TestData.space}, applyMiddleware(thunk));
             store.dispatch = jest.fn();
 
             renderWithRedux(
                 <RecoilRoot>
-                    <DeleteSpaceForm space={TestUtils.space} spaceHasEditors={true}/>
+                    <DeleteSpaceForm space={TestData.space} spaceHasEditors={true}/>
                 </RecoilRoot>,
                 store
             );
@@ -113,7 +114,7 @@ describe('Delete Space Form', () => {
                 const bigRedButton = await screen.getByText('Delete space');
                 fireEvent.click(bigRedButton);
 
-                await waitFor(() => expect(SpaceClient.deleteSpaceByUuid).toHaveBeenCalledWith(TestUtils.space.uuid));
+                await waitFor(() => expect(SpaceClient.deleteSpaceByUuid).toHaveBeenCalledWith(TestData.space.uuid));
             });
 
             it('should open the Transfer Ownership modal when the assign a new owner button is pressed', async () => {
@@ -125,7 +126,7 @@ describe('Delete Space Form', () => {
                 await waitFor(() => expect(store.dispatch).toHaveBeenCalledWith({
                     type: AvailableActions.SET_CURRENT_MODAL,
                     modal: AvailableModals.TRANSFER_OWNERSHIP,
-                    item: TestUtils.space,
+                    item: TestData.space,
                 }));
             });
         });

--- a/ui/src/SpaceDashboard/SpaceDashboardTile.test.tsx
+++ b/ui/src/SpaceDashboard/SpaceDashboardTile.test.tsx
@@ -17,7 +17,8 @@
 
 import {fireEvent, waitFor} from '@testing-library/dom';
 import {screen} from '@testing-library/react';
-import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import React from 'react';
 import SpaceDashboardTile from './SpaceDashboardTile';
 import {createStore, Store} from 'redux';
@@ -38,8 +39,8 @@ describe('SpaceDashboardTile tests', () => {
         jest.clearAllMocks();
         SpaceClient.getUsersForSpace = jest.fn().mockResolvedValue(
             [
-                {id: '1', userId: 'USER_ID', permission: 'owner', spaceUuid: TestUtils.space.uuid!} as UserSpaceMapping,
-                {id: '2', userId: 'USER_IDDQD', permission: 'editor', spaceUuid: TestUtils.space.uuid!} as UserSpaceMapping
+                {id: '1', userId: 'USER_ID', permission: 'owner', spaceUuid: TestData.space.uuid!} as UserSpaceMapping,
+                {id: '2', userId: 'USER_IDDQD', permission: 'editor', spaceUuid: TestData.space.uuid!} as UserSpaceMapping
             ]
         );
         store = createStore(rootReducer, {});
@@ -63,21 +64,21 @@ describe('SpaceDashboardTile tests', () => {
         
         expect(store.dispatch).toBeCalledWith(setCurrentModalAction({
             modal: AvailableModals.EDIT_SPACE,
-            item: TestUtils.space,
+            item: TestData.space,
         }));
     });
 
     describe('deleting a space', () => {
         it('should not show Delete Space menu item if user is not owner of the space', async () => {
             SpaceClient.getUsersForSpace = jest.fn().mockResolvedValue(
-                [{id: '1', userId: 'USER_ID', permission: 'editor', spaceUuid: TestUtils.space.uuid!} as UserSpaceMapping]
+                [{id: '1', userId: 'USER_ID', permission: 'editor', spaceUuid: TestData.space.uuid!} as UserSpaceMapping]
             );
             unmount();
             await renderSpaceDashboardList(store, onClick);
 
             const spaceEllipsis = await screen.findByTestId('ellipsisButton');
             fireEvent.click(spaceEllipsis);
-            expect(SpaceClient.getUsersForSpace).toHaveBeenCalledWith(TestUtils.space.uuid);
+            expect(SpaceClient.getUsersForSpace).toHaveBeenCalledWith(TestData.space.uuid);
             expect(screen.queryByText('Delete Space')).not.toBeInTheDocument();
         });
 
@@ -88,7 +89,7 @@ describe('SpaceDashboardTile tests', () => {
             fireEvent.click(leaveSpaceTile);
             expect(store.dispatch).toBeCalledWith(setCurrentModalAction({
                 modal: AvailableModals.DELETE_SPACE,
-                item: TestUtils.space,
+                item: TestData.space,
             }));
         });
     });
@@ -96,27 +97,27 @@ describe('SpaceDashboardTile tests', () => {
     describe('Leaving a space', () => {
         it('should not show Leave Space menu item if user is not owner of the space', async () => {
             SpaceClient.getUsersForSpace = jest.fn().mockResolvedValue(
-                [{id: '1', userId: 'USER_ID', permission: 'editor', spaceUuid: TestUtils.space.uuid!} as UserSpaceMapping]
+                [{id: '1', userId: 'USER_ID', permission: 'editor', spaceUuid: TestData.space.uuid!} as UserSpaceMapping]
             );
             unmount();
             await renderSpaceDashboardList(store, onClick)
 
             const spaceEllipsis = await screen.findByTestId('ellipsisButton');
             fireEvent.click(spaceEllipsis);
-            expect(SpaceClient.getUsersForSpace).toHaveBeenCalledWith(TestUtils.space.uuid);
+            expect(SpaceClient.getUsersForSpace).toHaveBeenCalledWith(TestData.space.uuid);
             expect(screen.queryByText('Leave Space')).not.toBeInTheDocument();
         });
 
         it('should not show Leave Space menu item if space has no editors', async () => {
             SpaceClient.getUsersForSpace = jest.fn().mockResolvedValue(
-                [{id: '1', userId: 'USER_ID', permission: 'owner', spaceUuid: TestUtils.space.uuid!} as UserSpaceMapping]
+                [{id: '1', userId: 'USER_ID', permission: 'owner', spaceUuid: TestData.space.uuid!} as UserSpaceMapping]
             );
             unmount();
             await renderSpaceDashboardList(store, onClick);
 
             const spaceEllipsis = await screen.findByTestId('ellipsisButton');
             fireEvent.click(spaceEllipsis);
-            expect(SpaceClient.getUsersForSpace).toHaveBeenCalledWith(TestUtils.space.uuid);
+            expect(SpaceClient.getUsersForSpace).toHaveBeenCalledWith(TestData.space.uuid);
             expect(screen.queryByText('Leave Space')).not.toBeInTheDocument();
         });
 
@@ -127,7 +128,7 @@ describe('SpaceDashboardTile tests', () => {
             fireEvent.click(leaveSpaceTile);
             expect(store.dispatch).toBeCalledWith(setCurrentModalAction({
                 modal: AvailableModals.TRANSFER_OWNERSHIP,
-                item: TestUtils.space,
+                item: TestData.space,
             }));
         });
     });
@@ -144,7 +145,7 @@ async function renderSpaceDashboardList(store: Store, onClick: () => void) {
         <RecoilRoot initializeState={({set}) => {
             set(CurrentUserState, 'USER_ID')
         }}>
-            <SpaceDashboardTile space={TestUtils.space} onClick={onClick}/>
+            <SpaceDashboardTile space={TestData.space} onClick={onClick}/>
         </RecoilRoot>,
         store
     );

--- a/ui/src/SpaceDashboard/TransferOwnershipForm.test.tsx
+++ b/ui/src/SpaceDashboard/TransferOwnershipForm.test.tsx
@@ -16,7 +16,8 @@
  */
 
 import React from 'react';
-import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import TransferOwnershipForm from './TransferOwnershipForm';
 import SpaceClient from '../Space/SpaceClient';
 
@@ -43,7 +44,7 @@ describe('Transfer Ownership Form', () => {
             <RecoilRoot initializeState={({set}) => {
                 set(CurrentUserState,  'user_id')
             }}>
-                <TransferOwnershipForm space={TestUtils.space}/>
+                <TransferOwnershipForm space={TestData.space}/>
             </RecoilRoot>,
             store
         );
@@ -52,7 +53,7 @@ describe('Transfer Ownership Form', () => {
     });
 
     it('should prompt the choice with the space name', () => {
-        expect(screen.getByText('Please choose who you would like to be the new owner of ' + TestUtils.space.name)).toBeDefined();
+        expect(screen.getByText('Please choose who you would like to be the new owner of ' + TestData.space.name)).toBeDefined();
     });
 
     it('should show each editors name', () => {
@@ -89,13 +90,13 @@ describe('Transfer Ownership Form', () => {
         it('should use the Client to promote the selected editor to owner', async () => {
             fireEvent.click(screen.getByText('user_id_2'));
             await act(async () => {fireEvent.click(screen.getByText('Transfer ownership'));});
-            expect(SpaceClient.changeOwner).toHaveBeenCalledWith(TestUtils.space, TestUtils.spaceMappingsArray[0], TestUtils.spaceMappingsArray[1]);
+            expect(SpaceClient.changeOwner).toHaveBeenCalledWith(TestData.space, TestData.spaceMappingsArray[0], TestData.spaceMappingsArray[1]);
         });
 
         it('should use the Client to remove the current users permissions from the space', async () => {
             fireEvent.click(screen.getByText('user_id_2'));
             await act(async () => {fireEvent.click(screen.getByText('Transfer ownership'));});
-            expect(SpaceClient.removeUser).toHaveBeenCalledWith(TestUtils.space, TestUtils.spaceMappingsArray[0]);
+            expect(SpaceClient.removeUser).toHaveBeenCalledWith(TestData.space, TestData.spaceMappingsArray[0]);
         });
 
         it('should refresh user spaces if a new owner is assigned', async () => {

--- a/ui/src/Tags/MyTags.test.tsx
+++ b/ui/src/Tags/MyTags.test.tsx
@@ -17,6 +17,7 @@
 
 import React from 'react';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {findByTestId, findByText, fireEvent, queryByText, screen} from '@testing-library/react';
 import LocationClient from '../Locations/LocationClient';
 import ProductTagClient from './ProductTag/ProductTagClient';
@@ -25,10 +26,10 @@ import {FilterType, FilterTypeListings} from '../SortingAndFiltering/FilterLibra
 
 describe('My Tags Form', () => {
     const initialState = {
-        locations: TestUtils.locations,
-        productTags: TestUtils.productTags,
-        currentSpace: TestUtils.space,
-        allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions,
+        locations: TestData.locations,
+        productTags: TestData.productTags,
+        currentSpace: TestData.space,
+        allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions,
     };
 
     beforeEach(() => {
@@ -47,10 +48,10 @@ describe('My Tags Form', () => {
             const locationTags: Array<HTMLSpanElement> = await screen.findAllByTestId('tagName__location');
             expect(locationTags).toHaveLength(4);
 
-            expect(locationTags[0].innerHTML).toEqual(TestUtils.annarbor.name);
-            expect(locationTags[1].innerHTML).toEqual(TestUtils.detroit.name);
-            expect(locationTags[2].innerHTML).toEqual(TestUtils.dearborn.name);
-            expect(locationTags[3].innerHTML).toEqual(TestUtils.southfield.name);
+            expect(locationTags[0].innerHTML).toEqual(TestData.annarbor.name);
+            expect(locationTags[1].innerHTML).toEqual(TestData.detroit.name);
+            expect(locationTags[2].innerHTML).toEqual(TestData.dearborn.name);
+            expect(locationTags[3].innerHTML).toEqual(TestData.southfield.name);
         });
 
         it('Should contain all product tags available in the space', async () => {
@@ -58,7 +59,7 @@ describe('My Tags Form', () => {
             const myTagsModal = await screen.findByTestId('myTagsModal');
             const productTags: Array<HTMLSpanElement> = await screen.findAllByTestId('tagName__product_tag');
             expect(productTags).toHaveLength(4);
-            for (const productTag of TestUtils.productTags) {
+            for (const productTag of TestData.productTags) {
                 await findByText(myTagsModal, productTag.name);
             }
         });
@@ -72,7 +73,7 @@ describe('My Tags Form', () => {
                 LocationClient.get = jest.fn().mockResolvedValue({
                     data: [
                         {id: 1, name: 'Saline', spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'},
-                        TestUtils.detroit, TestUtils.dearborn, TestUtils.southfield
+                        TestData.detroit, TestData.dearborn, TestData.southfield
                     ],
                 });
                 renderMyTagsForm(FilterTypeListings.Location);
@@ -138,7 +139,7 @@ describe('My Tags Form', () => {
                 ProductTagClient.get = jest.fn().mockResolvedValue({
                     data: [
                         {id: 5, name: 'Finance', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'},
-                        TestUtils.productTag2, TestUtils.productTag3, TestUtils.productTag4
+                        TestData.productTag2, TestData.productTag3, TestData.productTag4
                     ],
                 });
                 renderMyTagsForm(FilterTypeListings.ProductTag);
@@ -167,7 +168,7 @@ describe('My Tags Form', () => {
 
             it('should display error message only for corresponding edit product tag section', async () => {
                 const editProductTagText = await screen.findByTestId('tagNameInput');
-                fireEvent.change(editProductTagText, {target: {value: TestUtils.productTag2.name}});
+                fireEvent.change(editProductTagText, {target: {value: TestData.productTag2.name}});
                 const saveButton = await screen.findByTestId('saveTagButton');
                 expect(saveButton).toBeDisabled();
 
@@ -184,7 +185,7 @@ describe('My Tags Form', () => {
 
             beforeEach(async () => {
                 LocationClient.get = jest.fn().mockResolvedValue({
-                    data: [TestUtils.detroit, TestUtils.dearborn, TestUtils.southfield],
+                    data: [TestData.detroit, TestData.dearborn, TestData.southfield],
                 });
                 renderMyTagsForm(FilterTypeListings.Location);
                 const deleteIcons = await screen.findAllByTestId('deleteIcon__location');
@@ -217,7 +218,7 @@ describe('My Tags Form', () => {
 
             beforeEach(async () => {
                 ProductTagClient.get = jest.fn().mockResolvedValue({
-                    data: [TestUtils.productTag2, TestUtils.productTag3, TestUtils.productTag4],
+                    data: [TestData.productTag2, TestData.productTag3, TestData.productTag4],
                 });
                 renderMyTagsForm(FilterTypeListings.ProductTag);
                 const deleteIcons = await screen.findAllByTestId('deleteIcon__product_tag');
@@ -252,7 +253,7 @@ describe('My Tags Form', () => {
             beforeEach(async () => {
                 LocationClient.get = jest.fn().mockResolvedValue({
                     data: [
-                        ...TestUtils.locations,
+                        ...TestData.locations,
                         {id: 5, name: 'Ahmedabad', spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'}
                     ],
                 });
@@ -308,7 +309,7 @@ describe('My Tags Form', () => {
             beforeEach(async () => {
                 ProductTagClient.get = jest.fn().mockResolvedValue({
                     data: [
-                        ...TestUtils.productTags,
+                        ...TestData.productTags,
                         {id: 5, name: 'Fin Tech', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'}
                     ],
                 });

--- a/ui/src/Tags/MyTagsForm.test.tsx
+++ b/ui/src/Tags/MyTagsForm.test.tsx
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import {screen} from '@testing-library/react';
 import MyTagsForm from './MyTagsForm';
 import {FilterTypeListings} from '../SortingAndFiltering/FilterLibraries';
@@ -25,27 +26,27 @@ import {GlobalStateProps} from '../Redux/Reducers';
 
 describe('My Tags Form', () => {
     const initialState: PreloadedState<Partial<GlobalStateProps>> = {
-        productTags: TestUtils.productTags,
-        locations: TestUtils.locations,
-        allGroupedTagFilterOptions: TestUtils.allGroupedTagFilterOptions,
-        currentSpace: TestUtils.space,
+        productTags: TestData.productTags,
+        locations: TestData.locations,
+        allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions,
+        currentSpace: TestData.space,
     };
 
     it('should only display location tags when the passed-in filter type is location tags', async () => {
         renderWithRedux(<MyTagsForm filterType={FilterTypeListings.Location}/>, undefined, initialState);
 
-        await screen.findByText( TestUtils.annarbor.name);
-        await screen.findByText( TestUtils.detroit.name);
-        await screen.findByText( TestUtils.dearborn.name);
-        await screen.findByText( TestUtils.southfield.name);
+        await screen.findByText( TestData.annarbor.name);
+        await screen.findByText( TestData.detroit.name);
+        await screen.findByText( TestData.dearborn.name);
+        await screen.findByText( TestData.southfield.name);
     });
 
     it('should only display product tags when the passed-in filter type is product tags', async () => {
         renderWithRedux(<MyTagsForm filterType={FilterTypeListings.ProductTag}/>, undefined, initialState);
 
-        await screen.findByText(TestUtils.productTag1.name);
-        await screen.findByText(TestUtils.productTag2.name);
-        await screen.findByText(TestUtils.productTag3.name);
-        await screen.findByText(TestUtils.productTag4.name);
+        await screen.findByText(TestData.productTag1.name);
+        await screen.findByText(TestData.productTag2.name);
+        await screen.findByText(TestData.productTag3.name);
+        await screen.findByText(TestData.productTag4.name);
     });
 });

--- a/ui/src/Tags/ProductTag/ProductTagClient.test.tsx
+++ b/ui/src/Tags/ProductTag/ProductTagClient.test.tsx
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-import Axios, {AxiosResponse} from 'axios';
+import Axios from 'axios';
 import ProductTag from './ProductTagClient';
-import TestUtils from '../../Utils/TestUtils';
+import TestData from '../../Utils/TestData';
 import Cookies from 'universal-cookie';
 
 describe('Product Tags Client', function() {
@@ -34,22 +34,10 @@ describe('Product Tags Client', function() {
     beforeEach(() => {
         cookies.set('accessToken', '123456');
 
-        // @ts-ignore
-        Axios.post = jest.fn(x => Promise.resolve({
-            data: 'Created Product Tag',
-        } as AxiosResponse));
-        // @ts-ignore
-        Axios.put = jest.fn(x => Promise.resolve({
-            data: 'Updated Product Tag',
-        } as AxiosResponse));
-        // @ts-ignore
-        Axios.delete = jest.fn(x => Promise.resolve({
-            data: 'Deleted Product Tag',
-        } as AxiosResponse));
-        // @ts-ignore
-        Axios.get = jest.fn(x => Promise.resolve({
-            data: 'Get Product Tags',
-        } as AxiosResponse));
+        Axios.post = jest.fn().mockResolvedValue({ data: 'Created Product Tag' });
+        Axios.put = jest.fn().mockResolvedValue({ data: 'Updated Product Tag' });
+        Axios.delete = jest.fn().mockResolvedValue({ data: 'Deleted Product Tag' });
+        Axios.get = jest.fn().mockResolvedValue({ data: 'Get Product Tags' });
     });
 
     afterEach(() => {
@@ -67,8 +55,8 @@ describe('Product Tags Client', function() {
     });
 
     it('should create a product tag and return that product tag', function(done) {
-        const expectedProductAddRequest = { name: TestUtils.productTag1.name };
-        ProductTag.add(expectedProductAddRequest, TestUtils.space)
+        const expectedProductAddRequest = { name: TestData.productTag1.name };
+        ProductTag.add(expectedProductAddRequest, TestData.space)
             .then((response) => {
                 expect(Axios.post).toHaveBeenCalledWith(baseProductTagsUrl, expectedProductAddRequest, expectedConfig);
                 expect(response.data).toBe('Created Product Tag');
@@ -78,20 +66,20 @@ describe('Product Tags Client', function() {
 
     it('should edit a product tag and return that product tag', function(done) {
         const expectedProductEditRequest = {
-            id: TestUtils.productTag1.id,
-            name: TestUtils.productTag1.name,
+            id: TestData.productTag1.id,
+            name: TestData.productTag1.name,
         };
-        ProductTag.edit(expectedProductEditRequest, TestUtils.space)
+        ProductTag.edit(expectedProductEditRequest, TestData.space)
             .then((response) => {
-                expect(Axios.put).toHaveBeenCalledWith(`${baseProductTagsUrl}/${TestUtils.productTag1.id}`, expectedProductEditRequest, expectedConfig);
+                expect(Axios.put).toHaveBeenCalledWith(`${baseProductTagsUrl}/${TestData.productTag1.id}`, expectedProductEditRequest, expectedConfig);
                 expect(response.data).toBe('Updated Product Tag');
                 done();
             });
     });
 
     it('should delete a product tag', function(done) {
-        const expectedUrl = `${baseProductTagsUrl}/${TestUtils.productTag1.id}`;
-        ProductTag.delete(TestUtils.productTag1.id, TestUtils.space)
+        const expectedUrl = `${baseProductTagsUrl}/${TestData.productTag1.id}`;
+        ProductTag.delete(TestData.productTag1.id, TestData.space)
             .then((response) => {
                 expect(Axios.delete).toHaveBeenCalledWith(expectedUrl, expectedConfig);
                 expect(response.data).toBe('Deleted Product Tag');

--- a/ui/src/TimeOnProductPage/TimeOnProduct.test.tsx
+++ b/ui/src/TimeOnProductPage/TimeOnProduct.test.tsx
@@ -17,6 +17,7 @@
 
 import React from 'react';
 import TestUtils, {renderWithRedux} from '../Utils/TestUtils';
+import TestData from '../Utils/TestData';
 import TimeOnProduct, {
     generateTimeOnProductItems,
     LOADING,
@@ -55,15 +56,15 @@ describe('TimeOnProduct', () => {
 
     describe('calculation', () => {
         beforeEach(async () => {
-            await renderTimeOnProduct({currentSpace: TestUtils.space }, ({set}) => {
+            await renderTimeOnProduct({currentSpace: TestData.space }, ({set}) => {
                 set(ViewingDateState, new Date(2020, 0, 1))
                 set(IsReadOnlyState, false)
-                set(ProductsState, [TestUtils.productForHank])
+                set(ProductsState, [TestData.productForHank])
             })
         });
 
         it('should show 1 day spend on the project when viewingDate equal start date', async () => {
-            const list = await screen.getByTestId(TestUtils.productForHank.assignments[0].id.toString());
+            const list = await screen.getByTestId(TestData.productForHank.assignments[0].id.toString());
             expect(list).toContainHTML('Hank');
             expect(list).toContainHTML('1 day');
         });
@@ -71,14 +72,14 @@ describe('TimeOnProduct', () => {
         it('should show the number of days on the project since selected viewingDate', async () => {
             cleanup();
             const initialState = {
-                currentSpace: TestUtils.space,
+                currentSpace: TestData.space,
             };
             store = createStore(rootReducer, initialState);
             store.dispatch = jest.fn();
             renderWithRedux(
                 <RecoilRoot initializeState={({set}) => {
                     set(ViewingDateState, new Date(2020, 0, 10))
-                    set(ProductsState, [TestUtils.productForHank])
+                    set(ProductsState, [TestData.productForHank])
                 }}>
                     <MemoryRouter initialEntries={['/team-uuid']}>
                         <Routes>
@@ -90,19 +91,19 @@ describe('TimeOnProduct', () => {
             );
             await waitFor(() => expect(ProductClient.getProductsForDate).toHaveBeenCalled())
 
-            const list = await screen.getByTestId(TestUtils.productForHank.assignments[0].id.toString());
+            const list = await screen.getByTestId(TestData.productForHank.assignments[0].id.toString());
             expect(list).toContainHTML('Hank');
             expect(list).toContainHTML('10 days');
         });
 
         it('should make the call to open the Edit Person modal when person name is clicked', async () => {
-            const hank = screen.getByText(TestUtils.hank.name);
+            const hank = screen.getByText(TestData.hank.name);
             expect(hank).toBeEnabled();
             fireEvent.click(hank);
             expect(store.dispatch).toHaveBeenCalledWith(
                 setCurrentModalAction({
                     modal: AvailableModals.EDIT_PERSON,
-                    item: TestUtils.hank,
+                    item: TestData.hank,
                 })
             );
         });
@@ -112,14 +113,14 @@ describe('TimeOnProduct', () => {
         it('should redirect to the space page when there is no state', async () => {
             renderWithRedux(
                 <RecoilRoot>
-                    <MemoryRouter initialEntries={[`/${TestUtils.space.uuid}/timeonproduct`]}>
+                    <MemoryRouter initialEntries={[`/${TestData.space.uuid}/timeonproduct`]}>
                         <Routes>
                             <Route path="/:teamUUID/timeonproduct" element={<TimeOnProduct/>} />
                         </Routes>
                     </MemoryRouter>
                 </RecoilRoot>
             );
-            expect(mockedUsedNavigate).toHaveBeenCalledWith(`/${TestUtils.space.uuid}`);
+            expect(mockedUsedNavigate).toHaveBeenCalledWith(`/${TestData.space.uuid}`);
         });
     });
 
@@ -129,13 +130,13 @@ describe('TimeOnProduct', () => {
                 id: 999,
                 name: UNASSIGNED,
                 spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-                assignments: [TestUtils.assignmentForUnassigned, TestUtils.assignmentForUnassignedNoRole],
+                assignments: [TestData.assignmentForUnassigned, TestData.assignmentForUnassignedNoRole],
                 startDate: '',
                 endDate: '',
                 archived: false,
                 tags: [],
             };
-            const products = [TestUtils.productForHank, unassignedProduct];
+            const products = [TestData.productForHank, unassignedProduct];
             const viewingDate = new Date(2020, 0, 10);
             const timeOnProductItems = generateTimeOnProductItems(products, viewingDate);
 
@@ -227,7 +228,7 @@ describe('TimeOnProduct', () => {
     describe('Loading', () => {
         it('should show loading state', async () => {
             const initialState = {
-                currentSpace: TestUtils.space,
+                currentSpace: TestData.space,
             };
             const store = createStore(rootReducer, initialState, applyMiddleware(thunk));
             renderWithRedux(<RecoilRoot><TimeOnProduct/></RecoilRoot>, store);
@@ -237,13 +238,13 @@ describe('TimeOnProduct', () => {
 
     describe('View Only', () => {
         it('person name button should be disabled', async () => {
-            ProductClient.getProductsForDate = jest.fn().mockResolvedValue({ data: [TestUtils.productForHank] })
-            await renderTimeOnProduct({ currentSpace: TestUtils.space }, ({set}) => {
+            ProductClient.getProductsForDate = jest.fn().mockResolvedValue({ data: [TestData.productForHank] })
+            await renderTimeOnProduct({ currentSpace: TestData.space }, ({set}) => {
                 set(ViewingDateState, new Date(2020, 0, 1))
                 set(IsReadOnlyState, true)
             })
             await waitFor(() => expect(ProductClient.getProductsForDate).toHaveBeenCalled())
-            const hank = screen.getByText(TestUtils.hank.name);
+            const hank = screen.getByText(TestData.hank.name);
             expect(hank).toBeDisabled();
         });
     });
@@ -253,7 +254,7 @@ describe('TimeOnProduct', () => {
         store.dispatch = jest.fn()
         renderWithRedux(
             <RecoilRoot initializeState={initializeState}>
-                <MemoryRouter initialEntries={[`/${TestUtils.space.uuid}/timeonproduct`]}>
+                <MemoryRouter initialEntries={[`/${TestData.space.uuid}/timeonproduct`]}>
                     <Routes>
                         <Route path="/:teamUUID/timeonproduct" element={<TimeOnProduct/>} />
                     </Routes>

--- a/ui/src/TimeOnProductPage/TimeOnProduct.test.tsx
+++ b/ui/src/TimeOnProductPage/TimeOnProduct.test.tsx
@@ -45,6 +45,7 @@ jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),
     useNavigate: () => mockedUsedNavigate,
 }));
+jest.mock('../Products/ProductClient');
 
 describe('TimeOnProduct', () => {
     let store: Store;

--- a/ui/src/Utils/TestData.ts
+++ b/ui/src/Utils/TestData.ts
@@ -1,0 +1,527 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Person} from '../People/Person';
+import {Assignment} from '../Assignments/Assignment';
+import {Product} from '../Products/Product';
+import {Tag} from '../Tags/Tag';
+import {Color, RoleTag} from '../Roles/RoleTag.interface';
+import {LocationTag} from '../Locations/LocationTag.interface';
+import {Space} from '../Space/Space';
+import {UserSpaceMapping} from '../Space/UserSpaceMapping';
+import {AllGroupedTagFilterOptions} from '../SortingAndFiltering/FilterLibraries';
+
+const originDateString = '2019-01-01';
+
+const annarbor = {id: 1, name: 'Ann Arbor', spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'};
+const detroit = {id: 2, name: 'Detroit', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
+const dearborn = {id: 3, name: 'Dearborn', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
+const southfield = {id: 4, name: 'Southfield', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
+
+const locations: LocationTag[] = [
+    annarbor,
+    detroit,
+    dearborn,
+    southfield,
+];
+
+const productTag1: Tag = {id: 5, name: 'AV', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
+const productTag2: Tag = {id: 6, name: 'FordX', spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'};
+const productTag3: Tag = {id: 7, name: 'EV', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
+const productTag4: Tag = {id: 8, name: 'Mache', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
+
+const productTags: Array<Tag> = [
+    productTag1,
+    productTag2,
+    productTag3,
+    productTag4,
+];
+
+const personTag1: Tag = {id: 5, name: 'The lil boss', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
+const personTag2: Tag = {id: 6, name: 'The big boss', spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'};
+
+const personTags: Array<Tag> = [
+    personTag1,
+    personTag2,
+];
+
+const color1: Color = {color: '#81C0FA', id: 1};
+const color2: Color = {color: '#83DDC2', id: 2};
+const color3: Color = {color: '#FCBAE9', id: 3};
+const whiteColor: Color = {color: '#FFFFFF', id: 4};
+
+const colors: Array<Color> = [
+    color1,
+    color2,
+    color3,
+    whiteColor,
+];
+
+const softwareEngineer = {name: 'Software Engineer', id: 1, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', color: color1};
+const productManager = {name: 'Product Manager', id: 2, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', color: color2};
+const productDesigner = {name: 'Product Designer', id: 3, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', color: color3};
+
+const roles: RoleTag[] = [
+    productDesigner,
+    productManager,
+    softwareEngineer,
+];
+
+const person1: Person = {
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    id: 100,
+    name: 'Person 1',
+    spaceRole: softwareEngineer,
+    notes: 'I love the theater',
+    newPerson: false,
+    tags: [personTag1],
+};
+
+const hank: Person = {
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    id: 200,
+    name: 'Hank',
+    spaceRole: productManager,
+    notes: "Don't forget the WD-40!",
+    newPerson: false,
+    tags: [personTag1],
+    archiveDate: new Date(2200, 0, 1),
+};
+
+const archivedPerson: Person = {
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    id: 1010,
+    name: 'Unassigned Person 77',
+    spaceRole: softwareEngineer,
+    newPerson: false,
+    tags: [],
+    archiveDate: new Date(2001, 10, 10),
+};
+
+const unassignedPerson: Person = {
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    id: 101,
+    name: 'Unassigned Person 7',
+    spaceRole: softwareEngineer,
+    newPerson: false,
+    tags: [],
+};
+
+const unassignedPersonNoRole: Person = {
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    id: 106,
+    name: 'Unassigned Person No Role',
+    newPerson: false,
+    tags: [],
+};
+
+const unassignedBigBossSE: Person = {
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    id: 102,
+    name: 'Unassigned Big Boss SE',
+    spaceRole: softwareEngineer,
+    newPerson: false,
+    tags: [personTag2],
+    archiveDate: new Date(1993, 8, 1),
+};
+
+const person2: Person = {
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    id: 103,
+    name: 'bob se',
+    spaceRole: softwareEngineer,
+    newPerson: false,
+    tags: personTags,
+};
+
+const person3: Person = {
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    id: 104,
+    name: 'bob pm',
+    spaceRole: productManager,
+    newPerson: false,
+    tags: [personTag1],
+};
+
+const personNoRoleNoTag: Person = {
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    id: 105,
+    name: 'bob norole notag',
+    newPerson: false,
+    tags: [],
+};
+
+const people: Array<Person> = [
+    person1,
+    hank,
+    archivedPerson,
+    unassignedPerson,
+];
+
+const assignmentForPerson1: Assignment = {
+    id: 1,
+    productId: 1,
+    placeholder: false,
+    person: person1,
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    effectiveDate: new Date(2020, 5, 1),
+};
+
+const assignmentForHank: Assignment = {
+    id: 3,
+    productId: 102,
+    placeholder: true,
+    person: hank,
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    effectiveDate: new Date(2020, 6, 1),
+    startDate: new Date(2020, 0, 1),
+};
+
+const assignmentVacationForHank: Assignment = {
+    id: 20,
+    productId: 999,
+    person: hank,
+    placeholder: false,
+    spaceUuid: hank.spaceUuid,
+    startDate: new Date(2019, 11, 1),
+    endDate: new Date(2020, 0, 1),
+};
+
+const previousAssignmentForHank: Assignment = {
+    id: 21,
+    productId: 3,
+    person: hank,
+    placeholder: false,
+    spaceUuid: hank.spaceUuid,
+    startDate: new Date(2019, 9, 1),
+    endDate: new Date(2019, 11, 1),
+};
+
+const assignmentForUnassigned: Assignment = {
+    id: 11,
+    productId: 999,
+    person: unassignedPerson,
+    placeholder: false,
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    effectiveDate: new Date(2020, 4, 15),
+    startDate: new Date(2020, 0, 2),
+};
+
+const assignmentForArchived: Assignment = {
+    id: 111,
+    productId: 999,
+    person: archivedPerson,
+    placeholder: false,
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    effectiveDate: new Date(2020, 4, 15),
+    startDate: new Date(2020, 0, 2),
+};
+
+const assignmentForUnassignedNoRole: Assignment = {
+    id: 14,
+    productId: 999,
+    person: unassignedPersonNoRole,
+    placeholder: false,
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    effectiveDate: new Date(2020, 4, 15),
+    startDate: new Date(2020, 0, 2),
+};
+
+const assignmentForUnassignedBigBossSE: Assignment = {
+    id: 12,
+    productId: 999,
+    person: unassignedBigBossSE,
+    placeholder: false,
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    effectiveDate: new Date(2020, 4, 15),
+};
+
+const assignmentForPerson2: Assignment = {
+    id: 15,
+    productId: 1,
+    person: person2,
+    placeholder: false,
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    effectiveDate: new Date(2020, 4, 15),
+};
+
+const assignmentForPerson3: Assignment = {
+    id: 17,
+    productId: 1,
+    person: person3,
+    placeholder: false,
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    effectiveDate: new Date(2020, 4, 15),
+};
+
+const assignmentForPersonNoRoleNoTag: Assignment = {
+    id: 19,
+    productId: 1,
+    person: personNoRoleNoTag,
+    placeholder: false,
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    effectiveDate: new Date(2020, 4, 15),
+};
+
+const assignments: Array<Assignment> = [
+    assignmentForPerson1,
+    assignmentForHank,
+    assignmentForUnassigned,
+];
+
+const assignmentsFilterTest: Array<Assignment> = [
+    assignmentForPerson1,
+    assignmentForPerson2,
+    assignmentForPerson3,
+    assignmentForPersonNoRoleNoTag,
+];
+
+const unassignedProduct: Product = {
+    id: 999,
+    name: 'unassigned',
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    assignments: [assignmentForUnassigned, assignmentForArchived],
+    startDate: '',
+    endDate: undefined,
+    archived: false,
+    tags: [],
+};
+
+const unassignedProductForBigBossSE: Product = {
+    id: 998,
+    name: 'unassigned',
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    assignments: [assignmentForUnassignedBigBossSE],
+    startDate: '',
+    endDate: '',
+    archived: false,
+    tags: [],
+};
+
+const productWithAssignments: Product = {
+    id: 1,
+    name: 'Product 1',
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    startDate: '2011-01-01',
+    endDate: '9999-02-02',
+    spaceLocation: southfield,
+    assignments: [assignmentForPerson1],
+    archived: false,
+    tags: [productTag2],
+    notes: 'note',
+};
+
+const productWithoutAssignments: Product = {
+    id: 3,
+    name: 'Product 3',
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    startDate: '2011-01-01',
+    endDate: '9999-02-02',
+    spaceLocation: dearborn,
+    assignments: [],
+    archived: false,
+    tags: [productTag1],
+    dorf: '',
+    notes: '',
+    url: '',
+};
+
+const productForHank: Product = {
+    id: 102,
+    name: 'Hanky Product',
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    startDate: '2011-01-01',
+    endDate: '9999-02-02',
+    spaceLocation: annarbor,
+    assignments: [assignmentForHank],
+    archived: false,
+    tags: [],
+};
+
+const productWithoutLocation: Product = {
+    id: 5,
+    name: 'Awesome Product',
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    startDate: '2011-01-01',
+    endDate: '9999-02-02',
+    assignments: [],
+    archived: false,
+    tags: [],
+};
+
+const archivedProduct: Product = {
+    id: 4,
+    name: 'I am archived',
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    startDate: '',
+    endDate: '2019-11-02',
+    spaceLocation: detroit,
+    assignments: [],
+    archived: true,
+    tags: [],
+};
+
+const productWithTags: Product = {
+    id: 6,
+    name: 'Product 6',
+    spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    startDate: '2011-01-01',
+    endDate: '9999-02-02',
+    spaceLocation: southfield,
+    assignments: assignmentsFilterTest,
+    archived: false,
+    tags: [productTag2],
+    notes: 'note',
+};
+
+const products: Array<Product> = [
+    unassignedProduct,
+    productWithAssignments,
+    productForHank,
+    productWithoutAssignments,
+    archivedProduct,
+    productWithoutLocation,
+];
+
+const notEmptyProducts: Array<Product> = [
+    productWithAssignments,
+];
+
+const productsForBoard2: Array<Product> = [
+    {
+        id: 2,
+        name: 'Product 2',
+        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        startDate: '',
+        endDate: '',
+        spaceLocation: detroit,
+        assignments: [],
+        archived: false,
+        tags: [],
+    },
+];
+
+const space: Space = {
+    id: 1,
+    uuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    name: 'testSpace',
+    lastModifiedDate: originDateString,
+    todayViewIsPublic: true,
+}
+
+const spaceMappingsArray: UserSpaceMapping[] = [
+    {id: '1', spaceUuid: space.uuid!, userId: 'user_id', permission: 'owner'},
+    {id: '2', spaceUuid: space.uuid!, userId: 'user_id_2', permission: 'editor'},
+];
+
+const allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions> = [
+    {
+        label:'Location Tags:',
+        options: [{
+            label: 'Ann Arbor',
+            value: '1_Ann Arbor',
+            selected: true,
+        }],
+    },
+    {
+        label:'Product Tags:',
+        options: [],
+    },
+    {
+        label:'Role Tags:',
+        options: [],
+    },
+    {
+        label:'Person Tags:',
+        options: [],
+    },
+]
+
+const TestData = {
+    allGroupedTagFilterOptions,
+
+    spaceMappingsArray,
+    space,
+
+    products,
+    productsForBoard2,
+    notEmptyProducts,
+    productWithTags,
+    archivedProduct,
+    productForHank,
+    productWithoutAssignments,
+    productWithAssignments,
+    productWithoutLocation,
+    unassignedProductForBigBossSE,
+    unassignedProduct,
+
+    assignments,
+    assignmentsFilterTest,
+    assignmentForPersonNoRoleNoTag,
+    assignmentForPerson3,
+    assignmentForPerson2,
+    assignmentForUnassignedBigBossSE,
+    assignmentForUnassignedNoRole,
+    assignmentForArchived,
+    assignmentForUnassigned,
+    previousAssignmentForHank,
+    assignmentVacationForHank,
+    assignmentForHank,
+    assignmentForPerson1,
+
+    people,
+    personNoRoleNoTag,
+    person3,
+    person2,
+    person1,
+    unassignedBigBossSE,
+    unassignedPersonNoRole,
+    unassignedPerson,
+    archivedPerson,
+    hank,
+
+    roles,
+    productDesigner,
+    productManager,
+    softwareEngineer,
+
+    colors,
+    whiteColor,
+    color1,
+    color2,
+    color3,
+
+    personTags,
+    personTag1,
+    personTag2,
+
+    productTags,
+    productTag1,
+    productTag2,
+    productTag3,
+    productTag4,
+
+    locations,
+    southfield,
+    dearborn,
+    detroit,
+    annarbor,
+
+    originDateString,
+}
+
+export default TestData;

--- a/ui/src/Utils/TestUtils.tsx
+++ b/ui/src/Utils/TestUtils.tsx
@@ -15,37 +15,95 @@
  * limitations under the License.
  */
 
-import RoleClient from '../Roles/RoleClient';
-import LocationClient from '../Locations/LocationClient';
+import React from 'react';
 import PeopleClient from '../People/PeopleClient';
+import SpaceClient from '../Space/SpaceClient';
 import AssignmentClient from '../Assignments/AssignmentClient';
+import RoleClient from '../Roles/RoleClient';
+import ColorClient from '../Roles/ColorClient';
+import LocationClient from '../Locations/LocationClient';
 import ProductClient from '../Products/ProductClient';
-import {render, RenderResult, waitFor} from '@testing-library/react';
+import ProductTagClient from '../Tags/ProductTag/ProductTagClient';
+import PersonTagClient from '../Tags/PersonTag/PersonTagClient';
 import {applyMiddleware, createStore, PreloadedState, Store} from 'redux';
 import rootReducer, {GlobalStateProps} from '../Redux/Reducers';
-import {Provider} from 'react-redux';
-import React from 'react';
-import thunk from 'redux-thunk';
-import {Person} from '../People/Person';
-import {Assignment} from '../Assignments/Assignment';
-import {Product} from '../Products/Product';
-import ProductTagClient from '../Tags/ProductTag/ProductTagClient';
-import {Tag} from '../Tags/Tag';
-import ColorClient from '../Roles/ColorClient';
-import {Color, RoleTag} from '../Roles/RoleTag.interface';
-import {LocationTag} from '../Locations/LocationTag.interface';
-import {AxiosResponse} from 'axios';
-import SpaceClient from '../Space/SpaceClient';
-import {Space} from '../Space/Space';
-import {UserSpaceMapping} from '../Space/UserSpaceMapping';
-import {AllGroupedTagFilterOptions} from '../SortingAndFiltering/FilterLibraries';
-import PersonTagClient from '../Tags/PersonTag/PersonTagClient';
+import {MutableSnapshot, RecoilRoot} from 'recoil';
+import {render, RenderResult, waitFor} from '@testing-library/react';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import PeopleMover from '../PeopleMover/PeopleMover';
-import {MutableSnapshot, RecoilRoot} from 'recoil';
+import thunk from 'redux-thunk';
+import {Provider} from 'react-redux';
+import TestData from '../Utils/TestData';
+import {AxiosResponse} from 'axios';
 
-export function createDataTestId(prefix: string, name: string): string {
-    return prefix + '__' + name.toLowerCase().replace(/ /g, '_');
+// @todo replace this with jest manual mocks
+function mockClientCalls(): void {
+    PeopleClient.createPersonForSpace = jest.fn((space, person) => Promise.resolve({ data: person } as AxiosResponse));
+    PeopleClient.getAllPeopleInSpace = jest.fn().mockResolvedValue({ data: TestData.people });
+    PeopleClient.updatePerson = jest.fn().mockResolvedValue({data: {}});
+    PeopleClient.removePerson = jest.fn().mockResolvedValue({data: {}});
+
+    SpaceClient.removeUser = jest.fn().mockResolvedValue({data: {}});
+    SpaceClient.getSpaceFromUuid = jest.fn().mockResolvedValue({data: TestData.space});
+    SpaceClient.getUsersForSpace = jest.fn().mockResolvedValue(TestData.spaceMappingsArray);
+
+    AssignmentClient.createAssignmentForDate = jest.fn().mockResolvedValue({ data: [TestData.assignmentForPerson1] });
+    AssignmentClient.getAssignmentsUsingPersonIdAndDate = jest.fn().mockResolvedValue({ data: [{...TestData.assignmentForPerson1}] });
+    AssignmentClient.getAssignmentEffectiveDates = jest.fn().mockResolvedValue({
+        data: [
+            new Date(2020, 4, 15),
+            new Date(2020, 5, 1),
+            new Date(2020, 6, 1),
+        ],
+    });
+    AssignmentClient.getReassignments = jest.fn().mockResolvedValue({ data: [] });
+    AssignmentClient.getAssignmentsV2ForSpaceAndPerson = jest.fn().mockResolvedValue({ data: [] });
+
+
+    RoleClient.get = jest.fn().mockResolvedValue({ data: [
+        {id: 1, name: 'Software Engineer', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestData.color1},
+        {id: 2, name: 'Product Manager', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestData.color2},
+        {id: 3, name: 'Product Designer', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestData.color3},
+    ]});
+    RoleClient.add = jest.fn().mockResolvedValue({
+        data: {name: 'Product Owner', id: 1, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: {color: '1', id: 2}},
+    });
+    RoleClient.edit = jest.fn().mockResolvedValue({
+        data: {name: 'Architecture', id: 1, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestData.color3},
+    });
+    RoleClient.delete = jest.fn().mockResolvedValue({ data: {} });
+
+    ColorClient.getAllColors = jest.fn().mockResolvedValue({ data: TestData.colors });
+
+    LocationClient.get = jest.fn().mockResolvedValue({ data: TestData.locations });
+    LocationClient.add = jest.fn().mockResolvedValue({ data: { id: 11, name: 'Ahmedabad' } });
+    LocationClient.edit = jest.fn().mockResolvedValue({ data: { id: 1, name: 'Saline' } });
+    LocationClient.delete = jest.fn().mockResolvedValue({ data: {} });
+
+    // @todo DELETE THESE 4 ME ON FRIDAY
+    ProductClient.createProduct = jest.fn().mockResolvedValue({ data: {} });
+    ProductClient.deleteProduct = jest.fn().mockResolvedValue({ data: {} });
+    ProductClient.editProduct = jest.fn().mockResolvedValue({ data: {} });
+    ProductClient.getProductsForDate = jest.fn().mockResolvedValue({ data: TestData.products });
+
+
+
+
+    ProductTagClient.get = jest.fn().mockResolvedValue({ data: TestData.productTags });
+    ProductTagClient.add = jest.fn().mockResolvedValue({ data: {id: 9, name: 'Fin Tech'} });
+    ProductTagClient.edit = jest.fn().mockResolvedValue({
+        data: {id: 6, name: 'Finance', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'},
+    });
+    ProductTagClient.delete = jest.fn().mockResolvedValue({ data: {} });
+
+    PersonTagClient.get = jest.fn().mockResolvedValue({ data: TestData.personTags });
+    PersonTagClient.add = jest.fn().mockResolvedValue({
+        data: {id: 1337, name: 'Low Achiever', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'},
+    });
+    PersonTagClient.edit = jest.fn().mockResolvedValue({
+        data: {id: 6, name: 'Halo Group', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'},
+    });
+    PersonTagClient.delete = jest.fn().mockResolvedValue({ data: {} });
 }
 
 export function renderWithRedux(
@@ -57,36 +115,34 @@ export function renderWithRedux(
     return render(<Provider store={testingStore}>{component}</Provider>);
 }
 
+async function renderPeopleMoverComponent(
+    store?: Store,
+    initialReduxState?: PreloadedState<Partial<GlobalStateProps>>,
+    initializedRecoilState?: (mutableSnapshot: MutableSnapshot) => void,
+    initialPath = '/uuid'
+): Promise<RenderResult> {
+    const result = renderWithRedux(
+        <MemoryRouter initialEntries={[initialPath]}>
+            <RecoilRoot initializeState={initializedRecoilState}>
+                <Routes>
+                    <Route path="/:teamUUID" element={<PeopleMover/>} />
+                </Routes>
+            </RecoilRoot>
+        </MemoryRouter>,
+        store,
+        initialReduxState
+    );
+    await waitFor(() => expect(SpaceClient.getSpaceFromUuid).toHaveBeenCalledWith(initialPath.replace('/', '')))
+    return result;
+}
+
 export function renderWithRecoil(component: JSX.Element, initializeState?: (mutableSnapshot: MutableSnapshot) => void): RenderResult {
     return render(<RecoilRoot initializeState={initializeState}>{component}</RecoilRoot>)
 }
 
-export const mockDate = (expected: Date): () => void => {
-    const _Date = Date;
-
-    // If any Date or number is passed to the constructor
-    // use that instead of our mocked date
-    function MockDate(mockOverride?: Date | number): Date {
-        return new _Date(mockOverride || expected);
-    }
-
-    MockDate.UTC = _Date.UTC;
-    MockDate.parse = _Date.parse;
-    MockDate.now = (): number => expected.getTime();
-    // Give our mock Date has the same prototype as Date
-    // Some libraries rely on this to identify Date objects
-    MockDate.prototype = _Date.prototype;
-
-    // Our mock is not a full implementation of Date
-    // Types will not match but it's good enough for our tests
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    global.Date = MockDate as any;
-
-    // Callback function to remove the Date mock
-    return (): void => {
-        global.Date = _Date;
-    };
-};
+export function createDataTestId(prefix: string, name: string): string {
+    return prefix + '__' + name.toLowerCase().replace(/ /g, '_');
+}
 
 export function mockCreateRange(): () => void {
     if (window.document) {
@@ -113,570 +169,18 @@ export function mockCreateRange(): () => void {
     }
 }
 
-class TestUtils {
-
-    static mockClientCalls(): void {
-        PeopleClient.createPersonForSpace = jest.fn((space, person) => Promise.resolve({
-            data: person,
-        } as AxiosResponse));
-        PeopleClient.getAllPeopleInSpace = jest.fn(() => Promise.resolve({
-            data: TestUtils.people,
-        } as AxiosResponse));
-        PeopleClient.updatePerson = jest.fn(() => Promise.resolve({data: {}} as AxiosResponse));
-        PeopleClient.removePerson = jest.fn(() => Promise.resolve({data: {}} as AxiosResponse));
-
-        SpaceClient.removeUser = jest.fn(() => Promise.resolve({data: {}} as AxiosResponse));
-
-        SpaceClient.getSpaceFromUuid = jest.fn(() => Promise.resolve({
-            data: TestUtils.space,
-        } as AxiosResponse));
-
-        SpaceClient.getUsersForSpace = jest.fn(() => Promise.resolve(
-            TestUtils.spaceMappingsArray as UserSpaceMapping[]));
-
-        AssignmentClient.createAssignmentForDate = jest.fn(() => Promise.resolve({
-            data: [TestUtils.assignmentForPerson1],
-        } as AxiosResponse));
-        AssignmentClient.getAssignmentsUsingPersonIdAndDate = jest.fn().mockResolvedValue({ data: [{...TestUtils.assignmentForPerson1}] });
-        AssignmentClient.getAssignmentEffectiveDates = jest.fn(() => Promise.resolve({
-            data: [
-                new Date(2020, 4, 15),
-                new Date(2020, 5, 1),
-                new Date(2020, 6, 1),
-            ],
-        } as AxiosResponse));
-        AssignmentClient.getReassignments = jest.fn(() => Promise.resolve({
-            data: [],
-        } as AxiosResponse));
-        AssignmentClient.getAssignmentsV2ForSpaceAndPerson = jest.fn(() => Promise.resolve({
-            data: [],
-        } as AxiosResponse));
-
-
-        RoleClient.get = jest.fn(() => Promise.resolve({
-            data: [
-                {id: 1, name: 'Software Engineer', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestUtils.color1},
-                {id: 2, name: 'Product Manager', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestUtils.color2},
-                {id: 3, name: 'Product Designer', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestUtils.color3},
-            ],
-        } as AxiosResponse));
-        RoleClient.add = jest.fn(() => Promise.resolve({
-            data: {name: 'Product Owner', id: 1, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: {color: '1', id: 2}},
-        } as AxiosResponse));
-        RoleClient.edit = jest.fn(() => Promise.resolve({
-            data: {name: 'Architecture', id: 1, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestUtils.color3},
-        } as AxiosResponse));
-        RoleClient.delete = jest.fn(() => Promise.resolve({data: {}} as AxiosResponse));
-
-        ColorClient.getAllColors = jest.fn(() => Promise.resolve({
-            data: TestUtils.colors,
-        } as AxiosResponse));
-
-        LocationClient.get = jest.fn(() => Promise.resolve({
-            data: TestUtils.locations,
-        } as AxiosResponse));
-        LocationClient.add = jest.fn(() => Promise.resolve({
-            data: {
-                id: 11,
-                name: 'Ahmedabad',
-            },
-        } as AxiosResponse));
-        LocationClient.edit = jest.fn(() => Promise.resolve({
-            data: {
-                id: 1,
-                name: 'Saline',
-            },
-        } as AxiosResponse));
-        LocationClient.delete = jest.fn(() => Promise.resolve({data: {}} as AxiosResponse));
-
-        ProductClient.createProduct = jest.fn(() => Promise.resolve({data: {}} as AxiosResponse));
-        ProductClient.deleteProduct = jest.fn(() => Promise.resolve({data: {}} as AxiosResponse));
-        ProductClient.editProduct = jest.fn(() => Promise.resolve({data: {}} as AxiosResponse));
-        ProductClient.getProductsForDate = jest.fn(() => Promise.resolve({
-            data: TestUtils.products,
-        } as AxiosResponse));
-
-        ProductTagClient.get = jest.fn(() => Promise.resolve({
-            data: TestUtils.productTags,
-        } as AxiosResponse));
-        ProductTagClient.add = jest.fn(() => Promise.resolve({
-            data: {id: 9, name: 'Fin Tech'},
-        } as AxiosResponse));
-        ProductTagClient.edit = jest.fn(() => Promise.resolve({
-            data: {id: 6, name: 'Finance', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'},
-        } as AxiosResponse));
-        ProductTagClient.delete = jest.fn(() => Promise.resolve({data: {}} as AxiosResponse));
-
-        PersonTagClient.get = jest.fn(() => Promise.resolve({
-            data: TestUtils.personTags,
-        } as AxiosResponse));
-        PersonTagClient.add = jest.fn(() => Promise.resolve({
-            data: {id: 1337, name: 'Low Achiever', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'},
-        } as AxiosResponse));
-        PersonTagClient.edit = jest.fn(() => Promise.resolve({
-            data: {id: 6, name: 'Halo Group', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'},
-        } as AxiosResponse));
-        PersonTagClient.delete = jest.fn(() => Promise.resolve({data: {}} as AxiosResponse));
-    }
-
-    static async renderPeopleMoverComponent(
-        store?: Store,
-        initialReduxState?: PreloadedState<Partial<GlobalStateProps>>,
-        initializedRecoilState?: (mutableSnapshot: MutableSnapshot) => void,
-        initialPath = '/uuid'
-    ): Promise<RenderResult> {
-        const result = renderWithRedux(
-            <MemoryRouter initialEntries={[initialPath]}>
-                <RecoilRoot initializeState={initializedRecoilState}>
-                    <Routes>
-                        <Route path="/:teamUUID" element={<PeopleMover/>} />
-                    </Routes>
-                </RecoilRoot>
-            </MemoryRouter>,
-            store,
-            initialReduxState
-        );
-        await waitFor(() => expect(SpaceClient.getSpaceFromUuid).toHaveBeenCalledWith(initialPath.replace('/', '')))
-        return result;
-    }
-
-
-    static async waitForHomePageToLoad(app: RenderResult): Promise<void> {
-        await app.findByText(/PeopleMover/i);
-    }
-
-    static dummyCallback: () => void = () => null;
-
-    static originDateString = '2019-01-01';
-
-    static annarbor = {id: 1, name: 'Ann Arbor', spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'};
-    static detroit = {id: 2, name: 'Detroit', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
-    static dearborn = {id: 3, name: 'Dearborn', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
-    static southfield = {id: 4, name: 'Southfield', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
-
-    static locations: LocationTag[] = [
-        TestUtils.annarbor,
-        TestUtils.detroit,
-        TestUtils.dearborn,
-        TestUtils.southfield,
-    ];
-
-    static productTag1: Tag = {id: 5, name: 'AV', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
-    static productTag2: Tag = {id: 6, name: 'FordX', spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'};
-    static productTag3: Tag = {id: 7, name: 'EV', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
-    static productTag4: Tag = {id: 8, name: 'Mache', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
-
-    static productTags: Array<Tag> = [
-        TestUtils.productTag1,
-        TestUtils.productTag2,
-        TestUtils.productTag3,
-        TestUtils.productTag4,
-    ];
-
-    static personTag1: Tag = {id: 5, name: 'The lil boss', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'};
-    static personTag2: Tag = {id: 6, name: 'The big boss', spaceUuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'};
-
-    static personTags: Array<Tag> = [
-        TestUtils.personTag1,
-        TestUtils.personTag2,
-    ];
-
-    static color1: Color = {color: '#81C0FA', id: 1};
-    static color2: Color = {color: '#83DDC2', id: 2};
-    static color3: Color = {color: '#FCBAE9', id: 3};
-    static whiteColor: Color = {color: '#FFFFFF', id: 4};
-
-    static colors: Array<Color> = [
-        TestUtils.color1,
-        TestUtils.color2,
-        TestUtils.color3,
-        TestUtils.whiteColor,
-    ];
-
-    static softwareEngineer = {name: 'Software Engineer', id: 1, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', color: TestUtils.color1};
-    static productManager = {name: 'Product Manager', id: 2, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', color: TestUtils.color2};
-    static productDesigner = {name: 'Product Designer', id: 3, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', color: TestUtils.color3};
-
-    static roles: RoleTag[] = [
-        TestUtils.productDesigner,
-        TestUtils.productManager,
-        TestUtils.softwareEngineer,
-    ];
-
-    static person1: Person = {
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        id: 100,
-        name: 'Person 1',
-        spaceRole: TestUtils.softwareEngineer,
-        notes: 'I love the theater',
-        newPerson: false,
-        tags: [TestUtils.personTag1],
-    };
-
-    static hank: Person = {
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        id: 200,
-        name: 'Hank',
-        spaceRole: TestUtils.productManager,
-        notes: "Don't forget the WD-40!",
-        newPerson: false,
-        tags: [TestUtils.personTag1],
-        archiveDate: new Date(2200, 0, 1),
-    };
-
-    static archivedPerson: Person = {
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        id: 1010,
-        name: 'Unassigned Person 77',
-        spaceRole: TestUtils.softwareEngineer,
-        newPerson: false,
-        tags: [],
-        archiveDate: new Date(2001, 10, 10),
-    };
-
-    static unassignedPerson: Person = {
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        id: 101,
-        name: 'Unassigned Person 7',
-        spaceRole: TestUtils.softwareEngineer,
-        newPerson: false,
-        tags: [],
-    };
-
-    static unassignedPersonNoRole: Person = {
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        id: 106,
-        name: 'Unassigned Person No Role',
-        newPerson: false,
-        tags: [],
-    };
-
-    static unassignedBigBossSE: Person = {
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        id: 102,
-        name: 'Unassigned Big Boss SE',
-        spaceRole: TestUtils.softwareEngineer,
-        newPerson: false,
-        tags: [TestUtils.personTag2],
-        archiveDate: new Date(1993, 8, 1),
-    };
-
-    static person2: Person = {
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        id: 103,
-        name: 'bob se',
-        spaceRole: TestUtils.softwareEngineer,
-        newPerson: false,
-        tags: TestUtils.personTags,
-    };
-
-    static person3: Person = {
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        id: 104,
-        name: 'bob pm',
-        spaceRole: TestUtils.productManager,
-        newPerson: false,
-        tags: [TestUtils.personTag1],
-    };
-
-    static personNoRoleNoTag: Person = {
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        id: 105,
-        name: 'bob norole notag',
-        newPerson: false,
-        tags: [],
-    };
-
-    static people: Array<Person> = [
-        TestUtils.person1,
-        TestUtils.hank,
-        TestUtils.archivedPerson,
-        TestUtils.unassignedPerson,
-    ];
-
-    static assignmentForPerson1: Assignment = {
-        id: 1,
-        productId: 1,
-        placeholder: false,
-        person: TestUtils.person1,
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        effectiveDate: new Date(2020, 5, 1),
-    };
-
-    static assignmentForHank: Assignment = {
-        id: 3,
-        productId: 102,
-        placeholder: true,
-        person: TestUtils.hank,
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        effectiveDate: new Date(2020, 6, 1),
-        startDate: new Date(2020, 0, 1),
-    };
-
-    static assignmentVacationForHank: Assignment = {
-        id: 20,
-        productId: 999,
-        person: TestUtils.hank,
-        placeholder: false,
-        spaceUuid: TestUtils.hank.spaceUuid,
-        startDate: new Date(2019, 11, 1),
-        endDate: new Date(2020, 0, 1),
-    };
-
-    static previousAssignmentForHank: Assignment = {
-        id: 21,
-        productId: 3,
-        person: TestUtils.hank,
-        placeholder: false,
-        spaceUuid: TestUtils.hank.spaceUuid,
-        startDate: new Date(2019, 9, 1),
-        endDate: new Date(2019, 11, 1),
-    };
-
-    static assignmentForUnassigned: Assignment = {
-        id: 11,
-        productId: 999,
-        person: TestUtils.unassignedPerson,
-        placeholder: false,
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        effectiveDate: new Date(2020, 4, 15),
-        startDate: new Date(2020, 0, 2),
-    };
-
-    static assignmentForArchived: Assignment = {
-        id: 111,
-        productId: 999,
-        person: TestUtils.archivedPerson,
-        placeholder: false,
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        effectiveDate: new Date(2020, 4, 15),
-        startDate: new Date(2020, 0, 2),
-    };
-
-    static assignmentForUnassignedNoRole: Assignment = {
-        id: 14,
-        productId: 999,
-        person: TestUtils.unassignedPersonNoRole,
-        placeholder: false,
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        effectiveDate: new Date(2020, 4, 15),
-        startDate: new Date(2020, 0, 2),
-    };
-
-    static assignmentForUnassignedBigBossSE: Assignment = {
-        id: 12,
-        productId: 999,
-        person: TestUtils.unassignedBigBossSE,
-        placeholder: false,
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        effectiveDate: new Date(2020, 4, 15),
-    };
-
-    static assignmentForPerson2: Assignment = {
-        id: 15,
-        productId: 1,
-        person: TestUtils.person2,
-        placeholder: false,
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        effectiveDate: new Date(2020, 4, 15),
-    };
-
-    static assignmentForPerson3: Assignment = {
-        id: 17,
-        productId: 1,
-        person: TestUtils.person3,
-        placeholder: false,
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        effectiveDate: new Date(2020, 4, 15),
-    };
-
-    static assignmentForPersonNoRoleNoTag: Assignment = {
-        id: 19,
-        productId: 1,
-        person: TestUtils.personNoRoleNoTag,
-        placeholder: false,
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        effectiveDate: new Date(2020, 4, 15),
-    };
-
-    static assignments: Array<Assignment> = [
-        TestUtils.assignmentForPerson1,
-        TestUtils.assignmentForHank,
-        TestUtils.assignmentForUnassigned,
-    ];
-
-    static assignmentsFilterTest: Array<Assignment> = [
-        TestUtils.assignmentForPerson1,
-        TestUtils.assignmentForPerson2,
-        TestUtils.assignmentForPerson3,
-        TestUtils.assignmentForPersonNoRoleNoTag,
-    ];
-
-    static unassignedProduct: Product = {
-        id: 999,
-        name: 'unassigned',
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        assignments: [TestUtils.assignmentForUnassigned, TestUtils.assignmentForArchived],
-        startDate: '',
-        endDate: undefined,
-        archived: false,
-        tags: [],
-    };
-
-    static unassignedProductForBigBossSE: Product = {
-        id: 998,
-        name: 'unassigned',
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        assignments: [TestUtils.assignmentForUnassignedBigBossSE],
-        startDate: '',
-        endDate: '',
-        archived: false,
-        tags: [],
-    };
-
-    static productWithAssignments: Product = {
-        id: 1,
-        name: 'Product 1',
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        startDate: '2011-01-01',
-        endDate: '9999-02-02',
-        spaceLocation: TestUtils.southfield,
-        assignments: [TestUtils.assignmentForPerson1],
-        archived: false,
-        tags: [TestUtils.productTag2],
-        notes: 'note',
-    };
-
-    static productWithoutAssignments: Product = {
-        id: 3,
-        name: 'Product 3',
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        startDate: '2011-01-01',
-        endDate: '9999-02-02',
-        spaceLocation: TestUtils.dearborn,
-        assignments: [],
-        archived: false,
-        tags: [TestUtils.productTag1],
-        dorf: '',
-        notes: '',
-        url: '',
-    };
-
-    static productForHank: Product = {
-        id: 102,
-        name: 'Hanky Product',
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        startDate: '2011-01-01',
-        endDate: '9999-02-02',
-        spaceLocation: TestUtils.annarbor,
-        assignments: [TestUtils.assignmentForHank],
-        archived: false,
-        tags: [],
-    };
-
-    static productWithoutLocation: Product = {
-        id: 5,
-        name: 'Awesome Product',
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        startDate: '2011-01-01',
-        endDate: '9999-02-02',
-        assignments: [],
-        archived: false,
-        tags: [],
-    };
-
-    static archivedProduct: Product = {
-        id: 4,
-        name: 'I am archived',
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        startDate: '',
-        endDate: '2019-11-02',
-        spaceLocation: TestUtils.detroit,
-        assignments: [],
-        archived: true,
-        tags: [],
-    };
-
-    static productWithTags: Product = {
-        id: 6,
-        name: 'Product 6',
-        spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        startDate: '2011-01-01',
-        endDate: '9999-02-02',
-        spaceLocation: TestUtils.southfield,
-        assignments: TestUtils.assignmentsFilterTest,
-        archived: false,
-        tags: [TestUtils.productTag2],
-        notes: 'note',
-    };
-
-    static products: Array<Product> = [
-        TestUtils.unassignedProduct,
-        TestUtils.productWithAssignments,
-        TestUtils.productForHank,
-        TestUtils.productWithoutAssignments,
-        TestUtils.archivedProduct,
-        TestUtils.productWithoutLocation,
-    ];
-
-    static notEmptyProducts: Array<Product> = [
-        TestUtils.productWithAssignments,
-    ];
-
-    static productsForBoard2: Array<Product> = [
-        {
-            id: 2,
-            name: 'Product 2',
-            spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-            startDate: '',
-            endDate: '',
-            spaceLocation: TestUtils.detroit,
-            assignments: [],
-            archived: false,
-            tags: [],
-        },
-    ];
-
-    static space: Space = {
-        id: 1,
-        uuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
-        name: 'testSpace',
-        lastModifiedDate: TestUtils.originDateString,
-        todayViewIsPublic: true,
-    }
-
-    static spaceMappingsArray: UserSpaceMapping[] = [
-        {id: '1', spaceUuid: TestUtils.space.uuid!, userId: 'user_id', permission: 'owner'},
-        {id: '2', spaceUuid: TestUtils.space.uuid!, userId: 'user_id_2', permission: 'editor'},
-    ];
-
-
-    static allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions> = [
-        {
-            label:'Location Tags:',
-            options: [{
-                label: 'Ann Arbor',
-                value: '1_Ann Arbor',
-                selected: true,
-            }],
-        },
-        {
-            label:'Product Tags:',
-            options: [],
-        },
-        {
-            label:'Role Tags:',
-            options: [],
-        },
-        {
-            label:'Person Tags:',
-            options: [],
-        },
-    ]
-
-    static expectedCreateOptionText(expectedCreationString: string): string {
-        return `Create "${expectedCreationString}"`;
-    }
+function expectedCreateOptionText(expectedCreationString: string): string {
+    return `Create "${expectedCreationString}"`;
+}
+
+const TestUtils = {
+    mockClientCalls,
+    renderPeopleMoverComponent,
+    renderWithRecoil,
+    renderWithRedux,
+    createDataTestId,
+    mockCreateRange,
+    expectedCreateOptionText
 }
 
 export default TestUtils;

--- a/ui/src/Utils/TestUtils.tsx
+++ b/ui/src/Utils/TestUtils.tsx
@@ -42,10 +42,6 @@ function mockClientCalls(): void {
     PeopleClient.updatePerson = jest.fn().mockResolvedValue({data: {}});
     PeopleClient.removePerson = jest.fn().mockResolvedValue({data: {}});
 
-    SpaceClient.removeUser = jest.fn().mockResolvedValue({data: {}});
-    SpaceClient.getSpaceFromUuid = jest.fn().mockResolvedValue({data: TestData.space});
-    SpaceClient.getUsersForSpace = jest.fn().mockResolvedValue(TestData.spaceMappingsArray);
-
     AssignmentClient.createAssignmentForDate = jest.fn().mockResolvedValue({ data: [TestData.assignmentForPerson1] });
     AssignmentClient.getAssignmentsUsingPersonIdAndDate = jest.fn().mockResolvedValue({ data: [{...TestData.assignmentForPerson1}] });
     AssignmentClient.getAssignmentEffectiveDates = jest.fn().mockResolvedValue({

--- a/ui/src/Utils/TestUtils.tsx
+++ b/ui/src/Utils/TestUtils.tsx
@@ -22,7 +22,6 @@ import AssignmentClient from '../Assignments/AssignmentClient';
 import RoleClient from '../Roles/RoleClient';
 import ColorClient from '../Roles/ColorClient';
 import LocationClient from '../Locations/LocationClient';
-import ProductClient from '../Products/ProductClient';
 import ProductTagClient from '../Tags/ProductTag/ProductTagClient';
 import PersonTagClient from '../Tags/PersonTag/PersonTagClient';
 import {applyMiddleware, createStore, PreloadedState, Store} from 'redux';
@@ -79,15 +78,6 @@ function mockClientCalls(): void {
     LocationClient.add = jest.fn().mockResolvedValue({ data: { id: 11, name: 'Ahmedabad' } });
     LocationClient.edit = jest.fn().mockResolvedValue({ data: { id: 1, name: 'Saline' } });
     LocationClient.delete = jest.fn().mockResolvedValue({ data: {} });
-
-    // @todo DELETE THESE 4 ME ON FRIDAY
-    ProductClient.createProduct = jest.fn().mockResolvedValue({ data: {} });
-    ProductClient.deleteProduct = jest.fn().mockResolvedValue({ data: {} });
-    ProductClient.editProduct = jest.fn().mockResolvedValue({ data: {} });
-    ProductClient.getProductsForDate = jest.fn().mockResolvedValue({ data: TestData.products });
-
-
-
 
     ProductTagClient.get = jest.fn().mockResolvedValue({ data: TestData.productTags });
     ProductTagClient.add = jest.fn().mockResolvedValue({ data: {id: 9, name: 'Fin Tech'} });


### PR DESCRIPTION
## Issue
Resolves N/A

I started writing tests for the hooks we have so far, but was coming up against some issues when I tried to manually mock the ProductService and decided to address those issues so I can slowly move towards moving all mocking of services to jest manual mocks. This means putting a `__mocks__` folder right next to the service I'm wanting to mock, and then mocking that client in a file with the same name. 
Example:
```
__mocks__/ProductService.ts <-- mocked file
ProductService.ts <-- real file
```
I was trying to use our TestUtils data in the mocked file, but it was having issues since TestUtils is a tsx file vs a ts file. So I moved all the test data into a TestData.ts file and left all the test functions in TestUtils.

I aim to slowly delete some of the test utils functions, namely, `mockClientCalls` which is mocking out all of the different services at once. This is not how jest suggests doing it, and makes it hard to know which services actually are being used in a test.

For more information on jest manual mocks, see this page: https://jestjs.io/docs/manual-mocks

## What was done
- [x] Moved test data out of `TestUtils.tsx` and into `TestData.ts`
- [x] Removed ProductClient and SpaceClient from the TestUtils.mockClientCalls method and transitioned to jest manual mocks for those files
- [x] Wrote unit tests for the `useFetchProducts` and `useFetchUserSpaces` hooks 

## How to test
1.

