### PR TITLE
Sort spaces alphabetically regardless of case

### DIFF
--- a/ui/src/Hooks/useFetchUserSpaces/useFetchUserSpaces.test.tsx
+++ b/ui/src/Hooks/useFetchUserSpaces/useFetchUserSpaces.test.tsx
@@ -25,10 +25,12 @@ const wrapper = TestUtils.hookWrapper;
 jest.mock('Services/Api/SpaceClient');
 
 describe('useFetchUserSpaces Hook', () => {
-    it('should fetch all spaces and store them in recoil alphabetically by name', async () => {
-        const space1 = {...TestData.space, name: 'Space 1'};
-        const space2 = {...TestData.space, name: 'Space 2'};
-        SpaceClient.getSpacesForUser = jest.fn().mockResolvedValue([space2, space1]);
+    it('should fetch all spaces and store them in recoil alphabetically by name (ignoring case)', async () => {
+        const space1 = {...TestData.space, name: 'A Space 1'};
+        const space2 = {...TestData.space, name: 'a Space 2'};
+        const space3 = {...TestData.space, name: 'Space 3'};
+        const space4 = {...TestData.space, name: 'Space 4'};
+        SpaceClient.getSpacesForUser = jest.fn().mockResolvedValue([space3, space2, space4, space1]);
         const { result } = renderHook(() => useFetchUserSpaces(), { wrapper });
 
         expect(SpaceClient.getSpacesForUser).not.toHaveBeenCalled()
@@ -38,6 +40,6 @@ describe('useFetchUserSpaces Hook', () => {
             await result.current.fetchUserSpaces()
         });
         expect(SpaceClient.getSpacesForUser).toHaveBeenCalledWith();
-        expect(result.current.userSpaces).toEqual([space1, space2]);
+        expect(result.current.userSpaces).toEqual([space1, space2, space3, space4]);
     });
 });

--- a/ui/src/Hooks/useFetchUserSpaces/useFetchUserSpaces.tsx
+++ b/ui/src/Hooks/useFetchUserSpaces/useFetchUserSpaces.tsx
@@ -30,8 +30,11 @@ function useFetchUserSpaces(): UseFetchUserSpaces {
     const [userSpaces, setUserSpaces] = useRecoilState(UserSpacesState);
 
     const sortAlphabetically = (a: Space, b: Space) => {
-        if(a.name < b.name) return -1;
-        if(a.name > b.name) return 1;
+        const spaceNameA = a.name.toLowerCase();
+        const spaceNameB = b.name.toLowerCase();
+
+        if(spaceNameA < spaceNameB) return -1;
+        if(spaceNameA > spaceNameB) return 1;
         return 0;
     }
 


### PR DESCRIPTION
## What was done
Previously the dashboard's spaces were sorted alphabetically, but if something was lowercase, it would be put at the end of the list. This updates it so that case is not considered.

## How to test
1. Go to the dashboard and create a space named "A", and another one named "a".
2. Create a space labeled "B" now.
3. Ensure that they both A spaces show up in the list next to each other with the B following.
