### PR TITLE
Resolve flaky cypress tests

### DIFF
--- a/api/src/main/kotlin/com/ford/internalprojects/peoplemover/E2ETestController.kt
+++ b/api/src/main/kotlin/com/ford/internalprojects/peoplemover/E2ETestController.kt
@@ -1,5 +1,7 @@
 package com.ford.internalprojects.peoplemover
 
+import com.ford.internalprojects.peoplemover.auth.UserSpaceMappingRepository
+import com.ford.internalprojects.peoplemover.space.SpaceRepository
 import com.ford.internalprojects.peoplemover.space.SpaceService
 import io.jsonwebtoken.JwtBuilder
 import io.jsonwebtoken.Jwts
@@ -18,9 +20,10 @@ import java.util.*
 @Controller
 @RequestMapping("/")
 class E2ETestController(
-        private val spaceService: SpaceService,
-        private val localDataGenerator: LocalDataGenerator,
-        private val mockJwtDecoder: JwtDecoder
+    private val spaceRepository: SpaceRepository,
+    private val userSpaceMappingRepository: UserSpaceMappingRepository,
+    private val localDataGenerator: LocalDataGenerator,
+    private val mockJwtDecoder: JwtDecoder
 ) {
 
     @GetMapping
@@ -29,8 +32,14 @@ class E2ETestController(
     }
 
     @DeleteMapping("/api/reset/{uuid}")
-    fun deleteTestSpace(@PathVariable uuid: String): ResponseEntity<Unit> {
-        spaceService.deleteSpace(uuid)
+    fun deleteTestSpaces(@PathVariable uuid: String): ResponseEntity<Unit> {
+        spaceRepository.deleteByUuid(uuid)
+
+        userSpaceMappingRepository.findAllByUserId("USER_ID").let { userSpaceMappings ->
+            for (space in userSpaceMappings) {
+                spaceRepository.deleteByUuid(space.spaceUuid)
+            }
+        }
         localDataGenerator.resetSpace(uuid)
         return ResponseEntity.ok()
                 .header("Set-Cookie", "accessToken=${createJWT()}")

--- a/ui/cypress/e2e/dashboard_page.cy.ts
+++ b/ui/cypress/e2e/dashboard_page.cy.ts
@@ -14,17 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const newSpaceName = 'SpaceShip';
+const flippingSweetSpaceName = 'Flipping Sweet'
 
-describe.skip('The Space Dashboard', () => {
-    const newSpaceName = 'SpaceShip';
-
+describe('The Space Dashboard', () => {
     beforeEach(() => {
-        cy.intercept('GET', Cypress.env('API_USERS_PATH')).as('getSpaceUsers');
         cy.intercept('GET', '/api/spaces/user').as('getSpacesForUser');
 
         cy.visit('/user/dashboard');
 
-        cy.wait(['@getSpaceUsers', '@getSpacesForUser']);
+        cy.wait('@getSpacesForUser');
 
         cy.get('[data-testid="spaceDashboardTile"]').as('spaceTiles');
 
@@ -33,16 +32,16 @@ describe.skip('The Space Dashboard', () => {
                 openDeleteSpaceModal(newSpaceName);
                 cy.get('[data-testid="confirmDeleteButton"]').click();
                 cy.contains('Ok').click({ force: true });
-                cy.wait(['@getSpaceUsers', '@getSpacesForUser']);
+                cy.wait('@getSpacesForUser');
             }
         });
 
         cy.get('@spaceTiles')
             .should('have.length', 1)
-            .should('contain', 'Flipping Sweet');
+            .should('contain', flippingSweetSpaceName);
         cy.get('[data-testid=peopleMoverHeader]')
             .should('contain', 'PEOPLEMOVER')
-            .should('not.contain', 'Flipping Sweet')
+            .should('not.contain', flippingSweetSpaceName)
     })
 
     it('Add a space', () => {
@@ -55,7 +54,7 @@ describe.skip('The Space Dashboard', () => {
     });
 
     it('Edit a space name', () => {
-        openSpaceActionsDropdown();
+        openSpaceActionsDropdown(flippingSweetSpaceName);
         cy.contains('Edit').click();
         cy.get('[data-testid="createSpaceInputField"]').type(' SpaceShip');
         cy.findByText('Save').click();
@@ -68,8 +67,7 @@ describe.skip('The Space Dashboard', () => {
     });
 
     it('Delete a space', () => {
-        const flippingSweetBoardName = 'Flipping Sweet'
-        openDeleteSpaceModal(flippingSweetBoardName);
+        openDeleteSpaceModal(flippingSweetSpaceName);
         cy.contains('Are you sure?').should('exist');
         cy.contains('Transfer Ownership').should('exist');
         cy.get('[data-testid="confirmationModalLeaveAndDeleteSpace"]').click();
@@ -77,13 +75,13 @@ describe.skip('The Space Dashboard', () => {
         cy.wait(['@getSpacesForUser']);
 
         checkPresenceOfDashboardWelcomeMessage(true);
-        cy.contains(flippingSweetBoardName).should('not.exist');
+        cy.contains(flippingSweetSpaceName).should('not.exist');
     });
 
     it('Leave a space (transfer ownership of a space)', () => {
         checkPresenceOfDashboardWelcomeMessage(false);
 
-        openSpaceActionsDropdown();
+        openSpaceActionsDropdown(flippingSweetSpaceName);
         cy.contains('Leave Space').click();
         cy.contains('Transfer Ownership of Space');
         cy.get('[data-testid="transferOwnershipFormRadioControl-BBARKER"]').click();
@@ -113,11 +111,11 @@ function checkPresenceOfDashboardWelcomeMessage(isPresent : boolean) {
     cy.contains('Create New Space').should('exist');
 }
 
-function openSpaceActionsDropdown() {
-    cy.get('[data-testid="ellipsisButton"]').should('exist').click();
+function openSpaceActionsDropdown(spaceName: string) {
+    cy.findByLabelText(`Open Menu for Space ${spaceName}`).click();
 }
 
 function openDeleteSpaceModal(spaceName: string) {
-    cy.findByLabelText(`Open Menu for Space ${spaceName}`).click();
+    openSpaceActionsDropdown(spaceName);
     cy.contains('Delete Space').click();
 }

--- a/ui/cypress/e2e/dashboard_page.cy.ts
+++ b/ui/cypress/e2e/dashboard_page.cy.ts
@@ -27,15 +27,6 @@ describe('The Space Dashboard', () => {
 
         cy.get('[data-testid="spaceDashboardTile"]').as('spaceTiles');
 
-        cy.get('@spaceTiles').then((elements) => {
-            if (elements.length > 1) {
-                openDeleteSpaceModal(newSpaceName);
-                cy.get('[data-testid="confirmDeleteButton"]').click();
-                cy.contains('Ok').click({ force: true });
-                cy.wait('@getSpacesForUser');
-            }
-        });
-
         cy.get('@spaceTiles')
             .should('have.length', 1)
             .should('contain', flippingSweetSpaceName);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -52,7 +52,7 @@
         "@types/react-text-mask": "^5.4.6",
         "awesome-typescript-loader": "^5.2.1",
         "axe-core": "^4.1.1",
-        "cypress": "^10.3.0",
+        "cypress": "^10.3.1",
         "cypress-axe": "^1.0.0",
         "eslint": "^8.15.0",
         "eslint-config-react-app": "^7.0.1",
@@ -8047,9 +8047,9 @@
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "node_modules/cypress": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.0.tgz",
-      "integrity": "sha512-txkQWKzvBVnWdCuKs5Xc08gjpO89W2Dom2wpZgT9zWZT5jXxqPIxqP/NC1YArtkpmp3fN5HW8aDjYBizHLUFvg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.4.0.tgz",
+      "integrity": "sha512-OM7F8MRE01SHQRVVzunid1ZK1m90XTxYnl+7uZfIrB4CYqUDCrZEeSyCXzIbsS6qcaijVCAhqDL60SxG8N6hew==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -31385,9 +31385,9 @@
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "cypress": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.0.tgz",
-      "integrity": "sha512-txkQWKzvBVnWdCuKs5Xc08gjpO89W2Dom2wpZgT9zWZT5jXxqPIxqP/NC1YArtkpmp3fN5HW8aDjYBizHLUFvg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.4.0.tgz",
+      "integrity": "sha512-OM7F8MRE01SHQRVVzunid1ZK1m90XTxYnl+7uZfIrB4CYqUDCrZEeSyCXzIbsS6qcaijVCAhqDL60SxG8N6hew==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/ui/package.json
+++ b/ui/package.json
@@ -81,7 +81,7 @@
     "@types/react-text-mask": "^5.4.6",
     "awesome-typescript-loader": "^5.2.1",
     "axe-core": "^4.1.1",
-    "cypress": "^10.3.0",
+    "cypress": "^10.4.0",
     "cypress-axe": "^1.0.0",
     "eslint": "^8.15.0",
     "eslint-config-react-app": "^7.0.1",


### PR DESCRIPTION
## Issue
Resolves N/A

## What was done
Made the dashboard cypress tests pass consistently by doing the following:
- [x] Updated the [SpaceDashboardTile.tsx](https://github.com/FordLabs/peoplemover/pull/832/files#diff-3d97583b7a5ff97658fefbf56de1c7ba428d73683e6c34c66b2ee04b1fdc3086) so it does not rerender more than once after fetching user data.
- [x] Upgraded cypress to version `10.4.0`
- [x] Updated the E2E test reset endpoint to delete all spaces owned by the test user  

## How to test
1. All cypress tests pass on a regular basis (not considered flaky)