### PR TITLE
Rename tests in AssignmentControllerInTimeApiTest.kt

### DIFF
--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerInTimeApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerInTimeApiTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.internal.util.collections.Sets
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Description
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
@@ -37,7 +38,8 @@ import java.time.format.DateTimeFormatter
 @AutoConfigureMockMvc
 class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     @Test
-    fun `GET should return all assignments for the given personId and a specific date`() {
+    @Description("GET should return all assignments for the given personId and a specific date")
+    fun getAssignmentsByPersonIdAndDate() {
         val oldAssignmentForPerson1: AssignmentV1 = assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -100,7 +102,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `GET should return all assignments for the given personId`() {
+    @Description("GET should return all assignments for the given personId")
+    fun getAssignmentsByPersonId() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -170,7 +173,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `GET should return all assignments for a read only space when requested date is today`() {
+    @Description("GET should return all assignments for a read only space when requested date is today")
+    fun getAssignmentsReadOnlyForToday() {
         val readOnlyAssignment: AssignmentV1 = assignmentRepository.save(
             AssignmentV1(
                 person = personInReadOnlySpace,
@@ -197,7 +201,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `GET should return all assignments for a read only space when requested date is tomorrow`() {
+    @Description("GET should return all assignments for a read only space when requested date is tomorrow")
+    fun getAssignmentsReadOnlyForTomorrow() {
         val tomorrow = LocalDate.now().plusDays(1L).format(DateTimeFormatter.ISO_DATE)
         val readOnlyAssignment: AssignmentV1 = assignmentRepository.save(
             AssignmentV1(
@@ -225,7 +230,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `GET should return all assignments for a read only space when requested date is yesterday`() {
+    @Description("GET should return all assignments for a read only space when requested date is yesterday")
+    fun getAssignmentsReadOnlyForYesterday() {
         val yesterday = LocalDate.now().minusDays(1L).format(DateTimeFormatter.ISO_DATE)
         val readOnlyAssignment: AssignmentV1 = assignmentRepository.save(
             AssignmentV1(
@@ -253,7 +259,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `GET should return FORBIDDEN when a read only user tries to access assignments from a date that is not valid`() {
+    @Description("GET should return FORBIDDEN when a read only user tries to access assignments from a date that is not valid")
+    fun getAssignmentsReturnForbiddenForInvalidDate() {
         mockMvc.perform(
             get(getBaseAssignmentForPersonInSpaceOnDateUrl(readOnlySpace.uuid, personInReadOnlySpace.id!!, april1))
                 .header("Authorization", "Bearer $GOOD_TOKEN")
@@ -263,7 +270,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `GET should return a set of effective dates given a space uuid`() {
+    @Description("GET should return a set of effective dates given a space uuid")
+    fun getAssignmentDatesBySpaceUUID() {
         val savedAssignmentOne = assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -300,7 +308,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `Effective dates include assignment start and end dates`() {
+    @Description("GET Effective dates should include assignment start and end dates")
+    fun getAssignmentDatesShouldIncludeStartAndEndDates() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -364,7 +373,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `GET dates with changes should return FORBIDDEN when a user does not have edit access`() {
+    @Description("GET dates with changes should return FORBIDDEN when a user does not have edit access")
+    fun getAssignmentsDatesReturnForbidden() {
         mockMvc.perform(
             get(getBaseAssignmentDatesUrl(editableSpace.uuid))
                 .header("Authorization", "Bearer $ANONYMOUS_TOKEN")
@@ -373,7 +383,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `POST should only replace any existing assignments for a given date`() {
+    @Description("POST should only replace any existing assignments for a given date")
+    fun postCreateAssignment() {
         val nullAssignmentToKeep: AssignmentV1 = assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -421,7 +432,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `POST should return 403 if user does not write access`() {
+    @Description("POST should return 403 if user does not write access")
+    fun postAssignmentReturnForbidden() {
         val person = Person(id = -1, name = "", spaceUuid = readOnlySpace.uuid)
         val createAssignmentsRequest = CreateAssignmentsRequest(LocalDate.now(), HashSet())
 
@@ -435,7 +447,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `POST should not assign person to unassigned when given set of products`() {
+    @Description("POST should not assign person to unassigned when given set of products")
+    fun postAssignmentShouldNotAssignUnassignedProduct() {
         val assignmentRequest = CreateAssignmentsRequest(
             requestedDate = LocalDate.parse(april1),
             products = Sets.newSet(
@@ -479,7 +492,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `POST should assign person to unassigned when given only unassigned product`() {
+    @Description("POST should assign person to unassigned when given only unassigned product")
+    fun postAssignmentShouldAssignToUnassignedProduct() {
         val unassignedAssignmentRequest = CreateAssignmentsRequest(
             requestedDate = LocalDate.parse(april1),
             products = Sets.newSet(
@@ -520,7 +534,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `POST should assign person to unassigned when given an empty set of products`() {
+    @Description("POST should assign person to unassigned when given an empty set of products")
+    fun postAssignmentShouldAssignToUnassignedProductWhenListIsEmpty() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -568,8 +583,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `POST should return 400 when creating assignments given an invalid person`() {
-
+    @Description("POST should return 400 when creating assignments given an invalid person")
+    fun postAssignmentReturn400ForInvalidPerson() {
         val bogusAssignmentRequest = CreateAssignmentsRequest(
             requestedDate = LocalDate.parse(april1),
             products = Sets.newSet(
@@ -592,7 +607,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `POST should return 400 when creating assignments given an invalid product`() {
+    @Description("POST should return 400 when creating assignments given an invalid product")
+    fun postAssignmentReturn400ForInvalidProduct() {
         val bogusAssignmentRequest = CreateAssignmentsRequest(
             requestedDate = LocalDate.parse(april1),
             products = Sets.newSet(ProductPlaceholderPair(productId = 99999999, placeholder = false))
@@ -610,7 +626,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `DELETE should remove assignment(s) given person and date`() {
+    @Description("DELETE should remove assignment(s) given person and date")
+    fun deleteAssignmentsByPersonIdAndDate() {
         val originalAssignmentForPerson: AssignmentV1 = assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -641,7 +658,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `DELETE should assign person to unassigned when no previous assignment exists`() {
+    @Description("DELETE should assign person to unassigned when no previous assignment exists")
+    fun deleteAssignmentByPersonIdAndDate() {
         val originalAssignmentForPerson: AssignmentV1 = assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -673,7 +691,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `DELETE for date should return 403 when trying to delete without write authorization`() {
+    @Description("DELETE date should return 403 when trying to delete without write authorization")
+    fun deleteAssignmentReturnForbidden() {
         mockMvc.perform(
             delete(getBaseDeleteAssignmentUrl(readOnlySpace.uuid, person.id!!, march1))
                 .header("Authorization", "Bearer $GOOD_TOKEN")
@@ -682,7 +701,8 @@ class AssignmentControllerInTimeApiTest : AssignmentControllerApiBaseTest() {
     }
 
     @Test
-    fun `DELETE  return 400 when trying to delete assignments for a person that does not belong to the space you are accessing`() {
+    @Description("DELETE should return 400 when trying to delete assignments for a person that does not belong to the space you are accessing")
+    fun deleteAssignmentReturnBadRequestIfAssignmentDoesNotBelongToSpace() {
         mockMvc.perform(
             delete(getBaseDeleteAssignmentUrl(editableSpace.uuid, personInReadOnlySpace.id!!, march1))
                 .header("Authorization", "Bearer $GOOD_TOKEN")

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerReassignmentsApiTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentControllerReassignmentsApiTest.kt
@@ -22,6 +22,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Description
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -33,7 +34,8 @@ import java.time.format.DateTimeFormatter
 @AutoConfigureMockMvc
 class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest() {
     @Test
-    fun `GET should return all reassignments for the given spaceUuid and exact requested date`() {
+    @Description("GET should return all reassignments for the given spaceUuid and exact requested date")
+    fun getReassignmentsByDate() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -83,7 +85,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should handle reassignment logic for person with multiple assignments changing only one of the assignments`() {
+    @Description("GET should handle reassignment logic for person with multiple assignments changing only one of the assignments")
+    fun getReassignmentsShouldChangeOnlyOneAssignment() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -141,8 +144,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should return all reassignments should handle multiple historical assignments in db`() {
-
+    @Description("GET should return all reassignments should handle multiple historical assignments in db")
+    fun getReassignmentsShouldHandleMultipleAssignments() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -191,11 +194,9 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
         assertThat(actualReassignments).contains(reassignment)
     }
 
-    private fun baseReassignmentUrl(spaceUuid: String, date: String) = "/api/spaces/$spaceUuid/reassignment/$date"
-
     @Test
-    fun `GET should return reassignments with empty string fromProductName when there are no previous assignments`() {
-
+    @Description("GET should return reassignments with empty string fromProductName when there are no previous assignments")
+    fun getReassignmentsWhenNoPreviousAssignments() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -228,7 +229,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should return no reassignment when fromProductName is empty and toProductName is unassigned`() {
+    @Description("GET should return no reassignment when fromProductName is empty and toProductName is unassigned")
+    fun getReassignmentsReturnNone() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -254,9 +256,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should handle reassignments for multiple people being reassigned and sort in reverse chronological order`() {
-
-
+    @Description("GET should handle reassignments for multiple people being reassigned and sort in reverse chronological order")
+    fun getReassignmentsAndHandleForMultiplePeople() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -321,7 +322,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should handle one assignment being cancelled when a person is on multiple assignments`() {
+    @Description("GET should handle one assignment being cancelled when a person is on multiple assignments")
+    fun getReassignmentsAndHandleOneAssignmentOnMultiple() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -381,7 +383,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should handle one assignment being cancelled when a person is on multiple assignments and there is more than one reassignment`() {
+    @Description("GET should handle one assignment being cancelled when a person is on multiple assignments and there is more than one reassignment")
+    fun getReassignmentsCancelOne() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -457,7 +460,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should handle one assignment being cancelled and one being reassigned when a person is on multiple assignments and there is more than one reassignment`() {
+    @Description("GET should handle one assignment being cancelled and one being reassigned when a person is on multiple assignments and there is more than one reassignment")
+    fun getReassignmentsCancelOneReassignOne() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -533,7 +537,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should handle when one person is moved from two products to another two products `() {
+    @Description("GET should handle when one person is moved from two products to another two products")
+    fun getReassignmentsMoveAssignmentFrom2ProductsToDifferent2Products() {
         assignmentRepository.save(
             AssignmentV1(
                 person = person,
@@ -595,7 +600,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should return all reassignments when requested date is today for read only space`() {
+    @Description("GET should return all reassignments when requested date is today for read only space")
+    fun getReassignmentsForToday() {
         assignmentRepository.save(
             AssignmentV1(
                 person = personInReadOnlySpace,
@@ -645,7 +651,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should return all reassignments when requested date is tomorrow for read only space`() {
+    @Description("GET should return all reassignments when requested date is tomorrow for read only space")
+    fun getReassignmentsForTomorrow() {
         val tomorrow = LocalDate.now().plusDays(1L).format(DateTimeFormatter.ISO_DATE)
         mockMvc.perform(
             get(baseReassignmentUrl(readOnlySpace.uuid, tomorrow))
@@ -656,7 +663,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should return all reassignments when requested date is yesterday for read only space`() {
+    @Description("GET should return all reassignments when requested date is yesterday for read only space")
+    fun getReassignmentsForYesterday() {
         val yesterday = LocalDate.now().minusDays(1L).format(DateTimeFormatter.ISO_DATE)
         mockMvc.perform(
             get(baseReassignmentUrl(readOnlySpace.uuid, yesterday))
@@ -667,7 +675,8 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
     }
 
     @Test
-    fun `GET should return FORBIDDEN when requested date is not valid for read only space`() {
+    @Description("GET should return FORBIDDEN when requested date is not valid for read only space")
+    fun getReassignmentsReturnForbiddenForInvalidDate() {
         mockMvc.perform(
             get(baseReassignmentUrl(readOnlySpace.uuid, march1))
                 .header("Authorization", "Bearer $GOOD_TOKEN")
@@ -676,4 +685,6 @@ class AssignmentControllerReassignmentsApiTest : AssignmentControllerApiBaseTest
             .andReturn()
 
     }
+
+    private fun baseReassignmentUrl(spaceUuid: String, date: String) = "/api/spaces/$spaceUuid/reassignment/$date"
 }

--- a/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentDateHandlerTest.kt
+++ b/api/src/test/kotlin/com/ford/internalprojects/peoplemover/assignment/AssignmentDateHandlerTest.kt
@@ -3,10 +3,10 @@ package com.ford.internalprojects.peoplemover.assignment
 import com.ford.internalprojects.peoplemover.person.Person
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.Description
 import java.time.LocalDate
 
 class AssignmentDateHandlerTest {
-
     val person = Person(name = "name", spaceUuid = "space")
     val jun1 = "2020-06-01"
     val jul1 = "2020-07-01"
@@ -19,7 +19,8 @@ class AssignmentDateHandlerTest {
     var assignmentDateHandler = AssignmentDateHandler()
 
     @Test
-    fun `findUniqueDates should return a unique date when one assignment supplied`() {
+    @Description("findUniqueDates should return a unique date when one assignment supplied")
+    fun findUniqueDatesOneAssignment() {
         effectiveDate = LocalDate.parse(jun1)
         val assignmentList: List<AssignmentV1> = listOf(AssignmentV1(person = person, spaceUuid = "space", productId = 1, effectiveDate = effectiveDate))
 
@@ -31,7 +32,8 @@ class AssignmentDateHandlerTest {
     }
 
     @Test
-    fun `findUniqueDates should return a unique date when two assignments with the same date are supplied`() {
+    @Description("findUniqueDates should return a unique date when two assignments with the same date are supplied")
+    fun findUniqueDatesTwoAssignmentsSameDates() {
         effectiveDate = LocalDate.parse(jun1)
         val assignmentList: List<AssignmentV1> = listOf(
                 AssignmentV1(person = person, spaceUuid = "space", productId = 1, effectiveDate = effectiveDate),
@@ -46,7 +48,8 @@ class AssignmentDateHandlerTest {
     }
 
     @Test
-    fun `findUniqueDates should return two unique dates when two assignments with different dates are supplied`() {
+    @Description("findUniqueDates should return two unique dates when two assignments with different dates are supplied")
+    fun findUniqueDatesTwoAssignmentsDifferentDates() {
         val effectiveDate1 = LocalDate.parse(jun1)
         val effectiveDate2 = LocalDate.parse(jul1)
         val assignmentList: List<AssignmentV1> = listOf(
@@ -62,7 +65,8 @@ class AssignmentDateHandlerTest {
     }
 
     @Test
-    fun `findUniqueDates should return two unique dates when three assignments with two different dates are supplied`() {
+    @Description("findUniqueDates should return two unique dates when three assignments with two different dates are supplied")
+    fun findUniqueDatesThreeAssignmentsDifferentDates() {
         val effectiveDate1 = LocalDate.parse(jun1)
         val effectiveDate2 = LocalDate.parse(jul1)
         val effectiveDate3 = LocalDate.parse(jul1)
@@ -80,7 +84,8 @@ class AssignmentDateHandlerTest {
     }
 
     @Test
-    fun `findUniqueDates should handle assignments with empty effective dates by giving them today's date`() {
+    @Description("findUniqueDates should handle assignments with empty effective dates by giving them today's date")
+    fun findUniqueDatesAssignTodaysDate() {
         val assignmentList: List<AssignmentV1> = listOf(
                 AssignmentV1(person = person, spaceUuid = "space", productId = 1)
         )
@@ -93,7 +98,8 @@ class AssignmentDateHandlerTest {
     }
 
     @Test
-    fun `findUniqueDates should return the dates in the order they were sent`() {
+    @Description("findUniqueDates should return the dates in the order they were sent")
+    fun findUniqueDatesReturnInOrder() {
         val effectiveDate1 = LocalDate.parse(jun1)
         val effectiveDate2 = LocalDate.parse(oct1)
         val effectiveDate3 = LocalDate.parse(jul1)
@@ -119,7 +125,8 @@ class AssignmentDateHandlerTest {
     }
 
     @Test
-    fun `findStartDate should return the last date in uniqueDatesForAllAssignments list as a default`() {
+    @Description("findStartDate should return the last date in uniqueDatesForAllAssignments list as a default")
+    fun findStartDate() {
         val uniqueDatesForAssignment: List<LocalDate> = listOf(LocalDate.parse(jul1))
         val uniqueDatesForAllAssignment: List<LocalDate> = listOf(LocalDate.parse(jul1))
 
@@ -132,7 +139,8 @@ class AssignmentDateHandlerTest {
     }
 
     @Test
-    fun `findStartDate should return the oldest of two dates in uniqueDatesForAllAssignments list when both lists are equal`() {
+    @Description("findStartDate should return the oldest of two dates in uniqueDatesForAllAssignments list when both lists are equal")
+    fun findStartDateReturnOldestFirst() {
         val uniqueDatesForAssignment: List<LocalDate> = listOf(LocalDate.parse(jun1), LocalDate.parse(jul1))
         val uniqueDatesForAllAssignment: List<LocalDate> = listOf(LocalDate.parse(jun1), LocalDate.parse(jul1))
 
@@ -144,7 +152,8 @@ class AssignmentDateHandlerTest {
     }
 
     @Test
-    fun `findStartDate should return newest of 2 dates when lists are not equal`() {
+    @Description("findStartDate should return newest of 2 dates when lists are not equal")
+    fun findStartDateReturnNewest() {
         val uniqueDatesForAssignment: List<LocalDate> = listOf(LocalDate.parse(jul1))
         val uniqueDatesForAllAssignment: List<LocalDate> = listOf(LocalDate.parse(jun1), LocalDate.parse(jul1))
 
@@ -156,7 +165,8 @@ class AssignmentDateHandlerTest {
     }
 
     @Test
-    fun `findStartDate should return first non missing date`() {
+    @Description("findStartDate should return first non missing date")
+    fun findStartDateReturnFirstNonMissingDate() {
         val uniqueDatesForAssignment: List<LocalDate> = listOf(LocalDate.parse(sep1), LocalDate.parse(aug1))
         val uniqueDatesForAllAssignment: List<LocalDate> = listOf(LocalDate.parse(sep1), LocalDate.parse(jul1), LocalDate.parse(aug1))
 


### PR DESCRIPTION
## Issue
Resolves N/A

## What was done
- [x] This PR addresses these kind of sonarcube issues within the AssignmentControllerInTimeApiTest, AssignmentDateHandlerTest.kt, and AssignmentControllerReassignmentsApiTest tests. Sonarcube is not happy with how we named tests in the backend.
<img width="1330" alt="Screen Shot 2022-08-16 at 1 14 03 PM" src="https://user-images.githubusercontent.com/17144844/184939170-a3cc097a-625b-4ea7-aa45-7bb57ac2ca20.png">

## How to test
1. Ensure test names and descriptions make sense and pass sonarcube's requirements.