### PR TITLE
Move global storage of Roles from redux to recoil

### DIFF
--- a/ui/src/Assignments/Unassigned.test.tsx
+++ b/ui/src/Assignments/Unassigned.test.tsx
@@ -30,6 +30,7 @@ import {PeopleState} from '../State/PeopleState';
 jest.mock('../Products/ProductClient');
 jest.mock('../Space/SpaceClient');
 jest.mock('../People/PeopleClient');
+jest.mock('../Roles/RoleClient');
 
 describe('Unassigned Products', () => {
     const submitFormButtonText = 'Add';

--- a/ui/src/Hooks/useFetchRoles.test.tsx
+++ b/ui/src/Hooks/useFetchRoles.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {ReactNode} from 'react';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {act, renderHook} from '@testing-library/react-hooks';
+import {RecoilRoot} from 'recoil';
+import useFetchRoles from './useFetchRoles';
+import RoleClient from '../Roles/RoleClient';
+import TestData from '../Utils/TestData';
+
+jest.mock('../Roles/RoleClient');
+
+const teamUUID = 'team-uuid';
+
+const rolesNotAlphabetical = [
+    TestData.productManager,
+    TestData.softwareEngineer,
+    TestData.productDesigner,
+]
+const rolesAlphabetical = TestData.roles;
+
+describe('useFetchRoles Hook', () => {
+    it('should fetch all roles for space and store them in recoil alphabetically', async () => {
+        RoleClient.get = jest.fn().mockResolvedValue({ data: rolesNotAlphabetical })
+
+        const { result } = renderHook(() => useFetchRoles(), { wrapper });
+
+        expect(RoleClient.get).not.toHaveBeenCalled()
+        expect(result.current.roles).toEqual([]);
+
+        await act(async () => {
+            result.current.fetchRoles()
+        });
+        expect(RoleClient.get).toHaveBeenCalledWith(teamUUID);
+        expect(result.current.roles).toEqual(rolesAlphabetical);
+    });
+});
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[`/${teamUUID}`]}>
+        <RecoilRoot>
+            <Routes>
+                <Route path="/:teamUUID" element={children} />
+            </Routes>
+        </RecoilRoot>
+    </MemoryRouter>
+);

