### PR TITLE
follow sonarqube suggestion replacing [!(a===b)] with [a!==b]

### DIFF
--- a/ui/src/Common/PersonForm/PersonForm.tsx
+++ b/ui/src/Common/PersonForm/PersonForm.tsx
@@ -198,7 +198,7 @@ function PersonForm({ isEditPersonForm, initiallySelectedProduct, initialPersonN
                         onChange={(): void => {
                             const newPersonFlag = !person.newPerson;
                             updatePersonField('newPerson', newPersonFlag);
-                            setHasNewPersonChanged(!(newPersonFlag === initialNewPersonFlag));
+                            setHasNewPersonChanged((newPersonFlag !== initialNewPersonFlag));
                         }}
                     />
                 </div>


### PR DESCRIPTION
## Issue
Resolves [sonarqube issue](https://sonarcloud.io/project/issues?resolved=false&rules=typescript%3AS1940&severities=MINOR&id=FordLabs_PeopleMover&open=AYLQjiDk_U1u1hS-Odyd)

## What was done
- [x] used opposite comparison instead of negating the boolean to reduce complexity