### PR TITLE
Remove redirect client

### DIFF
--- a/ui/cypress/e2e/share_access_form.cy.ts
+++ b/ui/cypress/e2e/share_access_form.cy.ts
@@ -104,11 +104,13 @@ describe('Share Access Form', () => {
             cy.get('[data-testid=userListItem__ELISE]').should('not.exist');
         });
 
-        it('Transferring ownership to an editor should change current owner to editor', () => {
+        it('Transferring ownership', () => {
             cy.server();
             cy.route('POST', Cypress.env('API_USERS_PATH')).as('postAddPersonToSpace');
             cy.route('PUT', `${Cypress.env('API_USERS_PATH')}/ELISE`).as('putChangeOwner');
             cy.route('GET', Cypress.env('API_USERS_PATH')).as('getAllUsers');
+
+            cy.log('**Transferring ownership to an editor should change current owner to editor**');
 
             cy.get('[id=employeeIdTextArea]').focus().type('Elise', {force: true});
             cy.get('[data-testid=inviteEditorsFormSubmitButton]').should('not.be.disabled').click();
@@ -132,7 +134,8 @@ describe('Share Access Form', () => {
                 .find(':contains("Editor")').eq(0)
                 .click();
 
-            cy.get('[data-testid=userAccessOptionLabel]').eq(1).should('contain.text', 'Owner')
+            cy.get('[data-testid=userAccessOptionLabel]').eq(1)
+                .should('contain.text', 'Owner')
                 .click();
 
             cy.get('[data-testid=confirmDeleteButton]').should('contain.text', 'Yes').click();
@@ -155,6 +158,21 @@ describe('Share Access Form', () => {
                 .should('contain.text', 'ELISE');
             cy.get('[data-testid=userListItem__ELISE]')
                 .should('contain.text', 'owner');
+
+            cy.log('**Removing current user from space should direct user to dashboard**');
+            cy.get('[data-testid=userListItem__USER_ID]')
+                .should('contain.text', 'USER_ID')
+                .find(':contains("Editor")').eq(0)
+                .click();
+            cy.get('[data-testid=userAccessOptionLabel]').eq(1)
+                .should('contain.text', 'Remove')
+                .click();
+            cy.contains('Do you still want to remove yourself as editor?').should('exist');
+            cy.contains('Yes').click();
+
+            cy.log('**The space current user was removed from should no longer be on dashboard**');
+            cy.url().should('eq', Cypress.config().baseUrl + '/user/dashboard');
+            cy.contains('Flipping Sweet').should('not.exist');
         });
     });
 });

--- a/ui/src/AccountDropdown/ShareAccessForm/InviteEditorsFormSection/InviteEditorsFormSection.test.tsx
+++ b/ui/src/AccountDropdown/ShareAccessForm/InviteEditorsFormSection/InviteEditorsFormSection.test.tsx
@@ -22,7 +22,6 @@ import InviteEditorsFormSection from './InviteEditorsFormSection';
 import {fireEvent, screen, waitFor, within} from '@testing-library/react';
 import Cookies from 'universal-cookie';
 import SpaceClient from 'Services/Api/SpaceClient';
-import RedirectClient from 'Utils/RedirectClient';
 import {Space} from 'Types/Space';
 import {CurrentUserState} from 'State/CurrentUserState';
 import {CurrentSpaceState} from '../../../State/CurrentSpaceState';
@@ -36,7 +35,6 @@ describe('Invite Editors Form', function() {
         SpaceClient.getUsersForSpace = jest.fn().mockResolvedValue(TestData.spaceMappingsArray);
 
         cookies.set('accessToken', '123456');
-        RedirectClient.redirect = jest.fn();
     });
 
     describe('Feature toggle enabled', () => {
@@ -272,6 +270,11 @@ describe('Invite Editors Form', function() {
         });
 
         it('should show a confirmation modal when removing self', async () => {
+            const location = window.location;
+            Reflect.deleteProperty(window, 'location');
+            Object.defineProperty(window, 'location', {
+                value: { pathname: '/' }, writable: true,
+            });
             const currentUser = 'USER_ID_2';
             await renderComponent(currentUser);
             const editorRow = within(await screen.findByTestId(`userListItem__user_id_2`));
@@ -286,7 +289,8 @@ describe('Invite Editors Form', function() {
 
             await waitFor(() => expect(SpaceClient.removeUser).toHaveBeenCalledWith(TestData.space, TestData.spaceMappingsArray[1]));
             expect(screen.queryByText('Are you sure?')).not.toBeInTheDocument();
-            expect(RedirectClient.redirect).toHaveBeenCalledWith('/user/dashboard');
+            await waitFor(() => expect(window.location.pathname).toBe('/user/dashboard'));
+            window.location = location;
         });
 
         it('should show a confirmation modal when removing editor access', async () => {

--- a/ui/src/ReusableComponents/RedirectWrapper.tsx
+++ b/ui/src/ReusableComponents/RedirectWrapper.tsx
@@ -16,14 +16,13 @@
  */
 
 import React from 'react';
-import RedirectClient from '../Utils/RedirectClient';
 
 interface RedirectWrapperProps {
     redirectUrl: string;
 }
 
 function RedirectWrapper({redirectUrl}: RedirectWrapperProps): JSX.Element {
-    RedirectClient.redirect(redirectUrl);
+    window.location.href = redirectUrl;
     return (<></>);
 }
 

--- a/ui/src/ReusableComponents/UserAccessList.tsx
+++ b/ui/src/ReusableComponents/UserAccessList.tsx
@@ -24,12 +24,11 @@ import {
 import React, {CSSProperties, useState} from 'react';
 import {Space} from 'Types/Space';
 import {UserSpaceMapping} from '../Types/UserSpaceMapping';
-
-import './UserAccessList.scss';
 import SpaceClient from '../Services/Api/SpaceClient';
 import ConfirmationModal from 'Modal/ConfirmationModal/ConfirmationModal';
 import {dashboardUrl} from '../Routes';
-import RedirectClient from '../Utils/RedirectClient';
+
+import './UserAccessList.scss';
 
 interface PermissionType {
     label: string;
@@ -123,7 +122,7 @@ function UserAccessList({
                         (): void => {
                             SpaceClient.removeUser(currentSpace, user).then(() => {
                                 setDisplayRevokeSelfEditorStatusConfirmationModal(false);
-                                RedirectClient.redirect(dashboardUrl);
+                                window.location.pathname = dashboardUrl;
                             });
                         }
                     }

--- a/ui/src/Utils/RedirectClient.ts
+++ b/ui/src/Utils/RedirectClient.ts
@@ -1,8 +1,0 @@
-// @todo yeet
-class RedirectClient {
-    static redirect(redirectUrl: string): void {
-        window.location.href = `${window.location.origin}${redirectUrl}`;
-    }
-}
-
-export default RedirectClient;


### PR DESCRIPTION
## Issue
Resolves N/A

## What was done
- [x] Remove redirect client

## How to test
1. Go to a space, and give another (fake) user access by opening the account dropdown, clicking "Share Access", and opening the "Invite Others to Edit" modal section. 
2. Reopen the "Invite Others to Edit" section and make that new person the "owner", which makes you ("user_id") an editor.
3. Now completely remove you ("user_id") and ensure that you're redirected back to the dashboard and you no longer have access to that space.

NOTE: I wrote a cypress test that does all this so we should be good.