--- a/ui/src/Hooks/useFetchRoles.tsx
+++ b/ui/src/Hooks/useFetchRoles.tsx
@@ -35,7 +35,7 @@ function useFetchRoles(): UseFetchRoles {
     const fetchRoles = useCallback(() => {
         RoleClient.get(teamUUID)
             .then(result => {
-                const roles: Array<RoleTag> = result.data || [];
+                const roles: Array<RoleTag> = [...result.data];
                 sortTagsAlphabetically(roles);
                 setRoles(roles)
             })

--- a/ui/src/Hooks/useFetchRoles.tsx
+++ b/ui/src/Hooks/useFetchRoles.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Ford Motor Company
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {useRecoilState} from 'recoil';
+import {useCallback} from 'react';
+import {useParams} from 'react-router-dom';
+import RoleClient from '../Roles/RoleClient';
+import {RolesState} from '../State/RolesState';
+import {RoleTag} from '../Roles/RoleTag.interface';
+import sortTagsAlphabetically from '../Tags/sortTagsAlphabetically';
+
+interface UseFetchRoles {
+    roles: RoleTag[];
+    fetchRoles(): void
+}
+
+function useFetchRoles(): UseFetchRoles {
+    const { teamUUID = '' } = useParams<{ teamUUID: string }>();
+    const [roles, setRoles] = useRecoilState(RolesState);
+
+    const fetchRoles = useCallback(() => {
+        RoleClient.get(teamUUID)
+            .then(result => {
+                const roles: Array<RoleTag> = result.data || [];
+                sortTagsAlphabetically(roles);
+                setRoles(roles)
+            })
+            .catch(console.error);
+    }, [setRoles, teamUUID])
+
+    return {
+        roles: roles || [],
+        fetchRoles
+    };
+}
+
+export default useFetchRoles;

--- a/ui/src/People/ArchivedPersonDrawer.test.tsx
+++ b/ui/src/People/ArchivedPersonDrawer.test.tsx
@@ -27,6 +27,7 @@ import {PeopleState} from '../State/PeopleState';
 
 jest.mock('../Products/ProductClient');
 jest.mock('../Space/SpaceClient');
+jest.mock('../Roles/RoleClient');
 
 describe('Archived People', () => {
     const mayFourteen2020: Date = new Date(2020, 4, 14);

--- a/ui/src/People/People.test.tsx
+++ b/ui/src/People/People.test.tsx
@@ -38,6 +38,7 @@ declare let window: MatomoWindow;
 jest.mock('../Products/ProductClient');
 jest.mock('../People/PeopleClient');
 jest.mock('../Space/SpaceClient');
+jest.mock('../Roles/RoleClient');
 
 describe('People actions', () => {
     const initialState: PreloadedState<Partial<GlobalStateProps>> = {currentSpace: TestData.space};

--- a/ui/src/People/PersonForm.tsx
+++ b/ui/src/People/PersonForm.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Ford Motor Company
+ * Copyright (c) 2022 Ford Motor Company
  * All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ import AssignmentClient from '../Assignments/AssignmentClient';
 import RoleClient from '../Roles/RoleClient';
 import PeopleClient from './PeopleClient';
 import {connect} from 'react-redux';
-import {closeModalAction, fetchRolesAction, setAllGroupedTagFilterOptionsAction} from '../Redux/Actions';
+import {closeModalAction, setAllGroupedTagFilterOptionsAction} from '../Redux/Actions';
 import {GlobalStateProps} from '../Redux/Reducers';
 import {AxiosResponse} from 'axios';
 import {emptyPerson, isArchived, Person} from './Person';
@@ -57,6 +57,7 @@ import {ViewingDateState} from '../State/ViewingDateState';
 import {IsUnassignedDrawerOpenState} from '../State/IsUnassignedDrawerOpenState';
 import {ProductsState} from '../State/ProductsState';
 import {PeopleState} from '../State/PeopleState';
+import useFetchRoles from '../Hooks/useFetchRoles';
 
 interface Props {
     isEditPersonForm: boolean
@@ -65,11 +66,9 @@ interface Props {
     personEdited?: Person;
     currentSpace: Space;
     allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions>;
-    roles: Array<RoleTag>;
 
     closeModal(): void;
     setAllGroupedTagFilterOptions(groupedTagFilterOptions: Array<AllGroupedTagFilterOptions>): void;
-    fetchRoles(): Array<RoleTag>;
 }
 
 function PersonForm({
@@ -81,13 +80,13 @@ function PersonForm({
     closeModal,
     allGroupedTagFilterOptions,
     setAllGroupedTagFilterOptions,
-    roles,
-    fetchRoles,
 }: Props): JSX.Element {
     const products = useRecoilValue(ProductsState);
     const viewingDate = useRecoilValue(ViewingDateState);
     const setIsUnassignedDrawerOpen = useSetRecoilState(IsUnassignedDrawerOpenState);
     const setPeople = useSetRecoilState(PeopleState);
+
+    const { fetchRoles, roles } = useFetchRoles();
 
     const spaceUuid = currentSpace.uuid!;
     const { ROLE_TAGS } = MetadataReactSelectProps;
@@ -454,14 +453,12 @@ function PersonForm({
 const mapStateToProps = (state: GlobalStateProps) => ({
     currentSpace: state.currentSpace,
     allGroupedTagFilterOptions: state.allGroupedTagFilterOptions,
-    roles: state.roles,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
     closeModal: () => dispatch(closeModalAction()),
     setAllGroupedTagFilterOptions: (allGroupedTagFilterOptions: Array<AllGroupedTagFilterOptions>) =>
         dispatch(setAllGroupedTagFilterOptionsAction(allGroupedTagFilterOptions)),
-    fetchRoles: () => dispatch(fetchRolesAction()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(PersonForm);

--- a/ui/src/PeopleMover/ArchivedProduct.test.tsx
+++ b/ui/src/PeopleMover/ArchivedProduct.test.tsx
@@ -23,6 +23,7 @@ import {fireEvent, screen} from '@testing-library/react';
 
 jest.mock('../Space/SpaceClient');
 jest.mock('../Products/ProductClient');
+jest.mock('../Roles/RoleClient');
 
 describe('Archive Products', () => {
     describe('integration tests', () => {

--- a/ui/src/PeopleMover/LocalStorageFilters.test.tsx
+++ b/ui/src/PeopleMover/LocalStorageFilters.test.tsx
@@ -24,6 +24,7 @@ import TestUtils from '../Utils/TestUtils';
 
 jest.mock('../Products/ProductClient');
 jest.mock('../Space/SpaceClient');
+jest.mock('../Roles/RoleClient');
 
 describe('Filter products', () => {
     class MockLocalStorage {

--- a/ui/src/PeopleMover/PeopleMover.test.tsx
+++ b/ui/src/PeopleMover/PeopleMover.test.tsx
@@ -34,6 +34,7 @@ declare let window: MatomoWindow;
 jest.mock('../Space/SpaceClient');
 jest.mock('../Products/ProductClient');
 jest.mock('../People/PeopleClient');
+jest.mock('../Roles/RoleClient');
 
 const mockedUsedNavigate = jest.fn();
 

--- a/ui/src/PeopleMover/PeopleMover.tsx
+++ b/ui/src/PeopleMover/PeopleMover.tsx
@@ -25,7 +25,6 @@ import {
     fetchLocationsAction,
     fetchPersonTagsAction,
     fetchProductTagsAction,
-    fetchRolesAction,
     setCurrentModalAction,
     setupSpaceAction,
 } from '../Redux/Actions';
@@ -46,7 +45,6 @@ import {AvailableModals} from '../Modal/AvailableModals';
 import Counter from '../ReusableComponents/Counter';
 import {AllGroupedTagFilterOptions} from '../SortingAndFiltering/FilterLibraries';
 import HeaderContainer from '../Header/HeaderContainer';
-import {RoleTag} from '../Roles/RoleTag.interface';
 import ArchivedPersonDrawer from '../People/ArchivedPersonDrawer';
 import {useRecoilValue} from 'recoil';
 import {ViewingDateState} from '../State/ViewingDateState';
@@ -56,6 +54,7 @@ import useFetchPeople from '../Hooks/useFetchPeople';
 
 import '../Styles/Main.scss';
 import './PeopleMover.scss';
+import useFetchRoles from '../Hooks/useFetchRoles';
 
 const BAD_REQUEST = 400;
 const FORBIDDEN = 403;
@@ -67,7 +66,6 @@ export interface PeopleMoverProps {
     fetchProductTags(): Array<Tag>;
     fetchPersonTags(): Array<Tag>;
     fetchLocations(): Array<LocationTag>;
-    fetchRoles(): Array<RoleTag>;
     setCurrentModal(modalState: CurrentModalState): void;
     setSpace(space: Space): void;
 }
@@ -79,7 +77,6 @@ function PeopleMover({
     fetchProductTags,
     fetchPersonTags,
     fetchLocations,
-    fetchRoles,
     setSpace,
     setCurrentModal,
 }: PeopleMoverProps): JSX.Element {
@@ -90,6 +87,7 @@ function PeopleMover({
     const isReadOnly = useRecoilValue(IsReadOnlyState);
 
     const { fetchPeople } = useFetchPeople();
+    const { fetchRoles } = useFetchRoles();
     const { fetchProducts, products } = useFetchProducts();
 
     const hasProductsAndFilters: boolean = products && products.length > 0 && currentSpace && allGroupedTagFilterOptions.length > 0;
@@ -195,7 +193,6 @@ const mapDispatchToProps = (dispatch: any) => ({
     fetchProductTags: () => dispatch(fetchProductTagsAction()),
     fetchPersonTags: () => dispatch(fetchPersonTagsAction()),
     fetchLocations: () => dispatch(fetchLocationsAction()),
-    fetchRoles: () => dispatch(fetchRolesAction()),
     setSpace: (space: Space) => dispatch(setupSpaceAction(space)),
     setCurrentModal: (modalState: CurrentModalState) => dispatch(setCurrentModalAction(modalState)),
 });

--- a/ui/src/Products/Product.test.tsx
+++ b/ui/src/Products/Product.test.tsx
@@ -37,6 +37,7 @@ import {IsReadOnlyState} from '../State/IsReadOnlyState';
 
 jest.mock('./ProductClient');
 jest.mock('../Space/SpaceClient');
+jest.mock('../Roles/RoleClient');
 
 describe('Products', () => {
     const addProductButtonText = 'Add Product';

--- a/ui/src/Redux/Actions/Actions.test.tsx
+++ b/ui/src/Redux/Actions/Actions.test.tsx
@@ -20,14 +20,12 @@ import {
     fetchLocationsAction,
     fetchPersonTagsAction,
     fetchProductTagsAction,
-    fetchRolesAction,
     setupSpaceAction,
 } from './index';
 import configureStore, {MockStoreCreator, MockStoreEnhanced} from 'redux-mock-store';
 import TestData from '../../Utils/TestData';
 import thunk from 'redux-thunk';
 import * as filterConstants from '../../SortingAndFiltering/FilterLibraries';
-import RoleClient from '../../Roles/RoleClient';
 import {AxiosResponse} from 'axios';
 import LocationClient from '../../Locations/LocationClient';
 import PersonTagClient from '../../Tags/PersonTag/PersonTagClient';
@@ -112,24 +110,6 @@ describe('Actions', () => {
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return store.dispatch<any>(fetchLocationsAction()).then(() => {
-                expect(mock).toHaveBeenCalledTimes(1);
-                expect(mock).toHaveBeenCalledWith(TestData.space.uuid);
-                expect(store.getActions()).toEqual(expectedActions);
-            });
-        });
-    });
-
-    describe('fetchRolesAction', () => {
-        it('should invoke RoleClient.get and fire the setRoles Action', () => {
-            const mock = jest.spyOn(RoleClient, 'get');
-            mock.mockReturnValueOnce(Promise.resolve({data: TestData.roles} as AxiosResponse));
-
-            const expectedActions = [
-                {type: AvailableActions.SET_ROLES, roles: TestData.roles},
-            ];
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            return store.dispatch<any>(fetchRolesAction()).then(() => {
                 expect(mock).toHaveBeenCalledTimes(1);
                 expect(mock).toHaveBeenCalledWith(TestData.space.uuid);
                 expect(store.getActions()).toEqual(expectedActions);

--- a/ui/src/Redux/Actions/index.ts
+++ b/ui/src/Redux/Actions/index.ts
@@ -26,8 +26,6 @@ import {LocationTag} from '../../Locations/LocationTag.interface';
 import LocationClient from '../../Locations/LocationClient';
 import {AllGroupedTagFilterOptions, getFilterOptionsForSpace} from '../../SortingAndFiltering/FilterLibraries';
 import PersonTagClient from '../../Tags/PersonTag/PersonTagClient';
-import {RoleTag} from '../../Roles/RoleTag.interface';
-import RoleClient from '../../Roles/RoleClient';
 import sortTagsAlphabetically from '../../Tags/sortTagsAlphabetically';
 
 export enum AvailableActions {
@@ -40,7 +38,6 @@ export enum AvailableActions {
     SET_PRODUCT_TAGS,
     SET_PERSON_TAGS,
     SET_LOCATIONS,
-    SET_ROLES,
 }
 
 export const setCurrentModalAction = (modalState: CurrentModalState) => ({
@@ -88,11 +85,6 @@ export const setLocationsAction = (locations: Array<LocationTag>) => ({
     locations,
 });
 
-export const setRolesAction = (roles: Array<RoleTag>) => ({
-    type: AvailableActions.SET_ROLES,
-    roles,
-});
-
 export const fetchProductTagsAction: ActionCreator<ThunkAction<void, Function, null, Action<string>>> = () =>
     (dispatch: Dispatch, getState: Function): Promise<void> => {
         return ProductTagClient.get(getState().currentSpace.uuid!,)
@@ -121,16 +113,6 @@ export const fetchLocationsAction: ActionCreator<ThunkAction<void, Function, nul
                 const locations: Array<LocationTag> = result.data || [];
                 sortTagsAlphabetically(locations);
                 dispatch(setLocationsAction(locations));
-            });
-    };
-
-export const fetchRolesAction: ActionCreator<ThunkAction<void, Function, null, Action<string>>> = () =>
-    (dispatch: Dispatch, getState: Function): Promise<void> => {
-        return RoleClient.get(getState().currentSpace.uuid,)
-            .then(result => {
-                const roles: Array<RoleTag> = result.data || [];
-                sortTagsAlphabetically(roles);
-                dispatch(setRolesAction(roles));
             });
     };
 

--- a/ui/src/Redux/Reducers/index.ts
+++ b/ui/src/Redux/Reducers/index.ts
@@ -28,8 +28,6 @@ import {Space} from '../../Space/Space';
 import {Tag} from '../../Tags/Tag';
 import {LocationTag} from '../../Locations/LocationTag.interface';
 import {AllGroupedTagFilterOptions} from '../../SortingAndFiltering/FilterLibraries';
-import {RoleTag} from '../../Roles/RoleTag.interface';
-import rolesReducer from './rolesReducer';
 
 export default combineReducers({
     currentModal: currentModalReducer,
@@ -39,7 +37,6 @@ export default combineReducers({
     productTags: productTagsReducer,
     personTags: personTagsReducer,
     locations: locationsReducer,
-    roles: rolesReducer,
 });
 
 export interface GlobalStateProps {
@@ -50,7 +47,6 @@ export interface GlobalStateProps {
     productTags: Array<Tag>;
     personTags: Array<Tag>;
     locations: Array<LocationTag>;
-    roles: Array<RoleTag>;
 }
 
 

--- a/ui/src/Roles/RoleModal.test.tsx
+++ b/ui/src/Roles/RoleModal.test.tsx
@@ -27,6 +27,8 @@ import {RecoilRoot} from 'recoil';
 import {RolesState} from '../State/RolesState';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 
+jest.mock('../Roles/RoleClient');
+
 describe('My Roles Form', () => {
     const initialState = {currentSpace: TestData.space, allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions};
 

--- a/ui/src/Roles/RoleModal.test.tsx
+++ b/ui/src/Roles/RoleModal.test.tsx
@@ -22,17 +22,31 @@ import {findByTestId, findByText, fireEvent, screen, waitFor} from '@testing-lib
 import RoleClient from './RoleClient';
 import {RoleAddRequest} from './RoleAddRequest.interface';
 import MyRolesForm from './MyRolesForm';
-import * as Actions from '../Redux/Actions';
 import ColorClient from '../Roles/ColorClient';
+import {RecoilRoot} from 'recoil';
+import {RolesState} from '../State/RolesState';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
 
 describe('My Roles Form', () => {
-    const initialState = {currentSpace: TestData.space, allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions, roles: TestData.roles};
+    const initialState = {currentSpace: TestData.space, allGroupedTagFilterOptions: TestData.allGroupedTagFilterOptions};
 
     beforeEach(async () => {
         jest.clearAllMocks();
         TestUtils.mockClientCalls();
 
-        renderWithRedux(<MyRolesForm/>, undefined, initialState);
+        renderWithRedux(
+            <RecoilRoot initializeState={({set}) => {
+                set(RolesState, TestData.roles)
+            }}>
+                <MemoryRouter initialEntries={['/' + TestData.space.uuid]}>
+                    <Routes>
+                        <Route path="/:teamUUID" element={<MyRolesForm/>} />
+                    </Routes>
+                </MemoryRouter>
+            </RecoilRoot>,
+            undefined,
+            initialState
+        );
 
         await waitFor(() => expect(ColorClient.getAllColors).toHaveBeenCalled());
     });
@@ -92,8 +106,6 @@ describe('My Roles Form', () => {
         });
 
         it('should make role with white color if user never changed color option', async () => {
-            const fetchRolesActionFn = jest.spyOn(Actions, 'fetchRolesAction');
-
             const expectedNewRoleName = 'Architecture';
 
             const addNewRoleButton = await screen.findByText('Add New Role');
@@ -115,9 +127,8 @@ describe('My Roles Form', () => {
             };
             expect(RoleClient.add).toHaveBeenCalledTimes(1);
             expect(RoleClient.add).toHaveBeenCalledWith(expectedRoleAddRequest, initialState.currentSpace);
-            expect(RoleClient.get).toHaveBeenCalledTimes(1);
-            expect(RoleClient.get).toHaveBeenCalledWith(initialState.currentSpace.uuid);
-            expect(fetchRolesActionFn).toHaveBeenCalledTimes(1);
+            await waitFor(() => expect(RoleClient.get).toHaveBeenCalledTimes(1));
+            expect(RoleClient.get).toHaveBeenCalledWith(initialState.currentSpace.uuid)
         });
 
         it('should not allow saving empty role', async () => {

--- a/ui/src/Roles/RoleTags.tsx
+++ b/ui/src/Roles/RoleTags.tsx
@@ -30,17 +30,18 @@ import {connect} from 'react-redux';
 import {Space} from '../Space/Space';
 import {INACTIVE_EDIT_STATE_INDEX} from '../Tags/MyTagsForm';
 import {RoleEditRequest} from './RoleEditRequest.interface';
-import {fetchRolesAction, setupSpaceAction} from '../Redux/Actions';
+import {setupSpaceAction} from '../Redux/Actions';
+import useFetchRoles from '../Hooks/useFetchRoles';
 
 interface Props {
     colors: Array<Color>;
-    roles: Array<RoleTag>;
-    fetchRoles(): Array<RoleTag>;
     updateFilterOptions(index: number, tag: TagInterface): void;
     currentSpace: Space;
 }
 
-const RoleTags = ({ colors, roles, fetchRoles, updateFilterOptions, currentSpace }: Props): JSX.Element => {
+const RoleTags = ({ colors, updateFilterOptions, currentSpace }: Props): JSX.Element => {
+    const { fetchRoles, roles } = useFetchRoles();
+
     const tagType = 'role';
     const roleFiltersIndex = 2;
     const [editRoleIndex, setEditRoleIndex] = useState<number>(INACTIVE_EDIT_STATE_INDEX);
@@ -77,7 +78,7 @@ const RoleTags = ({ colors, roles, fetchRoles, updateFilterOptions, currentSpace
             colorId: role.colorId,
         };
         return await RoleClient.add(newRole, currentSpace)
-            .then((response) => {
+            .then(() => {
                 fetchRoles();
                 returnToViewState();
             });
@@ -158,11 +159,9 @@ const RoleTags = ({ colors, roles, fetchRoles, updateFilterOptions, currentSpace
 /* eslint-disable */
 const mapStateToProps = (state: GlobalStateProps) => ({
     currentSpace: state.currentSpace,
-    roles: state.roles,
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
-    fetchRoles: () => dispatch(fetchRolesAction()),
     setSpace: (space: Space) => dispatch(setupSpaceAction(space)),
 });
 

--- a/ui/src/Roles/__mocks__/RoleClient.ts
+++ b/ui/src/Roles/__mocks__/RoleClient.ts
@@ -15,18 +15,10 @@
  * limitations under the License.
  */
 
-import {AvailableActions} from '../Actions';
-import sortTagsAlphabetically from '../../Tags/sortTagsAlphabetically';
-import {RoleTag} from '../../Roles/RoleTag.interface';
+import TestData from '../../Utils/TestData';
 
-const rolesReducer = (state: Array<RoleTag> = [], action: {type: AvailableActions; roles: Array<RoleTag>} ): Array<RoleTag> => {
-    if (action.type === AvailableActions.SET_ROLES) {
-        const roles = [...action.roles];
-        sortTagsAlphabetically(roles);
-        return roles;
-    } else {
-        return state;
-    }
-};
+const RoleClient = {
+    get: jest.fn().mockResolvedValue({ data: TestData.roles })
+}
 
-export default rolesReducer;
+export default RoleClient;

--- a/ui/src/Roles/__mocks__/RoleClient.ts
+++ b/ui/src/Roles/__mocks__/RoleClient.ts
@@ -18,7 +18,14 @@
 import TestData from '../../Utils/TestData';
 
 const RoleClient = {
-    get: jest.fn().mockResolvedValue({ data: TestData.roles })
+    get: jest.fn().mockResolvedValue({ data: [...TestData.roles] }),
+    add: jest.fn().mockResolvedValue({
+        data: {name: 'Product Owner', id: 1, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: {color: '1', id: 2}},
+    }),
+    edit: jest.fn().mockResolvedValue({
+        data: {name: 'Architecture', id: 1, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestData.color3},
+    }),
+    delete:  jest.fn().mockResolvedValue({ data: {} })
 }
 
 export default RoleClient;

--- a/ui/src/State/RolesState.ts
+++ b/ui/src/State/RolesState.ts
@@ -1,0 +1,24 @@
+/*
+* Copyright (c) 2022 Ford Motor Company
+* All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import {atom} from 'recoil';
+import {RoleTag} from '../Roles/RoleTag.interface';
+
+export const RolesState = atom<RoleTag[]>({
+    key: 'RolesState',
+    default: [],
+});

--- a/ui/src/Utils/TestUtils.tsx
+++ b/ui/src/Utils/TestUtils.tsx
@@ -18,7 +18,6 @@
 import React from 'react';
 import SpaceClient from '../Space/SpaceClient';
 import AssignmentClient from '../Assignments/AssignmentClient';
-import RoleClient from '../Roles/RoleClient';
 import ColorClient from '../Roles/ColorClient';
 import LocationClient from '../Locations/LocationClient';
 import ProductTagClient from '../Tags/ProductTag/ProductTagClient';
@@ -46,20 +45,6 @@ function mockClientCalls(): void {
     });
     AssignmentClient.getReassignments = jest.fn().mockResolvedValue({ data: [] });
     AssignmentClient.getAssignmentsV2ForSpaceAndPerson = jest.fn().mockResolvedValue({ data: [] });
-
-
-    RoleClient.get = jest.fn().mockResolvedValue({ data: [
-        {id: 1, name: 'Software Engineer', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestData.color1},
-        {id: 2, name: 'Product Manager', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestData.color2},
-        {id: 3, name: 'Product Designer', spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestData.color3},
-    ]});
-    RoleClient.add = jest.fn().mockResolvedValue({
-        data: {name: 'Product Owner', id: 1, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: {color: '1', id: 2}},
-    });
-    RoleClient.edit = jest.fn().mockResolvedValue({
-        data: {name: 'Architecture', id: 1, spaceUuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  color: TestData.color3},
-    });
-    RoleClient.delete = jest.fn().mockResolvedValue({ data: {} });
 
     ColorClient.getAllColors = jest.fn().mockResolvedValue({ data: TestData.colors });
 


### PR DESCRIPTION
## Issue
Resolves N/A

## What was done
- [x] Moves global storage of Roles from redux to recoil

## How to test
1. Ensure nothing functionally has changed and you can still move people around as usual